### PR TITLE
AE-1756 - fix: flicker when open modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.87",
+  "version": "1.1.88",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -96,6 +96,73 @@ describe('Modal', () => {
     expect(document.body.style.overflow).toBe('hidden');
   });
 
+  it('deve adicionar padding-right ao body quando há scrollbar', () => {
+    // Mock window.innerWidth e clientWidth para simular scrollbar
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      writable: true,
+      configurable: true,
+      value: 1009, // 15px de scrollbar
+    });
+
+    render(<Modal {...defaultProps} />);
+
+    expect(document.body.style.paddingRight).toBe('15px');
+  });
+
+  it('deve criar overlay para cobrir área da scrollbar', () => {
+    // Mock window.innerWidth e clientWidth para simular scrollbar
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      writable: true,
+      configurable: true,
+      value: 1009,
+    });
+
+    render(<Modal {...defaultProps} />);
+
+    const overlay = document.getElementById('modal-scrollbar-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay?.style.width).toBe('15px');
+    expect(overlay?.style.position).toBe('fixed');
+    expect(overlay?.style.top).toBe('0px');
+    expect(overlay?.style.right).toBe('0px');
+  });
+
+  it('deve remover overlay quando modal fecha', () => {
+    // Mock scrollbar
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      writable: true,
+      configurable: true,
+      value: 1009,
+    });
+
+    const { rerender } = render(<Modal {...defaultProps} />);
+
+    expect(
+      document.getElementById('modal-scrollbar-overlay')
+    ).toBeInTheDocument();
+
+    rerender(<Modal {...defaultProps} isOpen={false} />);
+
+    expect(
+      document.getElementById('modal-scrollbar-overlay')
+    ).not.toBeInTheDocument();
+  });
+
   it('deve aplicar as classes de estilo corretas no conteúdo', () => {
     render(<Modal {...defaultProps} />);
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -122,17 +122,51 @@ const Modal = ({
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, closeOnEscape, onClose]);
 
-  // Handle body scroll lock
+  // Handle body scroll lock and scrollbar shift fix
   useEffect(() => {
+    if (!isOpen) return;
+
+    // Calculate scrollbar width before hiding overflow
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth;
+
+    // Save original styles
     const originalOverflow = document.body.style.overflow;
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = originalOverflow;
+    const originalPaddingRight = document.body.style.paddingRight;
+
+    // Apply scroll lock
+    document.body.style.overflow = 'hidden';
+
+    // Fix scrollbar shift: add padding to compensate for lost scrollbar
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+
+      // Create overlay to cover the padding area with backdrop color
+      const overlay = document.createElement('div');
+      overlay.id = 'modal-scrollbar-overlay';
+      overlay.style.cssText = `
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: ${scrollbarWidth}px;
+        height: 100vh;
+        background-color: rgb(0 0 0 / 0.6);
+        z-index: 40;
+        pointer-events: none;
+      `;
+      document.body.appendChild(overlay);
     }
 
     return () => {
+      // Restore original styles
       document.body.style.overflow = originalOverflow;
+      document.body.style.paddingRight = originalPaddingRight;
+
+      // Remove overlay
+      const overlay = document.getElementById('modal-scrollbar-overlay');
+      if (overlay) {
+        overlay.remove();
+      }
     };
   }, [isOpen]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved modal experience: background scrolling is locked when open, and a subtle overlay covers the scrollbar gap for a consistent backdrop without layout shifts.
- Bug Fixes
  - Eliminated page jump/shift when opening modals by compensating for scrollbar width.
- Tests
  - Added tests for scrollbar compensation, overlay creation, and cleanup when the modal closes.
- Chores
  - Bumped version to 1.1.88.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->