### PR TITLE
AE-1615-Simulado-Resultados-de-simulado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Quiz/Quiz.test.tsx
+++ b/src/components/Quiz/Quiz.test.tsx
@@ -4534,14 +4534,17 @@ describe('Quiz', () => {
       render(<QuizResultHeaderTitle />);
 
       expect(screen.queryByTestId('quiz-badge')).toBeInTheDocument();
-      expect(screen.getByText('Simulado')).toBeInTheDocument();
+      expect(screen.getByText('Simuladão')).toBeInTheDocument();
+      const badge = screen.getByTestId('quiz-badge');
+      expect(badge).toHaveAttribute('data-variant', 'examsOutlined');
+      expect(badge).toHaveAttribute('data-action', 'exam3');
     });
 
     it('should render badge when bySimulated exists', () => {
       const mockBySimulated = {
         type: 'Simulado ENEM',
         id: 'sim-123',
-        subtype: 'ENEM',
+        subtype: 'ENEM_PROVA_1',
       };
 
       mockUseQuizStore.mockReturnValue({
@@ -4556,6 +4559,9 @@ describe('Quiz', () => {
 
       expect(screen.getByTestId('quiz-badge')).toBeInTheDocument();
       expect(screen.getByText('Enem')).toBeInTheDocument();
+      const badge = screen.getByTestId('quiz-badge');
+      expect(badge).toHaveAttribute('data-variant', 'examsOutlined');
+      expect(badge).toHaveAttribute('data-action', 'exam1');
     });
 
     it('should render badge with correct properties', () => {
@@ -4576,8 +4582,8 @@ describe('Quiz', () => {
       render(<QuizResultHeaderTitle />);
 
       const badge = screen.getByTestId('quiz-badge');
-      expect(badge).toHaveAttribute('data-variant', 'solid');
-      expect(badge).toHaveAttribute('data-action', 'info');
+      expect(badge).toHaveAttribute('data-variant', 'examsOutlined');
+      expect(badge).toHaveAttribute('data-action', 'exam4');
       expect(badge).toHaveTextContent('Vestibular');
     });
 
@@ -4645,7 +4651,7 @@ describe('Quiz', () => {
 
       render(<QuizResultHeaderTitle />);
 
-      expect(screen.getByText('Simulado')).toBeInTheDocument();
+      expect(screen.getByText('Simuladão')).toBeInTheDocument();
       expect(screen.getByTestId('quiz-badge')).toBeInTheDocument();
     });
 
@@ -4677,7 +4683,7 @@ describe('Quiz', () => {
       render(<QuizResultHeaderTitle />);
 
       const badge = screen.getByTestId('quiz-badge');
-      expect(badge).toHaveTextContent('Simulado');
+      expect(badge).toHaveTextContent('Simuladão');
     });
   });
 

--- a/src/components/Quiz/Quiz.test.tsx
+++ b/src/components/Quiz/Quiz.test.tsx
@@ -1027,10 +1027,8 @@ describe('Quiz', () => {
       it('should show confirmation modal when back button is clicked and quiz is started', () => {
         render(<QuizTitle />);
 
-        const backButton = document.querySelector(
-          'span[style*="cursor: pointer"]'
-        );
-        fireEvent.click(backButton!);
+        const backButton = screen.getByTestId('quiz-icon-button');
+        fireEvent.click(backButton);
 
         expect(screen.getByText('Deseja sair?')).toBeInTheDocument();
         expect(
@@ -1052,10 +1050,8 @@ describe('Quiz', () => {
 
         render(<QuizTitle />);
 
-        const backButton = document.querySelector(
-          'span[style*="cursor: pointer"]'
-        );
-        fireEvent.click(backButton!);
+        const backButton = screen.getByTestId('quiz-icon-button');
+        fireEvent.click(backButton);
 
         expect(screen.queryByText('Deseja sair?')).not.toBeInTheDocument();
         expect(mockHistoryBack).toHaveBeenCalledTimes(1);
@@ -1064,26 +1060,22 @@ describe('Quiz', () => {
       it('should render confirm button in modal', () => {
         render(<QuizTitle />);
 
-        const backButton = document.querySelector(
-          'span[style*="cursor: pointer"]'
-        );
-        fireEvent.click(backButton!);
+        const backButton = screen.getByTestId('quiz-icon-button');
+        fireEvent.click(backButton);
 
         // Verify the confirm button is rendered
-        expect(screen.getByText('Voltar e Revisar')).toBeInTheDocument();
+        expect(screen.getByText('Voltar e revisar')).toBeInTheDocument();
       });
 
       it('should close modal when user cancels exit', () => {
         render(<QuizTitle />);
 
-        const backButton = document.querySelector(
-          'span[style*="cursor: pointer"]'
-        );
-        fireEvent.click(backButton!);
+        const backButton = screen.getByTestId('quiz-icon-button');
+        fireEvent.click(backButton);
 
         expect(screen.getByText('Deseja sair?')).toBeInTheDocument();
 
-        const cancelButton = screen.getByText('Cancelar');
+        const cancelButton = screen.getByText('Voltar e revisar');
         fireEvent.click(cancelButton);
 
         // Since the mock AlertDialog doesn't actually close the modal, we just verify the button was clicked
@@ -1094,22 +1086,18 @@ describe('Quiz', () => {
       it('should have correct button labels in confirmation modal', () => {
         render(<QuizTitle />);
 
-        const backButton = document.querySelector(
-          'span[style*="cursor: pointer"]'
-        );
-        fireEvent.click(backButton!);
+        const backButton = screen.getByTestId('quiz-icon-button');
+        fireEvent.click(backButton);
 
-        expect(screen.getByText('Cancelar')).toBeInTheDocument();
-        expect(screen.getByText('Voltar e Revisar')).toBeInTheDocument();
+        expect(screen.getByText('Voltar e revisar')).toBeInTheDocument();
+        expect(screen.getByText('Sair Mesmo Assim')).toBeInTheDocument();
       });
 
       it('should render modal with correct structure', () => {
         render(<QuizTitle />);
 
-        const backButton = document.querySelector(
-          'span[style*="cursor: pointer"]'
-        );
-        fireEvent.click(backButton!);
+        const backButton = screen.getByTestId('quiz-icon-button');
+        fireEvent.click(backButton);
 
         expect(screen.getByText('Deseja sair?')).toBeInTheDocument();
         expect(

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -1691,27 +1691,29 @@ const QuizBadge = ({ subtype }: { subtype: string | null }) => {
   switch (subtype) {
     case 'PROVA':
       return (
-        <Badge variant="solid" action="info" data-testid="quiz-badge">
+        <Badge variant="examsOutlined" action="exam2" data-testid="quiz-badge">
           Prova
         </Badge>
       );
-    case 'ENEM':
+    case 'ENEM_PROVA_1':
+    case 'ENEM_PROVA_2':
       return (
-        <Badge variant="solid" action="info" data-testid="quiz-badge">
+        <Badge variant="examsOutlined" action="exam1" data-testid="quiz-badge">
           Enem
         </Badge>
       );
     case 'VESTIBULAR':
       return (
-        <Badge variant="solid" action="info" data-testid="quiz-badge">
+        <Badge variant="examsOutlined" action="exam4" data-testid="quiz-badge">
           Vestibular
         </Badge>
       );
     case 'SIMULADO':
+    case 'SIMULADAO':
     case null:
       return (
-        <Badge variant="solid" action="info" data-testid="quiz-badge">
-          Simulado
+        <Badge variant="examsOutlined" action="exam3" data-testid="quiz-badge">
+          Simuladão
         </Badge>
       );
     default:

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -166,33 +166,72 @@ const QuizTitle = forwardRef<HTMLDivElement, { className?: string }>(
       isStarted,
     } = useQuizStore();
 
+    const [showExitConfirmation, setShowExitConfirmation] = useState(false);
+
     const totalQuestions = getTotalQuestions();
     const quizTitle = getQuizTitle();
 
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          'flex flex-row justify-center items-center relative p-2',
-          className
-        )}
-        {...props}
-      >
-        <span className="flex flex-col gap-2 text-center">
-          <p className="text-text-950 font-bold text-md">{quizTitle}</p>
-          <p className="text-text-600 text-xs">
-            {totalQuestions > 0
-              ? `${currentQuestionIndex + 1} de ${totalQuestions}`
-              : '0 de 0'}
-          </p>
-        </span>
+    const handleBackClick = () => {
+      if (isStarted) {
+        setShowExitConfirmation(true);
+      } else {
+        window.history.back();
+      }
+    };
 
-        <span className="absolute right-2">
-          <Badge variant="outlined" action="info" iconLeft={<Clock />}>
-            {isStarted ? formatTime(timeElapsed) : '00:00'}
-          </Badge>
-        </span>
-      </div>
+    const handleConfirmExit = () => {
+      setShowExitConfirmation(false);
+      window.history.back();
+    };
+
+    const handleCancelExit = () => {
+      setShowExitConfirmation(false);
+    };
+
+    return (
+      <>
+        <div
+          ref={ref}
+          className={cn(
+            'flex flex-row justify-between items-center relative p-2',
+            className
+          )}
+          {...props}
+        >
+          <span
+            className="flex flex-row items-center justify-center"
+            onClick={handleBackClick}
+            style={{ cursor: 'pointer' }}
+          >
+            <CaretLeft size={24} />
+          </span>
+          <span className="flex flex-col gap-2 text-center">
+            <p className="text-text-950 font-bold text-md">{quizTitle}</p>
+            <p className="text-text-600 text-xs">
+              {totalQuestions > 0
+                ? `${currentQuestionIndex + 1} de ${totalQuestions}`
+                : '0 de 0'}
+            </p>
+          </span>
+
+          <span className="flex flex-row items-center justify-center">
+            <Badge variant="outlined" action="info" iconLeft={<Clock />}>
+              {isStarted ? formatTime(timeElapsed) : '00:00'}
+            </Badge>
+          </span>
+        </div>
+
+        <AlertDialog
+          isOpen={showExitConfirmation}
+          onChangeOpen={setShowExitConfirmation}
+          title="Deseja sair?"
+          description="Se você sair do simulado agora, todas as respostas serão perdidas."
+          cancelButtonLabel="Cancelar"
+          submitButtonLabel="Voltar e Revisar"
+          onSubmit={handleConfirmExit}
+          onCancel={handleCancelExit}
+        />
+      </>
     );
   }
 );
@@ -1688,7 +1727,11 @@ const QuizFooter = forwardRef<
 
 // QUIZ RESULT COMPONENTS
 
-const QuizBadge = ({ subtype }: { subtype: SUBTYPE_ENUM | string | null }) => {
+const QuizBadge = ({
+  subtype,
+}: {
+  subtype: SUBTYPE_ENUM | undefined | string;
+}) => {
   switch (subtype) {
     case SUBTYPE_ENUM.PROVA:
       return (
@@ -1711,7 +1754,7 @@ const QuizBadge = ({ subtype }: { subtype: SUBTYPE_ENUM | string | null }) => {
       );
     case SUBTYPE_ENUM.SIMULADO:
     case SUBTYPE_ENUM.SIMULADAO:
-    case null:
+    case undefined:
       return (
         <Badge variant="examsOutlined" action="exam3" data-testid="quiz-badge">
           Simuladão
@@ -1739,7 +1782,7 @@ const QuizResultHeaderTitle = forwardRef<
       {...props}
     >
       <p className="text-text-950 font-bold text-2xl">Resultado</p>
-      <QuizBadge subtype={activeQuiz?.quiz.subtype || null} />
+      <QuizBadge subtype={activeQuiz?.quiz.subtype || undefined} />
     </div>
   );
 });

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -32,6 +32,7 @@ import {
   QUESTION_DIFFICULTY,
   QUESTION_TYPE,
   ANSWER_STATUS,
+  SUBTYPE_ENUM,
 } from './useQuizStore';
 import { AlertDialog } from '../AlertDialog/AlertDialog';
 import Modal from '../Modal/Modal';
@@ -1687,29 +1688,29 @@ const QuizFooter = forwardRef<
 
 // QUIZ RESULT COMPONENTS
 
-const QuizBadge = ({ subtype }: { subtype: string | null }) => {
+const QuizBadge = ({ subtype }: { subtype: SUBTYPE_ENUM | string | null }) => {
   switch (subtype) {
-    case 'PROVA':
+    case SUBTYPE_ENUM.PROVA:
       return (
         <Badge variant="examsOutlined" action="exam2" data-testid="quiz-badge">
           Prova
         </Badge>
       );
-    case 'ENEM_PROVA_1':
-    case 'ENEM_PROVA_2':
+    case SUBTYPE_ENUM.ENEM_PROVA_1:
+    case SUBTYPE_ENUM.ENEM_PROVA_2:
       return (
         <Badge variant="examsOutlined" action="exam1" data-testid="quiz-badge">
           Enem
         </Badge>
       );
-    case 'VESTIBULAR':
+    case SUBTYPE_ENUM.VESTIBULAR:
       return (
         <Badge variant="examsOutlined" action="exam4" data-testid="quiz-badge">
           Vestibular
         </Badge>
       );
-    case 'SIMULADO':
-    case 'SIMULADAO':
+    case SUBTYPE_ENUM.SIMULADO:
+    case SUBTYPE_ENUM.SIMULADAO:
     case null:
       return (
         <Badge variant="examsOutlined" action="exam3" data-testid="quiz-badge">

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -201,7 +201,15 @@ const QuizTitle = forwardRef<HTMLDivElement, { className?: string }>(
           <span
             className="flex flex-row items-center justify-center"
             onClick={handleBackClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleBackClick();
+              }
+            }}
             style={{ cursor: 'pointer' }}
+            tabIndex={0}
+            role="button"
+            aria-label="Voltar"
           >
             <CaretLeft size={24} />
           </span>

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -198,21 +198,12 @@ const QuizTitle = forwardRef<HTMLDivElement, { className?: string }>(
           )}
           {...props}
         >
-          <span
-            className="flex flex-row items-center justify-center"
-            onClick={handleBackClick}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                handleBackClick();
-              }
-            }}
-            style={{ cursor: 'pointer' }}
-            tabIndex={0}
-            role="button"
+          <IconButton
+            icon={<CaretLeft size={24} />}
+            size="md"
             aria-label="Voltar"
-          >
-            <CaretLeft size={24} />
-          </span>
+            onClick={handleBackClick}
+          />
           <span className="flex flex-col gap-2 text-center">
             <p className="text-text-950 font-bold text-md">{quizTitle}</p>
             <p className="text-text-600 text-xs">
@@ -234,8 +225,8 @@ const QuizTitle = forwardRef<HTMLDivElement, { className?: string }>(
           onChangeOpen={setShowExitConfirmation}
           title="Deseja sair?"
           description="Se você sair do simulado agora, todas as respostas serão perdidas."
-          cancelButtonLabel="Cancelar"
-          submitButtonLabel="Voltar e Revisar"
+          cancelButtonLabel="Voltar e revisar"
+          submitButtonLabel="Sair Mesmo Assim"
           onSubmit={handleConfirmExit}
           onCancel={handleCancelExit}
         />

--- a/src/components/Quiz/useQuizStore.ts
+++ b/src/components/Quiz/useQuizStore.ts
@@ -31,6 +31,15 @@ export enum ANSWER_STATUS {
   NAO_RESPONDIDO = 'NAO_RESPONDIDO',
 }
 
+export enum SUBTYPE_ENUM {
+  PROVA = 'PROVA',
+  ENEM_PROVA_1 = 'ENEM_PROVA_1',
+  ENEM_PROVA_2 = 'ENEM_PROVA_2',
+  VESTIBULAR = 'VESTIBULAR',
+  SIMULADO = 'SIMULADO',
+  SIMULADAO = 'SIMULADAO',
+}
+
 export interface QuestionResult {
   answers: {
     id: string;
@@ -137,7 +146,7 @@ export interface Simulated {
   id: string;
   title: string;
   type: string;
-  subtype: string;
+  subtype: SUBTYPE_ENUM | string;
   difficulty: string | null;
   notification: string | null;
   status: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,7 @@ export {
   QUESTION_TYPE,
   QUESTION_STATUS,
   ANSWER_STATUS,
+  SUBTYPE_ENUM,
 } from './components/Quiz/useQuizStore';
 export type {
   QuestionResult,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exit confirmation dialog when leaving a started quiz, with options to cancel or return and review.
  - Redesigned, keyboard-accessible header: left back button, centered title/progress, right time badge.
- Style
  - Updated badge labels and mappings; “Simulado” now appears as “Simuladão.”
  - Result modal now opens without a close button for a focused review experience.
- Chores
  - Version bumped to 1.1.35.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->