### PR TITLE
AE-1471: fix adding white background to Select options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.0.85",
+  "version": "1.0.86",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -420,7 +420,7 @@ const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
         role="menu"
         ref={ref}
         className={cn(
-          'bg-white z-50 min-w-[210px] overflow-hidden rounded-md border p-1 shadow-md border-border-100',
+          'bg-secondary z-50 min-w-[210px] overflow-hidden rounded-md border p-1 shadow-md border-border-100',
           getPositionClasses(),
           className
         )}
@@ -479,7 +479,7 @@ const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>(
         aria-disabled={disabled}
         ref={ref}
         className={`
-          bg-white focus-visible:bg-background-50
+          bg-secondary focus-visible:bg-background-50
           relative flex select-none items-center gap-2 rounded-sm p-3 outline-none transition-colors [&>svg]:size-4 [&>svg]:shrink-0
           ${className}
           ${


### PR DESCRIPTION
<img width="1920" height="956" alt="Captura de Tela 2025-08-04 às 10 41 24" src="https://github.com/user-attachments/assets/f98b4481-82fb-45c4-b880-962571b3b44b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated background colors in dropdown and item components to use a consistent secondary background for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->