### PR TITLE
AE-1657: fix Notification Icon State

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.63",
+  "version": "1.1.64",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -1627,6 +1627,7 @@ describe('NotificationCard', () => {
       render(
         <NotificationCard
           mode="center"
+          getActionLabel={() => 'Ver mais'}
           groupedNotifications={[
             {
               label: 'Global',
@@ -1644,12 +1645,10 @@ describe('NotificationCard', () => {
       let closeButton = await screen.findByLabelText('Fechar modal');
       expect(closeButton).toBeInTheDocument();
 
-      // 3. Click on the global notification to trigger onGlobalNotificationClick
+      // 3. Click the action button to invoke onGlobalNotificationClick (lines 762-763)
       // This should execute lines 762-763: setIsModalOpen(false) and setGlobalNotificationModal
-      const globalNotificationElement = screen.getByText(
-        'Global Notification Test'
-      );
-      fireEvent.click(globalNotificationElement);
+      const actionBtn = screen.getByText('Ver mais');
+      fireEvent.click(actionBtn);
 
       // 4. The click should trigger lines 762-763:
       // Line 762: setIsModalOpen(false) - This closes the mobile modal
@@ -1657,6 +1656,8 @@ describe('NotificationCard', () => {
 
       // We verify that both actions happened by checking the notification is still accessible
       // and the modal content has changed (global modal has different structure)
+      // Mobile list modal closed, global modal opened with the notification content
+      expect(screen.queryByText('Notificações')).not.toBeInTheDocument();
       expect(screen.getByText('Global Notification Test')).toBeInTheDocument();
       expect(
         screen.getByText('This notification will trigger lines 762-763')

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import NotificationCard, {
   NotificationGroup,
@@ -1608,6 +1607,65 @@ describe('NotificationCard', () => {
       expect(
         screen.getAllByText('Test Global Notification').length
       ).toBeGreaterThan(0);
+    });
+
+    it('should handle global notification click in mobile modal and execute lines 762-763', async () => {
+      const globalNotification: Notification = {
+        id: 'global-1',
+        title: 'Global Notification Test',
+        message: 'This notification will trigger lines 762-763',
+        type: 'GENERAL',
+        isRead: false,
+        createdAt: new Date(),
+        entityType: undefined, // No entityType makes it global
+        entityId: undefined, // No entityId makes it global
+        sender: null,
+        activity: null,
+        goal: null,
+      };
+
+      render(
+        <NotificationCard
+          mode="center"
+          groupedNotifications={[
+            {
+              label: 'Global',
+              notifications: [globalNotification],
+            },
+          ]}
+        />
+      );
+
+      // 1. Open mobile modal first
+      const mobileButton = screen.getByRole('button');
+      fireEvent.click(mobileButton);
+
+      // 2. Verify mobile modal is open
+      let closeButton = await screen.findByLabelText('Fechar modal');
+      expect(closeButton).toBeInTheDocument();
+
+      // 3. Click on the global notification to trigger onGlobalNotificationClick
+      // This should execute lines 762-763: setIsModalOpen(false) and setGlobalNotificationModal
+      const globalNotificationElement = screen.getByText(
+        'Global Notification Test'
+      );
+      fireEvent.click(globalNotificationElement);
+
+      // 4. The click should trigger lines 762-763:
+      // Line 762: setIsModalOpen(false) - This closes the mobile modal
+      // Line 763: setGlobalNotificationModal({isOpen: true, notification}) - This opens the global modal
+
+      // We verify that both actions happened by checking the notification is still accessible
+      // and the modal content has changed (global modal has different structure)
+      expect(screen.getByText('Global Notification Test')).toBeInTheDocument();
+      expect(
+        screen.getByText('This notification will trigger lines 762-763')
+      ).toBeInTheDocument();
+
+      // The test successfully covers the execution of lines 762-763 by:
+      // 1. Opening the mobile modal
+      // 2. Clicking a global notification which triggers the onGlobalNotificationClick callback
+      // 3. Verifying the notification content remains accessible (in the new global modal)
     });
   });
 

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import NotificationCard, {
   NotificationGroup,
   LegacyNotificationCard,
+  syncNotificationState,
 } from './NotificationCard';
 import {
   NotificationEntityType,
@@ -2065,6 +2066,50 @@ describe('NotificationCard', () => {
       expect(
         screen.getByText('Nenhuma notificação configurada')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('syncNotificationState', () => {
+    it('should update state when open is false and notification is active', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncNotificationState(false, true, mockSetActiveStates);
+
+      expect(mockSetActiveStates).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback function
+      const callback = mockSetActiveStates.mock.calls[0][0];
+      const prevState = { notifications: true, profile: false };
+      const result = callback(prevState);
+
+      expect(result).toEqual({
+        notifications: false,
+        profile: false,
+      });
+    });
+
+    it('should not update state when open is true', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncNotificationState(true, true, mockSetActiveStates);
+
+      expect(mockSetActiveStates).not.toHaveBeenCalled();
+    });
+
+    it('should not update state when notification is not active', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncNotificationState(false, false, mockSetActiveStates);
+
+      expect(mockSetActiveStates).not.toHaveBeenCalled();
+    });
+
+    it('should not update state when open is true and notification is not active', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncNotificationState(true, false, mockSetActiveStates);
+
+      expect(mockSetActiveStates).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/NotificationCard/NotificationCard.tsx
+++ b/src/components/NotificationCard/NotificationCard.tsx
@@ -1,5 +1,12 @@
 import { DotsThreeVertical, Bell } from 'phosphor-react';
-import { MouseEvent, ReactNode, useState, useEffect } from 'react';
+import {
+  MouseEvent,
+  ReactNode,
+  useState,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { cn } from '../../utils/utils';
 import DropdownMenu, {
   DropdownMenuContent,
@@ -19,6 +26,23 @@ import type {
 } from '../../types/notifications';
 import { formatTimeAgo } from '../../store/notificationStore';
 import mockContentImage from '../../assets/img/mock-content.png';
+
+/**
+ * Synchronizes notification state when dropdown closes externally
+ * This ensures the notification icon state matches the dropdown state
+ */
+export const syncNotificationState = (
+  open: boolean,
+  isNotificationActive: boolean,
+  setActiveStates: Dispatch<SetStateAction<Record<string, boolean>>>
+) => {
+  if (!open && isNotificationActive) {
+    setActiveStates((prev) => ({
+      ...prev,
+      notifications: false,
+    }));
+  }
+};
 
 // Extended notification item for component usage with time string
 export interface NotificationItem extends Omit<Notification, 'createdAt'> {

--- a/src/components/NotificationCard/NotificationCard.tsx
+++ b/src/components/NotificationCard/NotificationCard.tsx
@@ -1,12 +1,6 @@
 import { DotsThreeVertical, Bell } from 'phosphor-react';
-import {
-  MouseEvent,
-  ReactNode,
-  useState,
-  useEffect,
-  Dispatch,
-  SetStateAction,
-} from 'react';
+import { MouseEvent, ReactNode, useState, useEffect } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { cn } from '../../utils/utils';
 import DropdownMenu, {
   DropdownMenuContent,
@@ -34,13 +28,11 @@ import mockContentImage from '../../assets/img/mock-content.png';
 export const syncNotificationState = (
   open: boolean,
   isNotificationActive: boolean,
-  setActiveStates: Dispatch<SetStateAction<Record<string, boolean>>>
+  setActiveStates: Dispatch<SetStateAction<Record<string, boolean>>>,
+  key: string = 'notifications'
 ) => {
   if (!open && isNotificationActive) {
-    setActiveStates((prev) => ({
-      ...prev,
-      notifications: false,
-    }));
+    setActiveStates((prev) => ({ ...prev, [key]: false }));
   }
 };
 
@@ -772,6 +764,22 @@ const NotificationCenter = ({
             </div>
           </div>
         </Modal>
+        {/* Global Notification Modal (mobile) */}
+        <Modal
+          isOpen={globalNotificationModal.isOpen}
+          onClose={() =>
+            setGlobalNotificationModal({ isOpen: false, notification: null })
+          }
+          title={globalNotificationModal.notification?.title || ''}
+          variant="activity"
+          description={globalNotificationModal.notification?.message}
+          image={emptyStateImage || mockContentImage}
+          actionLink={
+            globalNotificationModal.notification?.actionLink || undefined
+          }
+          actionLabel="Ver mais"
+          size="lg"
+        />
       </>
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ export { Modal };
 export { AlertDialog };
 export { LoadingModal };
 export { NotificationCard };
+export { syncNotificationState } from './components/NotificationCard/NotificationCard';
 export { ThemeToggle };
 export type {
   NotificationItem,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile notification handling: tapping a global notification in the mobile modal now closes the modal and opens the global view, ensuring content remains accessible.
  * Notification dropdowns now reset correctly when closed, preventing stuck active states.

* **Tests**
  * Added comprehensive tests for mobile/global notification flows and notification state synchronization.

* **Chores**
  * Version bumped to 1.1.64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->