### PR TITLE
AE-1561: fix NotificationCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -128,9 +128,17 @@ describe('NotificationCard', () => {
   it('prevents event bubbling when dropdown actions are clicked', () => {
     const parentClickHandler = jest.fn();
     render(
-      <div onClick={parentClickHandler}>
+      <button
+        onClick={parentClickHandler}
+        style={{
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          width: '100%',
+        }}
+      >
         <NotificationCard {...defaultProps} />
-      </div>
+      </button>
     );
 
     const menuButton = screen.getByLabelText('Menu de ações');
@@ -149,13 +157,21 @@ describe('NotificationCard', () => {
     const onNavigate = jest.fn();
 
     render(
-      <div onClick={parentClickHandler}>
+      <button
+        onClick={parentClickHandler}
+        style={{
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          width: '100%',
+        }}
+      >
         <NotificationCard
           {...defaultProps}
           onNavigate={onNavigate}
           actionLabel="Ver atividade"
         />
-      </div>
+      </button>
     );
 
     const actionButton = screen.getByText('Ver atividade');
@@ -297,12 +313,8 @@ describe('NotificationCard', () => {
       render(<NotificationCard groupedNotifications={[]} />);
 
       expect(
-        screen.getByText('Nenhuma notificação no momento')
+        screen.getByText('Nenhuma notificação encontrada')
       ).toBeInTheDocument();
-      expect(
-        screen.getByText(/Você está em dia com todas as novidades/)
-      ).toBeInTheDocument();
-      expect(screen.getByAltText('Sem notificações')).toBeInTheDocument();
     });
 
     it('renders custom empty state when renderEmpty is provided', () => {
@@ -523,20 +535,11 @@ describe('NotificationCard', () => {
   });
 
   describe('NotificationEmpty component', () => {
-    it('renders empty state with correct image and text', () => {
+    it('renders empty state with correct text', () => {
       render(<NotificationCard groupedNotifications={[]} />);
 
-      const image = screen.getByAltText('Sem notificações');
-      expect(image).toBeInTheDocument();
-      expect(image).toHaveAttribute('width', '82');
-      expect(image).toHaveAttribute('height', '82');
-      expect(image).toHaveClass('object-contain');
-
       expect(
-        screen.getByText('Nenhuma notificação no momento')
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/Você está em dia com todas as novidades/)
+        screen.getByText('Nenhuma notificação encontrada')
       ).toBeInTheDocument();
     });
 
@@ -550,31 +553,8 @@ describe('NotificationCard', () => {
       );
       expect(emptyStateContainer).toBeInTheDocument();
 
-      const imageContainer = container.querySelector(
-        '.w-20.h-20.flex.items-center.justify-center'
-      );
-      expect(imageContainer).toBeInTheDocument();
-
-      const title = screen.getByText('Nenhuma notificação no momento');
-      expect(title).toHaveClass(
-        'text-xl',
-        'font-semibold',
-        'text-text-950',
-        'text-center',
-        'leading-[23px]'
-      );
-
-      const description = screen.getByText(
-        /Você está em dia com todas as novidades/
-      );
-      expect(description).toHaveClass(
-        'text-sm',
-        'font-normal',
-        'text-text-400',
-        'text-center',
-        'max-w-[316px]',
-        'leading-[21px]'
-      );
+      const text = screen.getByText('Nenhuma notificação encontrada');
+      expect(text).toHaveClass('text-sm', 'text-text-400');
     });
 
     it('renders group header when notifications array is empty', () => {
@@ -595,7 +575,7 @@ describe('NotificationCard', () => {
       );
 
       expect(
-        screen.getByText('Nenhuma notificação no momento')
+        screen.getByText('Nenhuma notificação encontrada')
       ).toBeInTheDocument();
     });
 

--- a/src/components/NotificationCard/NotificationCard.tsx
+++ b/src/components/NotificationCard/NotificationCard.tsx
@@ -1,7 +1,6 @@
 import { DotsThreeVertical } from 'phosphor-react';
 import { MouseEvent, ReactNode } from 'react';
 import { cn } from '../../utils/utils';
-import noNotificationImg from '../../assets/img/no-notification-result.png';
 import DropdownMenu, {
   DropdownMenuContent,
   DropdownMenuItem,
@@ -214,37 +213,6 @@ const SingleNotificationCard = ({
 };
 
 /**
- * Empty state component for notifications
- */
-const NotificationEmpty = () => {
-  return (
-    <div className="flex flex-col items-center justify-center gap-4 p-6 w-full">
-      {/* Notification Icon */}
-      <div className="w-20 h-20 flex items-center justify-center">
-        <img
-          src={noNotificationImg}
-          alt="Sem notificações"
-          width={82}
-          height={82}
-          className="object-contain"
-        />
-      </div>
-
-      {/* Title */}
-      <h3 className="text-xl font-semibold text-text-950 text-center leading-[23px]">
-        Nenhuma notificação no momento
-      </h3>
-
-      {/* Description */}
-      <p className="text-sm font-normal text-text-400 text-center max-w-[316px] leading-[21px]">
-        Você está em dia com todas as novidades. Volte depois para conferir
-        atualizações!
-      </p>
-    </div>
-  );
-};
-
-/**
  * Notification list component for displaying grouped notifications
  */
 const NotificationList = ({
@@ -310,7 +278,9 @@ const NotificationList = ({
     return renderEmpty ? (
       <div className="w-full">{renderEmpty()}</div>
     ) : (
-      <NotificationEmpty />
+      <div className="flex flex-col items-center justify-center gap-4 p-6 w-full">
+        <p className="text-sm text-text-400">Nenhuma notificação encontrada</p>
+      </div>
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified the notifications empty state to a centered text-only message.
  - Updated empty-state copy from “Nenhuma notificação no momento” to “Nenhuma notificação encontrada”.

- Tests
  - Updated tests to reflect the new empty-state message and streamlined UI checks.

- Chores
  - Bumped version to 1.1.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->