### PR TITLE
fix subject-text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/SubjectInfo/SubjectInfo.stories.tsx
+++ b/src/components/SubjectInfo/SubjectInfo.stories.tsx
@@ -25,7 +25,7 @@ const SubjectCard = ({
   return (
     <div className="flex flex-col gap-1 text-center">
       <div
-        className={`${cardSize} ${subjectClass} flex items-center justify-center rounded-md`}
+        className={`${cardSize} ${subjectClass} flex items-center justify-center rounded-md text-text-950`}
         data-theme={isDark ? 'dark' : 'light'}
       >
         {cloneElement(icon, { size: iconSize })}

--- a/src/components/SubjectInfo/SubjectInfo.test.tsx
+++ b/src/components/SubjectInfo/SubjectInfo.test.tsx
@@ -110,27 +110,7 @@ describe('SubjectInfo', () => {
 
       subjectsWithColor.forEach((subject) => {
         const icon = SubjectInfo[subject].icon;
-        expect(icon.props.color).toBe('#000000');
-      });
-    });
-
-    it('should have icons without color property when not specified', () => {
-      const subjectsWithoutColor = [
-        SubjectEnum.FISICA,
-        SubjectEnum.HISTORIA,
-        SubjectEnum.GEOGRAFIA,
-        SubjectEnum.QUIMICA,
-        SubjectEnum.ARTES,
-        SubjectEnum.MATEMATICA,
-        SubjectEnum.REDACAO,
-        SubjectEnum.SOCIOLOGIA,
-        SubjectEnum.EDUCACAO_FISICA,
-        SubjectEnum.TRILHAS,
-      ];
-
-      subjectsWithoutColor.forEach((subject) => {
-        const icon = SubjectInfo[subject].icon;
-        expect(icon.props.color).toBeUndefined();
+        expect(icon.props.color).toBe('currentColor');
       });
     });
   });
@@ -219,11 +199,11 @@ describe('SubjectInfo', () => {
       // Test that IconProps interface is properly implemented
       const testProps: IconProps = {
         size: 17,
-        color: '#000000',
+        color: 'currentColor',
       };
 
       expect(testProps.size).toBe(17);
-      expect(testProps.color).toBe('#000000');
+      expect(testProps.color).toBe('currentColor');
     });
   });
 

--- a/src/components/SubjectInfo/SubjectInfo.tsx
+++ b/src/components/SubjectInfo/SubjectInfo.tsx
@@ -31,82 +31,82 @@ export interface SubjectData {
 
 export const SubjectInfo: Record<SubjectEnum, SubjectData> = {
   [SubjectEnum.FISICA]: {
-    icon: <Atom size={17} />,
+    icon: <Atom size={17} color="currentColor" />,
     colorClass: 'bg-subject-1',
     name: SubjectEnum.FISICA,
   },
   [SubjectEnum.HISTORIA]: {
-    icon: <Scroll size={17} />,
+    icon: <Scroll size={17} color="currentColor" />,
     colorClass: 'bg-subject-2',
     name: SubjectEnum.HISTORIA,
   },
   [SubjectEnum.LITERATURA]: {
-    icon: <BookOpenText size={17} color="#000000" />,
+    icon: <BookOpenText size={17} color="currentColor" />,
     colorClass: 'bg-subject-3',
     name: SubjectEnum.LITERATURA,
   },
   [SubjectEnum.GEOGRAFIA]: {
-    icon: <GlobeHemisphereWest size={17} />,
+    icon: <GlobeHemisphereWest size={17} color="currentColor" />,
     colorClass: 'bg-subject-4',
     name: SubjectEnum.GEOGRAFIA,
   },
   [SubjectEnum.BIOLOGIA]: {
-    icon: <Microscope size={17} color="#000000" />,
+    icon: <Microscope size={17} color="currentColor" />,
     colorClass: 'bg-subject-5',
     name: SubjectEnum.BIOLOGIA,
   },
   [SubjectEnum.PORTUGUES]: {
-    icon: <ChatPT size={17} color="#000000" />,
+    icon: <ChatPT size={17} color="currentColor" />,
     colorClass: 'bg-subject-6',
     name: SubjectEnum.PORTUGUES,
   },
   [SubjectEnum.QUIMICA]: {
-    icon: <Flask size={17} />,
+    icon: <Flask size={17} color="currentColor" />,
     colorClass: 'bg-subject-7',
     name: SubjectEnum.QUIMICA,
   },
   [SubjectEnum.ARTES]: {
-    icon: <Palette size={17} />,
+    icon: <Palette size={17} color="currentColor" />,
     colorClass: 'bg-subject-8',
     name: SubjectEnum.ARTES,
   },
   [SubjectEnum.MATEMATICA]: {
-    icon: <MathOperations size={17} />,
+    icon: <MathOperations size={17} color="currentColor" />,
     colorClass: 'bg-subject-9',
     name: SubjectEnum.MATEMATICA,
   },
   [SubjectEnum.FILOSOFIA]: {
-    icon: <HeadCircuit size={17} color="#000000" />,
+    icon: <HeadCircuit size={17} color="currentColor" />,
     colorClass: 'bg-subject-10',
     name: SubjectEnum.FILOSOFIA,
   },
   [SubjectEnum.ESPANHOL]: {
-    icon: <ChatES size={17} color="#000000" />,
+    icon: <ChatES size={17} color="currentColor" />,
     colorClass: 'bg-subject-11',
     name: SubjectEnum.ESPANHOL,
   },
   [SubjectEnum.REDACAO]: {
-    icon: <ArticleNyTimes size={17} />,
+    icon: <ArticleNyTimes size={17} color="currentColor" />,
     colorClass: 'bg-subject-12',
     name: SubjectEnum.REDACAO,
   },
   [SubjectEnum.SOCIOLOGIA]: {
-    icon: <Person size={17} />,
+    icon: <Person size={17} color="currentColor" />,
     colorClass: 'bg-subject-13',
     name: SubjectEnum.SOCIOLOGIA,
   },
   [SubjectEnum.INGLES]: {
-    icon: <ChatEN size={17} color="#000000" />,
+    icon: <ChatEN size={17} color="currentColor" />,
     colorClass: 'bg-subject-14',
     name: SubjectEnum.INGLES,
   },
   [SubjectEnum.EDUCACAO_FISICA]: {
-    icon: <DribbbleLogo size={17} />,
+    icon: <DribbbleLogo size={17} color="currentColor" />,
     colorClass: 'bg-subject-15',
     name: SubjectEnum.EDUCACAO_FISICA,
   },
   [SubjectEnum.TRILHAS]: {
-    icon: <BookBookmark size={17} />,
+    icon: <BookBookmark size={17} color="currentColor" />,
     colorClass: 'bg-subject-16',
     name: SubjectEnum.TRILHAS,
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized SubjectInfo icons to inherit color via currentColor for consistent theming.
  - Applied a Tailwind text color utility to ensure icons follow text color without layout changes.

- Tests
  - Updated tests to validate currentColor usage for icons, simplifying previous color-specific assertions.

- Chores
  - Bumped version to 1.1.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->