### PR TITLE
fix: focus to focus-visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,27 +6,27 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 const VARIANT_ACTION_CLASSES = {
   solid: {
     primary:
-      'bg-primary-950 text-text border-2 border-primary-950 hover:bg-primary-800 hover:border-primary-800 focus:bg-primary-950 focus:border-indicator-info active:bg-primary-700 active:border-primary-700 disabled:bg-primary-500 disabled:border-primary-500 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-primary-950 text-text border-2 border-primary-950 hover:bg-primary-800 hover:border-primary-800 focus-visible:bg-primary-950 focus-visible:border-indicator-info active:bg-primary-700 active:border-primary-700 disabled:bg-primary-500 disabled:border-primary-500 disabled:opacity-40 disabled:cursor-not-allowed',
     positive:
-      'bg-success-500 text-text border-2 border-success-500 hover:bg-success-600 hover:border-success-600 focus:bg-success-500 focus:border-indicator-info active:bg-success-700 active:border-success-700 disabled:bg-success-500 disabled:border-success-500 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-success-500 text-text border-2 border-success-500 hover:bg-success-600 hover:border-success-600 focus-visible:bg-success-500 focus-visible:border-indicator-info active:bg-success-700 active:border-success-700 disabled:bg-success-500 disabled:border-success-500 disabled:opacity-40 disabled:cursor-not-allowed',
     negative:
-      'bg-error-500 text-text border-2 border-error-500 hover:bg-error-600 hover:border-error-600 focus:bg-error-500 focus:border-indicator-info active:bg-error-700 active:border-error-700 disabled:bg-error-500 disabled:border-error-500 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-error-500 text-text border-2 border-error-500 hover:bg-error-600 hover:border-error-600 focus-visible:bg-error-500 focus-visible:border-indicator-info active:bg-error-700 active:border-error-700 disabled:bg-error-500 disabled:border-error-500 disabled:opacity-40 disabled:cursor-not-allowed',
   },
   outline: {
     primary:
-      'bg-transparent text-primary-950 border border-primary-950 hover:bg-background-50 hover:text-primary-400 hover:border-primary-400 focus:text-primary-600 focus:border-2 focus:border-indicator-info active:text-primary-700 active:border-primary-700 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-transparent text-primary-950 border border-primary-950 hover:bg-background-50 hover:text-primary-400 hover:border-primary-400 focus-visible:text-primary-600 focus-visible:border-2 focus-visible:border-indicator-info active:text-primary-700 active:border-primary-700 disabled:opacity-40 disabled:cursor-not-allowed',
     positive:
-      'bg-transparent text-success-500 border border-success-300 hover:bg-background-50 hover:text-success-400 hover:border-success-400 focus:text-success-600 focus:border-2 focus:border-indicator-info active:text-success-700 active:border-success-700 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-transparent text-success-500 border border-success-300 hover:bg-background-50 hover:text-success-400 hover:border-success-400 focus-visible:text-success-600 focus-visible:border-2 focus-visible:border-indicator-info active:text-success-700 active:border-success-700 disabled:opacity-40 disabled:cursor-not-allowed',
     negative:
-      'bg-transparent text-error-500 border border-error-300 hover:bg-background-50 hover:text-error-400 hover:border-error-400 focus:text-error-600 focus:border-2 focus:border-indicator-info active:text-error-700 active:border-error-700 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-transparent text-error-500 border border-error-300 hover:bg-background-50 hover:text-error-400 hover:border-error-400 focus-visible:text-error-600 focus-visible:border-2 focus-visible:border-indicator-info active:text-error-700 active:border-error-700 disabled:opacity-40 disabled:cursor-not-allowed',
   },
   link: {
     primary:
-      'bg-transparent text-primary-950 hover:text-primary-400 focus:text-primary-600 focus:border-2 focus:border-indicator-info active:text-primary-700 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-transparent text-primary-950 hover:text-primary-400 focus-visible:text-primary-600 focus-visible:border-2 focus-visible:border-indicator-info active:text-primary-700 disabled:opacity-40 disabled:cursor-not-allowed',
     positive:
-      'bg-transparent text-success-500 hover:text-success-400 focus:text-success-600 focus:border-2 focus:border-indicator-info active:text-success-700 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-transparent text-success-500 hover:text-success-400 focus-visible:text-success-600 focus-visible:border-2 focus-visible:border-indicator-info active:text-success-700 disabled:opacity-40 disabled:cursor-not-allowed',
     negative:
-      'bg-transparent text-error-500 hover:text-error-400 focus:text-error-600 focus:border-2 focus:border-indicator-info active:text-error-700 disabled:opacity-40 disabled:cursor-not-allowed',
+      'bg-transparent text-error-500 hover:text-error-400 focus-visible:text-error-600 focus-visible:border-2 focus-visible:border-indicator-info active:text-error-700 disabled:opacity-40 disabled:cursor-not-allowed',
   },
 } as const;
 

--- a/src/components/IconRoundedButton/IconRoundedButton.test.tsx
+++ b/src/components/IconRoundedButton/IconRoundedButton.test.tsx
@@ -39,14 +39,14 @@ describe('IconRoundedButton', () => {
       render(<IconRoundedButton icon={<TestIcon />} />);
       const button = screen.getByRole('button');
       expect(button).toHaveClass('hover:shadow-hard-shadow-1');
-      expect(button).toHaveClass('focus:shadow-hard-shadow-1');
-      expect(button).toHaveClass('focus:border-indicator-info');
+      expect(button).toHaveClass('focus-visible:shadow-hard-shadow-1');
+      expect(button).toHaveClass('focus-visible:border-indicator-info');
     });
 
     it('applies focus border classes', () => {
       render(<IconRoundedButton icon={<TestIcon />} />);
       const button = screen.getByRole('button');
-      expect(button).toHaveClass('focus:border-2');
+      expect(button).toHaveClass('focus-visible:border-2');
     });
   });
 

--- a/src/components/IconRoundedButton/IconRoundedButton.tsx
+++ b/src/components/IconRoundedButton/IconRoundedButton.tsx
@@ -49,9 +49,9 @@ export const IconRoundedButton = ({
     'bg-background',
     'text-text-950',
     'hover:shadow-hard-shadow-1',
-    'focus:shadow-hard-shadow-1',
-    'focus:border-2',
-    'focus:border-indicator-info',
+    'focus-visible:shadow-hard-shadow-1',
+    'focus-visible:border-2',
+    'focus-visible:border-indicator-info',
     'disabled:opacity-50',
     'disabled:cursor-not-allowed',
   ].join(' ');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated button and icon button focus styles to use focus-visible, ensuring focus outlines appear only during keyboard navigation for improved accessibility.
- **Tests**
  - Adjusted tests to verify focus-visible styles instead of generic focus styles on icon buttons.
- **Chores**
  - Bumped package version to 1.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->