### PR TITLE
AE-1587-Simulados-Ao-clicar-no-botao-de-ver-todas-as-questoes-o-modal-parece-vazio

### DIFF
--- a/src/components/Auth/useUrlAuthentication.test.ts
+++ b/src/components/Auth/useUrlAuthentication.test.ts
@@ -797,7 +797,6 @@ describe('useUrlAuthentication', () => {
       );
     });
 
-
     it('deve resetar processedRef.current quando ocorre erro final', async () => {
       mockApi.get.mockRejectedValue(new Error('Permanent error'));
 
@@ -863,7 +862,7 @@ describe('useUrlAuthentication', () => {
     it('deve executar o early return quando processedRef.current é true (cobertura linha 224)', async () => {
       // Mock console.warn para verificar que não há logs de retry (indica que não executou)
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-      
+
       mockApi.get.mockResolvedValue({
         data: { data: { profileId: 'p1', foo: 'bar' } },
       });
@@ -910,14 +909,14 @@ describe('useUrlAuthentication', () => {
       );
 
       // Aguardar um tempo para garantir que nenhuma chamada adicional foi feita
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Verificar que não houve novas chamadas (early return funcionou)
       expect(mockApi.get).not.toHaveBeenCalled();
       expect(mockSetTokens).not.toHaveBeenCalled();
       expect(mockSetSessionInfo).not.toHaveBeenCalled();
       expect(mockClearParams).not.toHaveBeenCalled();
-      
+
       consoleWarnSpy.mockRestore();
     });
   });

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -1624,7 +1624,11 @@ const QuizFooter = forwardRef<
             <div className="flex flex-row justify-between items-center py-6 pt-6 pb-4 border-b border-border-200">
               <p className="text-text-950 font-bold text-lg">Filtrar por</p>
               <span className="max-w-[266px]">
-                <Select value={filterType} onValueChange={setFilterType}>
+                <Select
+                  value={filterType}
+                  onValueChange={setFilterType}
+                  defaultValue="all"
+                >
                   <SelectTrigger variant="rounded" className="max-w-[266px]">
                     <SelectValue placeholder="Selecione uma opção" />
                   </SelectTrigger>

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -1420,7 +1420,7 @@ const QuizFooter = forwardRef<
     const [modalResultOpen, setModalResultOpen] = useState(false);
     const [modalNavigateOpen, setModalNavigateOpen] = useState(false);
     const [modalResolutionOpen, setModalResolutionOpen] = useState(false);
-    const [filterType, setFilterType] = useState<string | undefined>(undefined);
+    const [filterType, setFilterType] = useState<string>('all');
     const unansweredQuestions = getUnansweredQuestionsFromUserAnswers();
     const allQuestions = getTotalQuestions();
 
@@ -1624,11 +1624,7 @@ const QuizFooter = forwardRef<
             <div className="flex flex-row justify-between items-center py-6 pt-6 pb-4 border-b border-border-200">
               <p className="text-text-950 font-bold text-lg">Filtrar por</p>
               <span className="max-w-[266px]">
-                <Select
-                  value={filterType}
-                  onValueChange={setFilterType}
-                  defaultValue="all"
-                >
+                <Select value={filterType} onValueChange={setFilterType}>
                   <SelectTrigger variant="rounded" className="max-w-[266px]">
                     <SelectValue placeholder="Selecione uma opção" />
                   </SelectTrigger>


### PR DESCRIPTION
…ling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Quiz filter modal now opens with a default selection of “Todas,” providing an initial visible filter and making filtering quicker and clearer.

- Tests
  - Formatting and whitespace cleaned in authentication tests; a minor stylistic promise callback change was made with no impact on behavior or test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->