### PR TITLE
AE-1781

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.1.89",
+  "version": "1.1.90",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -379,7 +379,7 @@ describe('CardQuestions', () => {
     expect(screen.getByText('Nota')).toBeInTheDocument();
     expect(screen.getByText('00')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Ver Questão/i })
+      screen.getByRole('button', { name: /Ver Resultado/i })
     ).toBeInTheDocument();
   });
 
@@ -447,7 +447,7 @@ describe('CardQuestions', () => {
     expect(screen.getByText('92')).toBeInTheDocument();
     expect(screen.getByText('Realizado')).toBeInTheDocument();
 
-    const button = screen.getByRole('button', { name: /Ver Questão/i });
+    const button = screen.getByRole('button', { name: /Ver Resultado/i });
     button.click();
 
     expect(handleClick).toHaveBeenCalledWith('test-value');
@@ -482,7 +482,7 @@ describe('CardQuestions', () => {
       />
     );
 
-    const button = screen.getByRole('button', { name: /Ver Questão/i });
+    const button = screen.getByRole('button', { name: /Ver Resultado/i });
     fireEvent.click(button);
     expect(handleClick).toHaveBeenCalledWith('123');
   });

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -253,7 +253,7 @@ const CardQuestions = forwardRef<HTMLDivElement, CardQuestionProps>(
   ) => {
     const isDone = state === 'done';
     const stateLabel = isDone ? 'Realizado' : 'Não Realizado';
-    const buttonLabel = isDone ? 'Ver Questão' : 'Responder';
+    const buttonLabel = isDone ? 'Ver Resultado' : 'Responder';
 
     return (
       <CardBase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Card button label to show “Ver Resultado” when the question is completed; remains “Responder” otherwise.
* **Tests**
  * Adjusted tests to reflect the new button label and related interactions.
* **Chores**
  * Bumped package version to 1.1.90.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->