### PR TITLE
AE-1686: fix ProfileMenu Styles and fix Calendar and ProfileMenu Icons State

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.71",
+  "version": "1.1.72",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -12,8 +12,6 @@ import DropdownMenu, {
   ProfileMenuSection,
   ProfileMenuTrigger,
   ProfileToggleTheme,
-} from './DropdownMenu';
-import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -894,6 +892,52 @@ describe('ProfileToggleTheme component', () => {
       expect(screen.getByText('Claro')).toBeInTheDocument();
       expect(screen.getByText('Escuro')).toBeInTheDocument();
       expect(screen.getByText('Sistema')).toBeInTheDocument();
+    });
+  });
+
+  it('opens theme modal when Enter key is pressed on theme item', async () => {
+    render(
+      <DropdownMenu>
+        <ProfileMenuTrigger />
+        <DropdownMenuContent variant="profile">
+          <ProfileToggleTheme />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    // Click to open dropdown
+    fireEvent.click(screen.getByRole('button'));
+
+    // Press Enter on the theme toggle item
+    const themeItem = screen.getByText('Aparência');
+    fireEvent.keyDown(themeItem, { key: 'Enter' });
+
+    // Wait for modal to open
+    await waitFor(() => {
+      expect(screen.getByText('Escolha o tema:')).toBeInTheDocument();
+    });
+  });
+
+  it('opens theme modal when Space key is pressed on theme item', async () => {
+    render(
+      <DropdownMenu>
+        <ProfileMenuTrigger />
+        <DropdownMenuContent variant="profile">
+          <ProfileToggleTheme />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    // Click to open dropdown
+    fireEvent.click(screen.getByRole('button'));
+
+    // Press Space on the theme toggle item
+    const themeItem = screen.getByText('Aparência');
+    fireEvent.keyDown(themeItem, { key: ' ' });
+
+    // Wait for modal to open
+    await waitFor(() => {
+      expect(screen.getByText('Escolha o tema:')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -497,10 +497,23 @@ const ProfileToggleTheme = ({ ...props }: HTMLAttributes<HTMLDivElement>) => {
 
   return (
     <>
-      <div
-        role="menuitem"
-        data-variant="profile"
-        className="relative flex flex-row justify-between select-none items-center gap-2 rounded-sm p-4 text-sm outline-none transition-colors [&>svg]:size-6 [&>svg]:shrink-0 cursor-pointer hover:bg-background-50 text-text-700 focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground"
+      <DropdownMenuItem
+        variant="profile"
+        iconLeft={
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 25 25"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.5 2.75C15.085 2.75276 17.5637 3.78054 19.3916 5.6084C21.2195 7.43628 22.2473 9.915 22.25 12.5C22.25 14.4284 21.6778 16.3136 20.6064 17.917C19.5352 19.5201 18.0128 20.7699 16.2314 21.5078C14.4499 22.2458 12.489 22.4387 10.5977 22.0625C8.70642 21.6863 6.96899 20.758 5.60547 19.3945C4.24197 18.031 3.31374 16.2936 2.9375 14.4023C2.56129 12.511 2.75423 10.5501 3.49219 8.76855C4.23012 6.98718 5.47982 5.46483 7.08301 4.39355C8.68639 3.32221 10.5716 2.75 12.5 2.75ZM11.75 4.28516C9.70145 4.47452 7.7973 5.42115 6.41016 6.94043C5.02299 8.4599 4.25247 10.4426 4.25 12.5C4.25247 14.5574 5.02299 16.5401 6.41016 18.0596C7.7973 19.5789 9.70145 20.5255 11.75 20.7148V4.28516Z"
+              fill="currentColor"
+            />
+          </svg>
+        }
+        iconRight={<CaretRight />}
         onClick={handleClick}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -509,26 +522,12 @@ const ProfileToggleTheme = ({ ...props }: HTMLAttributes<HTMLDivElement>) => {
             setModalThemeToggle(true);
           }
         }}
-        tabIndex={0}
         {...props}
       >
-        <svg
-          width="25"
-          height="25"
-          viewBox="0 0 25 25"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.5 2.75C15.085 2.75276 17.5637 3.78054 19.3916 5.6084C21.2195 7.43628 22.2473 9.915 22.25 12.5C22.25 14.4284 21.6778 16.3136 20.6064 17.917C19.5352 19.5201 18.0128 20.7699 16.2314 21.5078C14.4499 22.2458 12.489 22.4387 10.5977 22.0625C8.70642 21.6863 6.96899 20.758 5.60547 19.3945C4.24197 18.031 3.31374 16.2936 2.9375 14.4023C2.56129 12.511 2.75423 10.5501 3.49219 8.76855C4.23012 6.98718 5.47982 5.46483 7.08301 4.39355C8.68639 3.32221 10.5716 2.75 12.5 2.75ZM11.75 4.28516C9.70145 4.47452 7.7973 5.42115 6.41016 6.94043C5.02299 8.4599 4.25247 10.4426 4.25 12.5C4.25247 14.5574 5.02299 16.5401 6.41016 18.0596C7.7973 19.5789 9.70145 20.5255 11.75 20.7148V4.28516Z"
-            fill="#525252"
-          />
-        </svg>
-        <Text className="w-full" size="md">
+        <Text size="md" color="text-text-700">
           Aparência
         </Text>
-        <CaretRight />
-      </div>
+      </DropdownMenuItem>
 
       <Modal
         isOpen={modalThemeToggle}
@@ -598,7 +597,7 @@ const ProfileMenuFooter = ({
       <span className="mr-2 flex items-center">
         <SignOut />
       </span>
-      <Text>Sair</Text>
+      <Text color="text-primary-950">Sair</Text>
     </Button>
   );
 };

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -595,9 +595,9 @@ const ProfileMenuFooter = ({
       {...props}
     >
       <span className="mr-2 flex items-center">
-        <SignOut />
+        <SignOut className="text-inherit" />
       </span>
-      <Text color="text-primary-950">Sair</Text>
+      <Text color="inherit">Sair</Text>
     </Button>
   );
 };

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -2,13 +2,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import NotificationCard, {
   NotificationGroup,
   LegacyNotificationCard,
-  syncNotificationState,
 } from './NotificationCard';
 import {
   NotificationEntityType,
   Notification,
 } from '../../types/notifications';
 import { DeviceType, useMobile } from '../../hooks/useMobile';
+import { syncDropdownState } from '../../utils/utils';
 
 // Mock para imagens PNG
 jest.mock(
@@ -2128,11 +2128,11 @@ describe('NotificationCard', () => {
     });
   });
 
-  describe('syncNotificationState', () => {
-    it('should update state when open is false and notification is active', () => {
+  describe('syncDropdownState', () => {
+    it('should update state when open is false and dropdown is active', () => {
       const mockSetActiveStates = jest.fn();
 
-      syncNotificationState(false, true, mockSetActiveStates);
+      syncDropdownState(false, true, mockSetActiveStates, 'notifications');
 
       expect(mockSetActiveStates).toHaveBeenCalledWith(expect.any(Function));
 
@@ -2150,25 +2150,43 @@ describe('NotificationCard', () => {
     it('should not update state when open is true', () => {
       const mockSetActiveStates = jest.fn();
 
-      syncNotificationState(true, true, mockSetActiveStates);
+      syncDropdownState(true, true, mockSetActiveStates, 'notifications');
 
       expect(mockSetActiveStates).not.toHaveBeenCalled();
     });
 
-    it('should not update state when notification is not active', () => {
+    it('should not update state when dropdown is not active', () => {
       const mockSetActiveStates = jest.fn();
 
-      syncNotificationState(false, false, mockSetActiveStates);
+      syncDropdownState(false, false, mockSetActiveStates, 'notifications');
 
       expect(mockSetActiveStates).not.toHaveBeenCalled();
     });
 
-    it('should not update state when open is true and notification is not active', () => {
+    it('should not update state when open is true and dropdown is not active', () => {
       const mockSetActiveStates = jest.fn();
 
-      syncNotificationState(true, false, mockSetActiveStates);
+      syncDropdownState(true, false, mockSetActiveStates, 'notifications');
 
       expect(mockSetActiveStates).not.toHaveBeenCalled();
+    });
+
+    it('should update state with custom key', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncDropdownState(false, true, mockSetActiveStates, 'profile');
+
+      expect(mockSetActiveStates).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback function
+      const callback = mockSetActiveStates.mock.calls[0][0];
+      const prevState = { notifications: false, profile: true };
+      const result = callback(prevState);
+
+      expect(result).toEqual({
+        notifications: false,
+        profile: false,
+      });
     });
   });
 });

--- a/src/components/NotificationCard/NotificationCard.tsx
+++ b/src/components/NotificationCard/NotificationCard.tsx
@@ -1,6 +1,5 @@
 import { DotsThreeVertical, Bell } from 'phosphor-react';
 import { MouseEvent, ReactNode, useState, useEffect } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
 import { cn } from '../../utils/utils';
 import DropdownMenu, {
   DropdownMenuContent,
@@ -20,21 +19,6 @@ import type {
 } from '../../types/notifications';
 import { formatTimeAgo } from '../../store/notificationStore';
 import mockContentImage from '../../assets/img/mock-content.png';
-
-/**
- * Synchronizes notification state when dropdown closes externally
- * This ensures the notification icon state matches the dropdown state
- */
-export const syncNotificationState = (
-  open: boolean,
-  isNotificationActive: boolean,
-  setActiveStates: Dispatch<SetStateAction<Record<string, boolean>>>,
-  key: string = 'notifications'
-) => {
-  if (!open && isNotificationActive) {
-    setActiveStates((prev) => ({ ...prev, [key]: false }));
-  }
-};
 
 // Extended notification item for component usage with time string
 export interface NotificationItem extends Omit<Notification, 'createdAt'> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ export { Modal };
 export { AlertDialog };
 export { LoadingModal };
 export { NotificationCard };
-export { syncNotificationState } from './components/NotificationCard/NotificationCard';
+export { syncDropdownState } from './utils/utils';
 export { ThemeToggle };
 export type {
   NotificationItem,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,11 @@ import type {
 import { useMobile, getDeviceType } from './hooks/useMobile';
 import type { DeviceType } from './hooks/useMobile';
 import { ThemeMode, useTheme } from './hooks/useTheme';
-import { cn, getSubjectColorWithOpacity } from './utils/utils';
+import {
+  cn,
+  getSubjectColorWithOpacity,
+  syncDropdownState,
+} from './utils/utils';
 
 // Import DropdownMenu and its sub-components
 import DropdownMenu, {
@@ -204,7 +208,6 @@ export { Modal };
 export { AlertDialog };
 export { LoadingModal };
 export { NotificationCard };
-export { syncDropdownState } from './utils/utils';
 export { ThemeToggle };
 export type {
   NotificationItem,
@@ -361,3 +364,4 @@ export type { DeviceType };
 export type { ThemeMode };
 export { cn };
 export { getSubjectColorWithOpacity };
+export { syncDropdownState };

--- a/src/utils/dropdown.ts
+++ b/src/utils/dropdown.ts
@@ -1,0 +1,21 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+/**
+ * Synchronizes dropdown state when it closes externally
+ * This ensures the toggle button state matches the dropdown state
+ *
+ * @param open - Current dropdown open state
+ * @param isActive - Current active state of the toggle button
+ * @param setActiveStates - Function to update active states
+ * @param key - Key identifier for the specific dropdown
+ */
+export const syncDropdownState = (
+  open: boolean,
+  isActive: boolean,
+  setActiveStates: Dispatch<SetStateAction<Record<string, boolean>>>,
+  key: string
+) => {
+  if (!open && isActive) {
+    setActiveStates((prev) => ({ ...prev, [key]: false }));
+  }
+};

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { cn, getSubjectColorWithOpacity } from './utils';
+import { cn, getSubjectColorWithOpacity, syncDropdownState } from './utils';
 
 describe('utils', () => {
   describe('cn', () => {
@@ -139,6 +139,68 @@ describe('utils', () => {
         );
         // Cor que já vem com opacidade da API em dark mode (deve remover)
         expect(getSubjectColorWithOpacity('#0066b8b3', true)).toBe('#0066b8');
+      });
+    });
+  });
+
+  describe('syncDropdownState', () => {
+    it('should update state when open is false and dropdown is active', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncDropdownState(false, true, mockSetActiveStates, 'notifications');
+
+      expect(mockSetActiveStates).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback function
+      const callback = mockSetActiveStates.mock.calls[0][0];
+      const prevState = { notifications: true, profile: false };
+      const result = callback(prevState);
+
+      expect(result).toEqual({
+        notifications: false,
+        profile: false,
+      });
+    });
+
+    it('should not update state when open is true', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncDropdownState(true, true, mockSetActiveStates, 'notifications');
+
+      expect(mockSetActiveStates).not.toHaveBeenCalled();
+    });
+
+    it('should not update state when dropdown is not active', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncDropdownState(false, false, mockSetActiveStates, 'notifications');
+
+      expect(mockSetActiveStates).not.toHaveBeenCalled();
+    });
+
+    it('should not update state when open is true and dropdown is not active', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncDropdownState(true, false, mockSetActiveStates, 'notifications');
+
+      expect(mockSetActiveStates).not.toHaveBeenCalled();
+    });
+
+    it('should update state with custom key', () => {
+      const mockSetActiveStates = jest.fn();
+
+      syncDropdownState(false, true, mockSetActiveStates, 'profile');
+
+      expect(mockSetActiveStates).toHaveBeenCalledWith(expect.any(Function));
+
+      // Test the callback function
+      const callback = mockSetActiveStates.mock.calls[0][0];
+      const prevState = { notifications: false, profile: true };
+      const result = callback(prevState);
+
+      expect(result).toEqual({
+        notifications: false,
+        profile: false,
       });
     });
   });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,6 +5,8 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export { syncDropdownState } from './dropdown';
+
 /**
  * Retorna a cor hexadecimal com opacidade 0.7 (b3) se não estiver em dark mode.
  * Se estiver em dark mode, retorna a cor original.


### PR DESCRIPTION
<img width="1296" height="934" alt="Captura de Tela 2025-09-19 às 13 42 29" src="https://github.com/user-attachments/assets/8d78790e-368a-4071-a2b7-c98bb24c0620" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Utilities
  - Added syncDropdownState to manage dropdown active states; replaces the previous helper.
- Refactor
  - Standardized the “Aparência” menu item with consistent icons and text styling.
  - Sign-out icon and label now inherit theme colors for visual consistency.
  - Public API updated to export syncDropdownState instead of the old helper.
- Tests
  - Added keyboard accessibility tests for opening the theme modal via Enter/Space.
  - Added comprehensive tests for syncDropdownState behavior.
- Chores
  - Bumped package version to 1.1.72.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->