### PR TITLE
fix: notification icon inherits color from parent div

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -135,7 +135,7 @@ const Badge = ({
         className={`${baseClasses} ${variantClasses} ${sizeClasses} ${className}`}
         {...props}
       >
-        <Bell size={24} className="text-primary-950" />
+        <Bell size={24} className="text-current" />
 
         {notificationActive && (
           <span


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Bell icon color in notification badges to better match the surrounding text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->