### PR TITLE
AE-1482: fix Quiz Question Title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.0.97",
+  "version": "1.0.98",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Quiz/Quiz.test.tsx
+++ b/src/components/Quiz/Quiz.test.tsx
@@ -743,7 +743,7 @@ describe('Quiz Component', () => {
       render(<QuizHeader />);
 
       expect(screen.getByTestId('header-alternative')).toBeInTheDocument();
-      expect(screen.getByText('Questão q1')).toBeInTheDocument();
+      expect(screen.getByText('Questão 1')).toBeInTheDocument();
       expect(screen.getByText('operacoes')).toBeInTheDocument();
       expect(screen.getByText('What is 2 + 2?')).toBeInTheDocument();
     });

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -188,12 +188,14 @@ const QuizSubTitle = forwardRef<HTMLDivElement, { subTitle: string }>(
 );
 
 const QuizHeader = () => {
-  const { getCurrentQuestion } = useQuizStore();
+  const { getCurrentQuestion, currentQuestionIndex } = useQuizStore();
   const currentQuestion = getCurrentQuestion();
 
   return (
     <HeaderAlternative
-      title={currentQuestion ? `Questão ${currentQuestion.id}` : 'Questão'}
+      title={
+        currentQuestion ? `Questão ${currentQuestionIndex + 1}` : 'Questão'
+      }
       subTitle={currentQuestion?.knowledgeMatrix?.[0]?.topicId ?? ''}
       content={currentQuestion?.questionText ?? ''}
     />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Quiz header now displays a sequential question number (1-based) instead of the question ID, improving clarity (e.g., “Questão 1”). When no current question is available, it continues to show “Questão”.
* Tests
  * Updated test expectations to align with the new question numbering in the quiz header.
* Chores
  * Bumped application version to 1.0.98. No other user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->