### PR TITLE
AE-1647: fix VideoPlayer responsiveness for small screen and fix duplicated controls in safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.77",
+  "version": "1.1.78",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -39,6 +39,10 @@ describe('NotificationCard', () => {
     mockUseMobile.mockReturnValue({
       isMobile: false,
       isTablet: false,
+      isSmallMobile: false,
+      isExtraSmallMobile: false,
+      isUltraSmallMobile: false,
+      isTinyMobile: false,
       getFormContainerClasses: jest.fn(
         () => 'w-full max-w-[992px] mx-auto px-0'
       ),
@@ -51,6 +55,7 @@ describe('NotificationCard', () => {
       getDesktopHeaderClasses: jest.fn(
         () => 'flex flex-row justify-between items-center gap-6 mb-8'
       ),
+      getVideoContainerClasses: jest.fn(() => 'aspect-video'),
       getDeviceType: jest.fn(() => 'desktop' as DeviceType),
     });
   });
@@ -1184,10 +1189,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 
@@ -1228,12 +1238,17 @@ describe('NotificationCard', () => {
     it('renders notification center in mobile mode when variant is center', () => {
       mockUseMobile.mockReturnValue({
         isMobile: true,
-        isTablet: false,
+        isTablet: true,
+        isSmallMobile: true,
+        isExtraSmallMobile: true,
+        isUltraSmallMobile: true,
+        isTinyMobile: true,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
-        getDeviceType: jest.fn(() => 'mobile' as DeviceType),
+        getVideoContainerClasses: jest.fn(() => 'aspect-square'),
+        getDeviceType: jest.fn(() => 'responsive' as DeviceType),
       });
 
       const mockProps = {
@@ -1275,12 +1290,17 @@ describe('NotificationCard', () => {
     it('renders notification center button in mobile mode', () => {
       mockUseMobile.mockReturnValue({
         isMobile: true,
-        isTablet: false,
+        isTablet: true,
+        isSmallMobile: true,
+        isExtraSmallMobile: true,
+        isUltraSmallMobile: true,
+        isTinyMobile: true,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
-        getDeviceType: jest.fn(() => 'mobile' as DeviceType),
+        getVideoContainerClasses: jest.fn(() => 'aspect-square'),
+        getDeviceType: jest.fn(() => 'responsive' as DeviceType),
       });
       const onFetchNotifications = jest.fn();
 
@@ -1307,10 +1327,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 
@@ -1446,11 +1471,16 @@ describe('NotificationCard', () => {
       // Mock as mobile
       mockUseMobile.mockReturnValue({
         isMobile: true,
-        isTablet: false,
+        isTablet: true,
+        isSmallMobile: true,
+        isExtraSmallMobile: true,
+        isUltraSmallMobile: true,
+        isTinyMobile: true,
         getFormContainerClasses: () => '',
         getHeaderClasses: () => '',
         getMobileHeaderClasses: () => '',
         getDesktopHeaderClasses: () => '',
+        getVideoContainerClasses: () => 'aspect-square',
         getDeviceType: (): DeviceType => 'responsive',
       });
     });
@@ -1677,10 +1707,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: () => '',
         getHeaderClasses: () => '',
         getMobileHeaderClasses: () => '',
         getDesktopHeaderClasses: () => '',
+        getVideoContainerClasses: () => 'aspect-video',
         getDeviceType: (): DeviceType => 'desktop',
       });
     });
@@ -1776,10 +1811,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 
@@ -1846,10 +1886,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 
@@ -1878,10 +1923,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 
@@ -1912,10 +1962,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 
@@ -1951,10 +2006,15 @@ describe('NotificationCard', () => {
       mockUseMobile.mockReturnValue({
         isMobile: false,
         isTablet: false,
+        isSmallMobile: false,
+        isExtraSmallMobile: false,
+        isUltraSmallMobile: false,
+        isTinyMobile: false,
         getFormContainerClasses: jest.fn(() => ''),
         getHeaderClasses: jest.fn(() => ''),
         getMobileHeaderClasses: jest.fn(() => ''),
         getDesktopHeaderClasses: jest.fn(() => ''),
+        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
         getDeviceType: jest.fn(() => 'desktop' as DeviceType),
       });
 

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -21,6 +21,31 @@ jest.mock('../../assets/img/mock-content.png', () => 'test-file-stub');
 jest.mock('../../hooks/useMobile');
 const mockUseMobile = useMobile as jest.MockedFunction<typeof useMobile>;
 
+/**
+ * Factory helper to create useMobile mock with consistent shape
+ */
+const makeUseMobileMock = (
+  overrides?: Partial<ReturnType<typeof useMobile>>
+) => ({
+  isMobile: false,
+  isTablet: false,
+  isSmallMobile: false,
+  isExtraSmallMobile: false,
+  isUltraSmallMobile: false,
+  isTinyMobile: false,
+  getFormContainerClasses: jest.fn(() => 'w-full max-w-[992px] mx-auto px-0'),
+  getHeaderClasses: jest.fn(
+    () => 'flex flex-row justify-between items-center gap-6 mb-8'
+  ),
+  getMobileHeaderClasses: jest.fn(() => 'flex flex-col items-start gap-4 mb-6'),
+  getDesktopHeaderClasses: jest.fn(
+    () => 'flex flex-row justify-between items-center gap-6 mb-8'
+  ),
+  getVideoContainerClasses: jest.fn(() => 'aspect-video'),
+  getDeviceType: jest.fn(() => 'desktop' as DeviceType),
+  ...overrides,
+});
+
 describe('NotificationCard', () => {
   const defaultProps = {
     mode: 'single' as const,
@@ -36,28 +61,7 @@ describe('NotificationCard', () => {
     jest.clearAllMocks();
 
     // Setup default mock for useMobile
-    mockUseMobile.mockReturnValue({
-      isMobile: false,
-      isTablet: false,
-      isSmallMobile: false,
-      isExtraSmallMobile: false,
-      isUltraSmallMobile: false,
-      isTinyMobile: false,
-      getFormContainerClasses: jest.fn(
-        () => 'w-full max-w-[992px] mx-auto px-0'
-      ),
-      getHeaderClasses: jest.fn(
-        () => 'flex flex-row justify-between items-center gap-6 mb-8'
-      ),
-      getMobileHeaderClasses: jest.fn(
-        () => 'flex flex-col items-start gap-4 mb-6'
-      ),
-      getDesktopHeaderClasses: jest.fn(
-        () => 'flex flex-row justify-between items-center gap-6 mb-8'
-      ),
-      getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-      getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-    });
+    mockUseMobile.mockReturnValue(makeUseMobileMock());
   });
 
   it('renders notification card with all required props', () => {
@@ -1186,20 +1190,14 @@ describe('NotificationCard', () => {
     });
 
     it('renders notification center in desktop mode when variant is center', () => {
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       const mockProps = {
         variant: 'center' as const,
@@ -1236,20 +1234,22 @@ describe('NotificationCard', () => {
     });
 
     it('renders notification center in mobile mode when variant is center', () => {
-      mockUseMobile.mockReturnValue({
-        isMobile: true,
-        isTablet: true,
-        isSmallMobile: true,
-        isExtraSmallMobile: true,
-        isUltraSmallMobile: true,
-        isTinyMobile: true,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-square'),
-        getDeviceType: jest.fn(() => 'responsive' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          isMobile: true,
+          isTablet: true,
+          isSmallMobile: true,
+          isExtraSmallMobile: true,
+          isUltraSmallMobile: true,
+          isTinyMobile: true,
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+          getVideoContainerClasses: jest.fn(() => 'aspect-square'),
+          getDeviceType: jest.fn(() => 'responsive' as DeviceType),
+        })
+      );
 
       const mockProps = {
         variant: 'center' as const,
@@ -1288,20 +1288,22 @@ describe('NotificationCard', () => {
     });
 
     it('renders notification center button in mobile mode', () => {
-      mockUseMobile.mockReturnValue({
-        isMobile: true,
-        isTablet: true,
-        isSmallMobile: true,
-        isExtraSmallMobile: true,
-        isUltraSmallMobile: true,
-        isTinyMobile: true,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-square'),
-        getDeviceType: jest.fn(() => 'responsive' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          isMobile: true,
+          isTablet: true,
+          isSmallMobile: true,
+          isExtraSmallMobile: true,
+          isUltraSmallMobile: true,
+          isTinyMobile: true,
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+          getVideoContainerClasses: jest.fn(() => 'aspect-square'),
+          getDeviceType: jest.fn(() => 'responsive' as DeviceType),
+        })
+      );
       const onFetchNotifications = jest.fn();
 
       const mockProps = {
@@ -1324,20 +1326,14 @@ describe('NotificationCard', () => {
     });
 
     it('renders empty state with custom properties in notification center', () => {
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       const mockProps = {
         variant: 'center' as const,
@@ -1469,20 +1465,22 @@ describe('NotificationCard', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       // Mock as mobile
-      mockUseMobile.mockReturnValue({
-        isMobile: true,
-        isTablet: true,
-        isSmallMobile: true,
-        isExtraSmallMobile: true,
-        isUltraSmallMobile: true,
-        isTinyMobile: true,
-        getFormContainerClasses: () => '',
-        getHeaderClasses: () => '',
-        getMobileHeaderClasses: () => '',
-        getDesktopHeaderClasses: () => '',
-        getVideoContainerClasses: () => 'aspect-square',
-        getDeviceType: (): DeviceType => 'responsive',
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          isMobile: true,
+          isTablet: true,
+          isSmallMobile: true,
+          isExtraSmallMobile: true,
+          isUltraSmallMobile: true,
+          isTinyMobile: true,
+          getFormContainerClasses: () => '',
+          getHeaderClasses: () => '',
+          getMobileHeaderClasses: () => '',
+          getDesktopHeaderClasses: () => '',
+          getVideoContainerClasses: () => 'aspect-square',
+          getDeviceType: (): DeviceType => 'responsive',
+        })
+      );
     });
 
     it('renders mobile notification button and opens modal on click', () => {
@@ -1704,20 +1702,14 @@ describe('NotificationCard', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       // Mock as desktop
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: () => '',
-        getHeaderClasses: () => '',
-        getMobileHeaderClasses: () => '',
-        getDesktopHeaderClasses: () => '',
-        getVideoContainerClasses: () => 'aspect-video',
-        getDeviceType: (): DeviceType => 'desktop',
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: () => '',
+          getHeaderClasses: () => '',
+          getMobileHeaderClasses: () => '',
+          getDesktopHeaderClasses: () => '',
+        })
+      );
     });
 
     it('handles navigation with cleanup callback on desktop', () => {
@@ -1808,20 +1800,14 @@ describe('NotificationCard', () => {
       const onNavigateById = jest.fn();
       const onToggleActive = jest.fn();
 
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       const mockGroupedNotifications = [
         {
@@ -1883,20 +1869,14 @@ describe('NotificationCard', () => {
     it('calls onToggleActive when desktop notification button is clicked', () => {
       const onToggleActive = jest.fn();
 
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       render(
         <NotificationCard
@@ -1920,20 +1900,14 @@ describe('NotificationCard', () => {
       const onToggleActive = jest.fn();
       const onFetchNotifications = jest.fn();
 
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       render(
         <NotificationCard
@@ -1959,20 +1933,14 @@ describe('NotificationCard', () => {
     it('fetches notifications when isActive becomes true', () => {
       const onFetchNotifications = jest.fn();
 
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       const { rerender } = render(
         <NotificationCard
@@ -2003,20 +1971,14 @@ describe('NotificationCard', () => {
     it('only calls onToggleActive when onOpenChange is not provided', () => {
       const onToggleActive = jest.fn();
 
-      mockUseMobile.mockReturnValue({
-        isMobile: false,
-        isTablet: false,
-        isSmallMobile: false,
-        isExtraSmallMobile: false,
-        isUltraSmallMobile: false,
-        isTinyMobile: false,
-        getFormContainerClasses: jest.fn(() => ''),
-        getHeaderClasses: jest.fn(() => ''),
-        getMobileHeaderClasses: jest.fn(() => ''),
-        getDesktopHeaderClasses: jest.fn(() => ''),
-        getVideoContainerClasses: jest.fn(() => 'aspect-video'),
-        getDeviceType: jest.fn(() => 'desktop' as DeviceType),
-      });
+      mockUseMobile.mockReturnValue(
+        makeUseMobileMock({
+          getFormContainerClasses: jest.fn(() => ''),
+          getHeaderClasses: jest.fn(() => ''),
+          getMobileHeaderClasses: jest.fn(() => ''),
+          getDesktopHeaderClasses: jest.fn(() => ''),
+        })
+      );
 
       render(
         <NotificationCard

--- a/src/components/VideoPlayer/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.test.tsx
@@ -2616,5 +2616,32 @@ describe('VideoPlayer', () => {
       window.requestAnimationFrame = originalRAF;
       jest.useRealTimers();
     });
+
+    it('should cleanup timeout on unmount when using setTimeout fallback', () => {
+      const originalRAF = window.requestAnimationFrame;
+
+      // Remove requestAnimationFrame to force setTimeout fallback
+      // @ts-expect-error - Testing fallback
+      delete window.requestAnimationFrame;
+
+      jest.useFakeTimers();
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      // Render component which triggers setTimeout fallback (line 553)
+      const { unmount } = render(<VideoPlayer {...defaultProps} />);
+
+      // Unmount before the timeout executes to trigger cleanup (lines 554-555)
+      act(() => {
+        unmount();
+      });
+
+      // Verify clearTimeout was called (covers lines 554-555)
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+
+      // Restore everything
+      clearTimeoutSpy.mockRestore();
+      window.requestAnimationFrame = originalRAF;
+      jest.useRealTimers();
+    });
   });
 });

--- a/src/components/VideoPlayer/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.test.tsx
@@ -2589,6 +2589,127 @@ describe('VideoPlayer', () => {
     });
   });
 
+  describe('Additional coverage tests', () => {
+    it('should render components with default props', () => {
+      const { container } = render(<VideoPlayer {...defaultProps} />);
+
+      // Test ProgressBar (covers line 90 - default className)
+      const progressBar = container.querySelector('input[type="range"]');
+      expect(progressBar).toBeInTheDocument();
+
+      // Test Volume controls (covers lines 128-129)
+      const muteButton = screen.getByRole('button', { name: /mute/i });
+      expect(muteButton).toBeInTheDocument();
+
+      // Test Speed menu (covers lines 184-185)
+      const speedButton = screen.getByRole('button', {
+        name: /playback speed/i,
+      });
+      expect(speedButton).toBeInTheDocument();
+    });
+
+    it('should handle different responsive screen sizes', () => {
+      // Mock window innerWidth for different screen sizes
+      const originalInnerWidth = window.innerWidth;
+
+      // Test tiny mobile (width < 320px) - covers lines 820-821, 829-830, 838-839, 847-848
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 300,
+      });
+
+      const { rerender } = render(<VideoPlayer {...defaultProps} />);
+
+      // Trigger responsive functions by interacting with controls
+      const speedButton = screen.getByRole('button', {
+        name: /playback speed/i,
+      });
+      act(() => {
+        fireEvent.click(speedButton);
+      });
+
+      // Test ultra small mobile (width < 375px)
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 350,
+      });
+
+      rerender(<VideoPlayer {...defaultProps} />);
+
+      // Restore
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    });
+
+    it('should handle menu positioning calculations', () => {
+      // Mock getBoundingClientRect for positioning calculations (covers lines 196-198)
+      const originalGetBoundingClientRect =
+        Element.prototype.getBoundingClientRect;
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({
+        width: 40,
+        height: 40,
+        top: 50,
+        left: 50,
+        bottom: 90,
+        right: 90,
+        x: 50,
+        y: 50,
+        toJSON: jest.fn(),
+      }));
+
+      render(<VideoPlayer {...defaultProps} />);
+
+      // Open speed menu to trigger positioning calculations
+      const speedButton = screen.getByRole('button', {
+        name: /playback speed/i,
+      });
+      act(() => {
+        fireEvent.click(speedButton);
+      });
+
+      // Menu should be rendered (either in document body or in component)
+      const menu =
+        document.querySelector('[role="menu"]') || screen.queryByRole('menu');
+      expect(menu).toBeTruthy();
+
+      // Restore
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    });
+
+    it('should handle fullscreen mode for speed menu', () => {
+      // Test fullscreen conditional rendering (covers line 289)
+      const { container } = render(<VideoPlayer {...defaultProps} />);
+      const section = container.querySelector('section')!;
+
+      // Mock fullscreen
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => section,
+      });
+
+      // Trigger fullscreen change
+      act(() => {
+        fireEvent(document, new Event('fullscreenchange'));
+      });
+
+      // Open speed menu
+      const speedButton = screen.getByRole('button', {
+        name: /playback speed/i,
+      });
+      act(() => {
+        fireEvent.click(speedButton);
+      });
+
+      // Should render menu directly (not in portal)
+      expect(container.querySelector('[role="menu"]')).toBeInTheDocument();
+    });
+  });
+
   describe('requestAnimationFrame fallback', () => {
     it('should use setTimeout fallback and cleanup properly', () => {
       const originalRAF = window.requestAnimationFrame;

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -976,6 +976,8 @@ const VideoPlayer = ({
           poster={poster}
           className="w-full h-full object-contain"
           controlsList="nodownload"
+          playsInline
+          webkit-playsinline="true"
           onTimeUpdate={handleTimeUpdate}
           onLoadedMetadata={handleLoadedMetadata}
           onClick={togglePlayPause}

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -475,6 +475,18 @@ const VideoPlayer = ({
   }, []);
 
   /**
+   * Set iOS/Safari inline playback attributes imperatively
+   */
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    // Ensure inline playback on iOS/Safari
+    video.setAttribute('playsinline', '');
+    video.setAttribute('webkit-playsinline', '');
+  }, []);
+
+  /**
    * Handle controls auto-hide when play state changes
    */
   useEffect(() => {
@@ -974,10 +986,9 @@ const VideoPlayer = ({
           ref={videoRef}
           src={src}
           poster={poster}
-          className="w-full h-full object-contain"
+          className="w-full h-full object-contain analytica-video"
           controlsList="nodownload"
           playsInline
-          webkit-playsinline="true"
           onTimeUpdate={handleTimeUpdate}
           onLoadedMetadata={handleLoadedMetadata}
           onClick={togglePlayPause}

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -838,6 +838,15 @@ const VideoPlayer = ({
   }, [isTinyMobile, isUltraSmallMobile]);
 
   /**
+   * Get responsive positioning classes for center play button
+   */
+  const getCenterPlayButtonPosition = useCallback(() => {
+    if (isTinyMobile) return 'items-center justify-center -translate-y-12';
+    if (isUltraSmallMobile) return 'items-center justify-center -translate-y-8';
+    return 'items-center justify-center';
+  }, [isTinyMobile, isUltraSmallMobile]);
+
+  /**
    * Calculate top controls opacity based on state
    */
   const getTopControlsOpacity = useCallback(() => {
@@ -988,7 +997,12 @@ const VideoPlayer = ({
 
         {/* Center Play Button */}
         {!isPlaying && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/30 transition-opacity">
+          <div
+            className={cn(
+              'absolute inset-0 flex bg-black/30 transition-opacity',
+              getCenterPlayButtonPosition()
+            )}
+          >
             <IconButton
               icon={<Play size={32} weight="regular" className="ml-1" />}
               onClick={togglePlayPause}

--- a/src/hooks/useMobile.test.ts
+++ b/src/hooks/useMobile.test.ts
@@ -228,3 +228,37 @@ describe('getDeviceType', () => {
     globalThis.window = originalWindow;
   });
 });
+
+describe('getVideoContainerClasses', () => {
+  it('should return aspect-square for tiny mobile screens (< 320px)', () => {
+    mockInnerWidth(300);
+
+    const { result } = renderHook(() => useMobile());
+
+    expect(result.current.getVideoContainerClasses()).toBe('aspect-square');
+  });
+
+  it('should return aspect-[4/3] for extra small mobile screens (< 375px)', () => {
+    mockInnerWidth(350);
+
+    const { result } = renderHook(() => useMobile());
+
+    expect(result.current.getVideoContainerClasses()).toBe('aspect-[4/3]');
+  });
+
+  it('should return aspect-[16/12] for small mobile screens (< 425px)', () => {
+    mockInnerWidth(400);
+
+    const { result } = renderHook(() => useMobile());
+
+    expect(result.current.getVideoContainerClasses()).toBe('aspect-[16/12]');
+  });
+
+  it('should return aspect-video for larger screens (>= 425px)', () => {
+    mockInnerWidth(500);
+
+    const { result } = renderHook(() => useMobile());
+
+    expect(result.current.getVideoContainerClasses()).toBe('aspect-video');
+  });
+});

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -7,6 +7,7 @@ const TABLET_WIDTH = 931;
 // Video responsive breakpoints
 const SMALL_MOBILE_WIDTH = 425;
 const EXTRA_SMALL_MOBILE_WIDTH = 375;
+const ULTRA_SMALL_MOBILE_WIDTH = 375; // For video controls
 const TINY_MOBILE_WIDTH = 320;
 // Default desktop width for SSR
 const DEFAULT_WIDTH = 1200;
@@ -45,6 +46,7 @@ export const useMobile = () => {
   const [isTablet, setIsTablet] = useState(false);
   const [isSmallMobile, setIsSmallMobile] = useState(false);
   const [isExtraSmallMobile, setIsExtraSmallMobile] = useState(false);
+  const [isUltraSmallMobile, setIsUltraSmallMobile] = useState(false);
   const [isTinyMobile, setIsTinyMobile] = useState(false);
 
   useEffect(() => {
@@ -54,6 +56,7 @@ export const useMobile = () => {
       setIsTablet(width < TABLET_WIDTH);
       setIsSmallMobile(width < SMALL_MOBILE_WIDTH);
       setIsExtraSmallMobile(width < EXTRA_SMALL_MOBILE_WIDTH);
+      setIsUltraSmallMobile(width < ULTRA_SMALL_MOBILE_WIDTH);
       setIsTinyMobile(width < TINY_MOBILE_WIDTH);
     };
 
@@ -118,6 +121,7 @@ export const useMobile = () => {
     isTablet,
     isSmallMobile,
     isExtraSmallMobile,
+    isUltraSmallMobile,
     isTinyMobile,
     getFormContainerClasses,
     getHeaderClasses,

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -4,6 +4,10 @@ import { useState, useEffect } from 'react';
 const MOBILE_WIDTH = 500;
 // Tablet width in pixels
 const TABLET_WIDTH = 931;
+// Video responsive breakpoints
+const SMALL_MOBILE_WIDTH = 425;
+const EXTRA_SMALL_MOBILE_WIDTH = 375;
+const TINY_MOBILE_WIDTH = 320;
 // Default desktop width for SSR
 const DEFAULT_WIDTH = 1200;
 
@@ -39,12 +43,18 @@ export const getDeviceType = (): DeviceType => {
 export const useMobile = () => {
   const [isMobile, setIsMobile] = useState(false);
   const [isTablet, setIsTablet] = useState(false);
+  const [isSmallMobile, setIsSmallMobile] = useState(false);
+  const [isExtraSmallMobile, setIsExtraSmallMobile] = useState(false);
+  const [isTinyMobile, setIsTinyMobile] = useState(false);
 
   useEffect(() => {
     const checkScreenSize = () => {
       const width = getWindowWidth();
       setIsMobile(width < MOBILE_WIDTH);
       setIsTablet(width < TABLET_WIDTH);
+      setIsSmallMobile(width < SMALL_MOBILE_WIDTH);
+      setIsExtraSmallMobile(width < EXTRA_SMALL_MOBILE_WIDTH);
+      setIsTinyMobile(width < TINY_MOBILE_WIDTH);
     };
 
     checkScreenSize();
@@ -92,13 +102,28 @@ export const useMobile = () => {
     return isMobile ? getMobileHeaderClasses() : getDesktopHeaderClasses();
   };
 
+  /**
+   * Get responsive classes for video container
+   * @returns className string for video container aspect ratio based on screen size
+   */
+  const getVideoContainerClasses = (): string => {
+    if (isTinyMobile) return 'aspect-square'; // 1:1 ratio for screens < 320px
+    if (isExtraSmallMobile) return 'aspect-[4/3]'; // 4:3 ratio for screens < 375px
+    if (isSmallMobile) return 'aspect-[16/12]'; // 16:12 ratio for screens < 425px
+    return 'aspect-video'; // 16:9 ratio for larger screens
+  };
+
   return {
     isMobile,
     isTablet,
+    isSmallMobile,
+    isExtraSmallMobile,
+    isTinyMobile,
     getFormContainerClasses,
     getHeaderClasses,
     getMobileHeaderClasses,
     getDesktopHeaderClasses,
+    getVideoContainerClasses,
     getDeviceType,
   };
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -668,3 +668,29 @@ div textarea:focus {
   border-width: 2px !important;
   border-color: var(--color-primary-950) !important;
 }
+
+/* Safari iOS video controls fix */
+video::-webkit-media-controls {
+  display: none !important;
+}
+
+video::-webkit-media-controls-panel {
+  display: none !important;
+}
+
+video::-webkit-media-controls-play-button {
+  display: none !important;
+}
+
+video::-webkit-media-controls-start-playback-button {
+  display: none !important;
+}
+
+video::-webkit-media-controls-enclosure {
+  display: none !important;
+}
+
+/* Garantir que o vídeo não force fullscreen no iOS */
+video {
+  -webkit-playsinline: true;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -669,28 +669,23 @@ div textarea:focus {
   border-color: var(--color-primary-950) !important;
 }
 
-/* Safari iOS video controls fix */
-video::-webkit-media-controls {
+/* Safari iOS video controls fix - Scoped to VideoPlayer only */
+.analytica-video::-webkit-media-controls {
   display: none !important;
 }
 
-video::-webkit-media-controls-panel {
+.analytica-video::-webkit-media-controls-panel {
   display: none !important;
 }
 
-video::-webkit-media-controls-play-button {
+.analytica-video::-webkit-media-controls-play-button {
   display: none !important;
 }
 
-video::-webkit-media-controls-start-playback-button {
+.analytica-video::-webkit-media-controls-start-playback-button {
   display: none !important;
 }
 
-video::-webkit-media-controls-enclosure {
+.analytica-video::-webkit-media-controls-enclosure {
   display: none !important;
-}
-
-/* Garantir que o vídeo não force fullscreen no iOS */
-video {
-  -webkit-playsinline: true;
 }


### PR DESCRIPTION
<img width="1289" height="932" alt="Captura de Tela 2025-09-25 às 11 24 39" src="https://github.com/user-attachments/assets/db0915c3-3988-4914-aaa0-a0ecf3d13ff5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Video player: finer mobile responsiveness with extra breakpoints, dynamically sized icons, adaptive control spacing, and tunable volume/speed UI (icon sizing and optional slider).

- Bug Fixes
  - Improved mobile playback: enables inline playback on iOS and hides default Safari video controls to avoid UI overlap.

- Tests
  - Expanded responsive breakpoint and video-container aspect tests; added cleanup/timeout and consolidated mobile-mock helpers.

- Chores
  - Bumped app version to 1.1.78.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->