### PR TITLE
feat: call GET feedback after PATCH in handleObservationSubmit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.63",
+  "version": "1.3.64",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -243,13 +243,19 @@ jest.mock('../CorrectActivityModal/CorrectActivityModal', () => ({
           Enviar com arquivo
         </button>
         <button
-          onClick={() =>
-            void onQuestionCorrectionSubmit?.(data?.studentId || '', {
-              questionId: 'q1',
-              isCorrect: true,
-              score: 10,
-            })?.catch(() => {})
-          }
+          onClick={() => {
+            void (async () => {
+              try {
+                await onQuestionCorrectionSubmit?.(data?.studentId || '', {
+                  questionId: 'q1',
+                  isCorrect: true,
+                  score: 10,
+                });
+              } catch {
+                // noop - error handled by component
+              }
+            })();
+          }}
           data-testid="submit-question-correction"
         >
           Corrigir questão

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -1290,7 +1290,12 @@ describe('ActivityDetails', () => {
       fireEvent.click(screen.getByTestId('submit-observation'));
 
       await waitFor(() => {
-        expect(mockSafeFetchStudentFeedback).toHaveBeenCalledTimes(2);
+        expect(screen.getByTestId('modal-observation')).toHaveTextContent(
+          'Ótimo trabalho!'
+        );
+        expect(screen.getByTestId('modal-attachment')).toHaveTextContent(
+          'https://s3.amazonaws.com/file.pdf'
+        );
       });
     });
 
@@ -1344,10 +1349,51 @@ describe('ActivityDetails', () => {
 
       await waitFor(() => {
         expect(mockSubmitObservation).toHaveBeenCalled();
+        expect(mockSafeFetchStudentFeedback).toHaveBeenCalledTimes(2);
       });
 
-      // Modal should still be open (submit succeeded, only feedback fetch failed silently)
-      expect(screen.getByTestId('correct-activity-modal')).toBeInTheDocument();
+      // Aguardar o setCorrectionData processar — observation deve continuar ausente
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('modal-observation')).not.toBeInTheDocument();
+    });
+
+    it('should clear observation when safeFetchStudentFeedback returns null teacherFeedback', async () => {
+      mockSafeFetchStudentFeedback
+        .mockResolvedValueOnce({ teacherFeedback: null, attachment: null })
+        .mockResolvedValueOnce({ teacherFeedback: null, attachment: null });
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-observation'));
+
+      await waitFor(() => {
+        expect(mockSafeFetchStudentFeedback).toHaveBeenCalledTimes(2);
+      });
+
+      // observation fica undefined (null ?? undefined) → span não aparece
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('modal-observation')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('modal-attachment')).not.toBeInTheDocument();
     });
 
     it('should call console.error when submitObservation fails', async () => {

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -179,7 +179,7 @@ jest.mock('../CorrectActivityModal/CorrectActivityModal', () => ({
   }: {
     isOpen: boolean;
     onClose: () => void;
-    data?: { studentId?: string };
+    data?: { studentId?: string; observation?: string; attachment?: string };
     isViewOnly?: boolean;
     onObservationSubmit?: (
       studentId: string,
@@ -190,6 +190,12 @@ jest.mock('../CorrectActivityModal/CorrectActivityModal', () => ({
     isOpen ? (
       <div data-testid="correct-activity-modal">
         <button onClick={onClose}>Fechar</button>
+        {data?.observation && (
+          <span data-testid="modal-observation">{data.observation}</span>
+        )}
+        {data?.attachment && (
+          <span data-testid="modal-attachment">{data.attachment}</span>
+        )}
         <button
           onClick={() =>
             onObservationSubmit?.(data?.studentId || '', 'Test observation', [])
@@ -526,7 +532,10 @@ describe('ActivityDetails', () => {
       },
     };
     mockFetchStudentCorrection.mockResolvedValue(apiResponse);
-    mockFetchStudentFeedback.mockResolvedValue({ teacherFeedback: null, attachment: null });
+    mockFetchStudentFeedback.mockResolvedValue({
+      teacherFeedback: null,
+      attachment: null,
+    });
     mockSubmitObservation.mockResolvedValue(undefined);
     mockSubmitQuestionCorrection.mockResolvedValue(undefined);
     mockMapSubjectNameToEnum.mockReturnValue('MATEMATICA');
@@ -662,7 +671,9 @@ describe('ActivityDetails', () => {
       (useActivityDetails as jest.Mock).mockReturnValue({
         fetchActivityDetails: mockFetchActivityDetailsZero,
         fetchStudentCorrection: jest.fn(),
-        fetchStudentFeedback: jest.fn().mockResolvedValue({ teacherFeedback: null, attachment: null }),
+        fetchStudentFeedback: jest
+          .fn()
+          .mockResolvedValue({ teacherFeedback: null, attachment: null }),
         submitObservation: jest.fn(),
         submitQuestionCorrection: jest.fn(),
       });
@@ -697,7 +708,9 @@ describe('ActivityDetails', () => {
       (useActivityDetails as jest.Mock).mockReturnValue({
         fetchActivityDetails: mockFetchActivityDetailsWithCount,
         fetchStudentCorrection: jest.fn(),
-        fetchStudentFeedback: jest.fn().mockResolvedValue({ teacherFeedback: null, attachment: null }),
+        fetchStudentFeedback: jest
+          .fn()
+          .mockResolvedValue({ teacherFeedback: null, attachment: null }),
         submitObservation: jest.fn(),
         submitQuestionCorrection: jest.fn(),
       });
@@ -1014,6 +1027,51 @@ describe('ActivityDetails', () => {
 
       consoleSpy.mockRestore();
     });
+
+    it('should pass teacherFeedback and attachment to modal when fetchStudentFeedback returns data', async () => {
+      mockFetchStudentFeedback.mockResolvedValue({
+        teacherFeedback: 'Ótimo trabalho!',
+        attachment: 'https://s3.amazonaws.com/bucket/file.pdf',
+      });
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('modal-observation')).toHaveTextContent(
+          'Ótimo trabalho!'
+        );
+        expect(screen.getByTestId('modal-attachment')).toHaveTextContent(
+          'https://s3.amazonaws.com/bucket/file.pdf'
+        );
+      });
+    });
+
+    it('should open modal normally when fetchStudentFeedback fails (inner catch noop)', async () => {
+      mockFetchStudentFeedback.mockRejectedValue(new Error('Feedback not found'));
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId('modal-observation')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('modal-attachment')).not.toBeInTheDocument();
+    });
   });
 
   describe('Table Data', () => {
@@ -1078,6 +1136,89 @@ describe('ActivityDetails', () => {
           null
         );
       });
+    });
+
+    it('should call fetchStudentFeedback after successful submitObservation', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-observation'));
+
+      await waitFor(() => {
+        // Called once on modal open, then again after submit
+        expect(mockFetchStudentFeedback).toHaveBeenCalledWith(
+          'activity-123',
+          'student-2'
+        );
+        expect(mockFetchStudentFeedback).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should keep modal open when fetchStudentFeedback fails after submit', async () => {
+      mockFetchStudentFeedback
+        .mockResolvedValueOnce({ teacherFeedback: null, attachment: null })
+        .mockRejectedValueOnce(new Error('Feedback failed'));
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-observation'));
+
+      await waitFor(() => {
+        expect(mockSubmitObservation).toHaveBeenCalled();
+      });
+
+      // Modal should still be open (submit succeeded, only feedback fetch failed silently)
+      expect(screen.getByTestId('correct-activity-modal')).toBeInTheDocument();
+    });
+
+    it('should call console.error when submitObservation fails', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      mockSubmitObservation.mockRejectedValue(new Error('Submit failed'));
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-observation'));
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+
+      consoleSpy.mockRestore();
     });
   });
 

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -491,6 +491,7 @@ describe('ActivityDetails', () => {
   const mockFetchActivityDetails = jest.fn();
   const mockFetchStudentCorrection = jest.fn();
   const mockFetchStudentFeedback = jest.fn();
+  const mockSafeFetchStudentFeedback = jest.fn();
   const mockSubmitObservation = jest.fn();
   const mockSubmitQuestionCorrection = jest.fn();
   const mockOnBack = jest.fn();
@@ -536,6 +537,10 @@ describe('ActivityDetails', () => {
       teacherFeedback: null,
       attachment: null,
     });
+    mockSafeFetchStudentFeedback.mockResolvedValue({
+      teacherFeedback: null,
+      attachment: null,
+    });
     mockSubmitObservation.mockResolvedValue(undefined);
     mockSubmitQuestionCorrection.mockResolvedValue(undefined);
     mockMapSubjectNameToEnum.mockReturnValue('MATEMATICA');
@@ -545,6 +550,7 @@ describe('ActivityDetails', () => {
       fetchActivityDetails: mockFetchActivityDetails,
       fetchStudentCorrection: mockFetchStudentCorrection,
       fetchStudentFeedback: mockFetchStudentFeedback,
+      safeFetchStudentFeedback: mockSafeFetchStudentFeedback,
       submitObservation: mockSubmitObservation,
       submitQuestionCorrection: mockSubmitQuestionCorrection,
     });
@@ -674,6 +680,9 @@ describe('ActivityDetails', () => {
         fetchStudentFeedback: jest
           .fn()
           .mockResolvedValue({ teacherFeedback: null, attachment: null }),
+        safeFetchStudentFeedback: jest
+          .fn()
+          .mockResolvedValue({ teacherFeedback: null, attachment: null }),
         submitObservation: jest.fn(),
         submitQuestionCorrection: jest.fn(),
       });
@@ -709,6 +718,9 @@ describe('ActivityDetails', () => {
         fetchActivityDetails: mockFetchActivityDetailsWithCount,
         fetchStudentCorrection: jest.fn(),
         fetchStudentFeedback: jest
+          .fn()
+          .mockResolvedValue({ teacherFeedback: null, attachment: null }),
+        safeFetchStudentFeedback: jest
           .fn()
           .mockResolvedValue({ teacherFeedback: null, attachment: null }),
         submitObservation: jest.fn(),
@@ -1028,8 +1040,8 @@ describe('ActivityDetails', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should pass teacherFeedback and attachment to modal when fetchStudentFeedback returns data', async () => {
-      mockFetchStudentFeedback.mockResolvedValue({
+    it('should pass teacherFeedback and attachment to modal when safeFetchStudentFeedback returns data', async () => {
+      mockSafeFetchStudentFeedback.mockResolvedValue({
         teacherFeedback: 'Ótimo trabalho!',
         attachment: 'https://s3.amazonaws.com/bucket/file.pdf',
       });
@@ -1052,8 +1064,8 @@ describe('ActivityDetails', () => {
       });
     });
 
-    it('should open modal normally when fetchStudentFeedback fails (inner catch noop)', async () => {
-      mockFetchStudentFeedback.mockRejectedValue(new Error('Feedback not found'));
+    it('should open modal normally when safeFetchStudentFeedback returns null', async () => {
+      mockSafeFetchStudentFeedback.mockResolvedValue(null);
 
       render(<ActivityDetails {...defaultProps} />);
 
@@ -1138,7 +1150,7 @@ describe('ActivityDetails', () => {
       });
     });
 
-    it('should call fetchStudentFeedback after successful submitObservation', async () => {
+    it('should call safeFetchStudentFeedback after successful submitObservation', async () => {
       render(<ActivityDetails {...defaultProps} />);
 
       await waitFor(() => {
@@ -1157,18 +1169,18 @@ describe('ActivityDetails', () => {
 
       await waitFor(() => {
         // Called once on modal open, then again after submit
-        expect(mockFetchStudentFeedback).toHaveBeenCalledWith(
+        expect(mockSafeFetchStudentFeedback).toHaveBeenCalledWith(
           'activity-123',
           'student-2'
         );
-        expect(mockFetchStudentFeedback).toHaveBeenCalledTimes(2);
+        expect(mockSafeFetchStudentFeedback).toHaveBeenCalledTimes(2);
       });
     });
 
-    it('should keep modal open when fetchStudentFeedback fails after submit', async () => {
-      mockFetchStudentFeedback
+    it('should keep modal open when safeFetchStudentFeedback returns null after submit', async () => {
+      mockSafeFetchStudentFeedback
         .mockResolvedValueOnce({ teacherFeedback: null, attachment: null })
-        .mockRejectedValueOnce(new Error('Feedback failed'));
+        .mockResolvedValueOnce(null);
 
       render(<ActivityDetails {...defaultProps} />);
 

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -80,7 +80,12 @@ jest.mock('../TableProvider/TableProvider', () => ({
       render?: (value: unknown, row: unknown) => ReactNode;
     }[];
     emptyState?: { component: ReactNode };
-    onParamsChange?: (params: { page?: number; limit?: number }) => void;
+    onParamsChange?: (params: {
+      page?: number;
+      limit?: number;
+      sortBy?: string;
+      sortOrder?: string;
+    }) => void;
   }) => {
     if (data.length === 0 && emptyState?.component) {
       return <div data-testid="table-provider">{emptyState.component}</div>;
@@ -160,6 +165,24 @@ jest.mock('../TableProvider/TableProvider', () => ({
               >
                 20 por página
               </button>
+              <button
+                onClick={() => onParamsChange?.({ sortBy: 'studentName' })}
+                data-testid="sort-by-name"
+              >
+                Ordenar por nome
+              </button>
+              <button
+                onClick={() => onParamsChange?.({ sortBy: '' })}
+                data-testid="sort-by-clear"
+              >
+                Limpar ordenação
+              </button>
+              <button
+                onClick={() => onParamsChange?.({ sortOrder: 'asc' })}
+                data-testid="sort-order-asc"
+              >
+                Ordenar crescente
+              </button>
             </div>
           ),
         })}
@@ -176,6 +199,7 @@ jest.mock('../CorrectActivityModal/CorrectActivityModal', () => ({
     onClose,
     data,
     onObservationSubmit,
+    onQuestionCorrectionSubmit,
   }: {
     isOpen: boolean;
     onClose: () => void;
@@ -185,6 +209,10 @@ jest.mock('../CorrectActivityModal/CorrectActivityModal', () => ({
       studentId: string,
       observation: string,
       files: File[]
+    ) => void;
+    onQuestionCorrectionSubmit?: (
+      studentId: string,
+      payload: { questionId: string; isCorrect: boolean; score: number }
     ) => void;
   }) =>
     isOpen ? (
@@ -203,6 +231,28 @@ jest.mock('../CorrectActivityModal/CorrectActivityModal', () => ({
           data-testid="submit-observation"
         >
           Enviar observação
+        </button>
+        <button
+          onClick={() =>
+            onObservationSubmit?.(data?.studentId || '', 'With file', [
+              new File(['content'], 'test.pdf', { type: 'application/pdf' }),
+            ])
+          }
+          data-testid="submit-observation-with-file"
+        >
+          Enviar com arquivo
+        </button>
+        <button
+          onClick={() =>
+            void onQuestionCorrectionSubmit?.(data?.studentId || '', {
+              questionId: 'q1',
+              isCorrect: true,
+              score: 10,
+            })?.catch(() => {})
+          }
+          data-testid="submit-question-correction"
+        >
+          Corrigir questão
         </button>
       </div>
     ) : null,
@@ -598,6 +648,18 @@ describe('ActivityDetails', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Servidor indisponível')).toBeInTheDocument();
+      });
+    });
+
+    it('should use fallback message when non-Error is thrown by fetchActivityDetails', async () => {
+      mockFetchActivityDetails.mockRejectedValue('string error');
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText('Erro ao carregar detalhes').length
+        ).toBeGreaterThan(0);
       });
     });
   });
@@ -1040,6 +1102,26 @@ describe('ActivityDetails', () => {
       consoleSpy.mockRestore();
     });
 
+    it('should use fallback error message when non-Error is thrown by fetchStudentCorrection', async () => {
+      mockFetchStudentCorrection.mockRejectedValue('non-error string');
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+
+      consoleSpy.mockRestore();
+    });
+
     it('should pass teacherFeedback and attachment to modal when safeFetchStudentFeedback returns data', async () => {
       mockSafeFetchStudentFeedback.mockResolvedValue({
         teacherFeedback: 'Ótimo trabalho!',
@@ -1174,6 +1256,62 @@ describe('ActivityDetails', () => {
           'student-2'
         );
         expect(mockSafeFetchStudentFeedback).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should update modal with returned feedback after successful submit', async () => {
+      mockSafeFetchStudentFeedback
+        .mockResolvedValueOnce({ teacherFeedback: null, attachment: null })
+        .mockResolvedValueOnce({
+          teacherFeedback: 'Ótimo trabalho!',
+          attachment: 'https://s3.amazonaws.com/file.pdf',
+        });
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-observation'));
+
+      await waitFor(() => {
+        expect(mockSafeFetchStudentFeedback).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should call submitObservation with file when files are provided', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-observation-with-file'));
+
+      await waitFor(() => {
+        expect(mockSubmitObservation).toHaveBeenCalledWith(
+          'activity-123',
+          'student-2',
+          'With file',
+          expect.any(File)
+        );
       });
     });
 
@@ -1795,6 +1933,221 @@ describe('ActivityDetails', () => {
 
       // Verify that handlePrint was called (meaning shouldPrint was true and conditions were met)
       expect(mockHandlePrint).toHaveBeenCalled();
+    });
+
+    it('should set shouldPrint to true when questions are already loaded (non-empty)', async () => {
+      const mockQuestions = [
+        createQuestion('q1', 'Questão 1', QUESTION_TYPE.ALTERNATIVA, [
+          { id: 'opt1', option: 'Opção A' },
+          { id: 'opt2', option: 'Opção B' },
+        ]),
+      ];
+
+      mockApiClient.get = jest.fn().mockResolvedValue({
+        data: { data: { questions: mockQuestions } },
+      });
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Baixar Atividade')).toBeInTheDocument();
+      });
+
+      // First click loads questions
+      fireEvent.click(screen.getByText('Baixar Atividade'));
+
+      await waitFor(
+        () => {
+          expect(mockHandlePrint).toHaveBeenCalled();
+        },
+        { timeout: 2000 }
+      );
+
+      mockHandlePrint.mockClear();
+
+      // Second click: questions already loaded (non-empty) → hits the else-if branch
+      fireEvent.click(screen.getByText('Baixar Atividade'));
+
+      await waitFor(
+        () => {
+          expect(mockHandlePrint).toHaveBeenCalled();
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it('should return empty array when response has neither questions nor questionIds', async () => {
+      // Mock API to return data with neither questions nor questionIds
+      mockApiClient.get = jest.fn().mockResolvedValueOnce({
+        data: { data: {} },
+      });
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Baixar Atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Baixar Atividade'));
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Nenhuma questão encontrada',
+          })
+        );
+      });
+    });
+
+    it('should reset shouldPrint when handlePrint is not available', async () => {
+      (useQuestionsPdfPrint as jest.Mock).mockReturnValue({
+        contentRef: { current: null },
+        handlePrint: undefined,
+      });
+
+      const mockQuestions = [
+        createQuestion('q1', 'Questão 1', QUESTION_TYPE.ALTERNATIVA, [
+          { id: 'opt1', option: 'Opção A' },
+        ]),
+      ];
+
+      mockApiClient.get = jest.fn().mockResolvedValueOnce({
+        data: { data: { questions: mockQuestions } },
+      });
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Baixar Atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Baixar Atividade'));
+
+      // Wait for the full async chain: fetch → state update → effect → setShouldPrint(false)
+      await waitFor(
+        () => {
+          // After questions are fetched and shouldPrint effect runs with null contentRef,
+          // the button should be back to normal (not loading)
+          expect(screen.queryByText('Carregando...')).not.toBeInTheDocument();
+          expect(screen.getByText('Baixar Atividade')).toBeInTheDocument();
+        },
+        { timeout: 2000 }
+      );
+
+      // handlePrint should not be called since contentRef.current is null
+      expect(mockHandlePrint).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Sorting', () => {
+    it('should map sortBy studentName to name API param', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sort-by-name')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('sort-by-name'));
+
+      await waitFor(() => {
+        expect(mockFetchActivityDetails).toHaveBeenCalledWith(
+          'activity-123',
+          expect.objectContaining({ sortBy: 'name' })
+        );
+      });
+    });
+
+    it('should set sortBy to undefined when sortBy param is empty string', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sort-by-clear')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('sort-by-clear'));
+
+      await waitFor(() => {
+        expect(mockFetchActivityDetails).toHaveBeenCalledWith(
+          'activity-123',
+          expect.objectContaining({ sortBy: undefined })
+        );
+      });
+    });
+
+    it('should set sortOrder when sortOrder param is provided', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('sort-order-asc')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('sort-order-asc'));
+
+      await waitFor(() => {
+        expect(mockFetchActivityDetails).toHaveBeenCalledWith(
+          'activity-123',
+          expect.objectContaining({ sortOrder: 'asc' })
+        );
+      });
+    });
+  });
+
+  describe('Question Correction Submit', () => {
+    it('should call submitQuestionCorrection when correction is submitted', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-question-correction'));
+
+      await waitFor(() => {
+        expect(mockSubmitQuestionCorrection).toHaveBeenCalledWith(
+          'activity-123',
+          'student-2',
+          { questionId: 'q1', isCorrect: true, score: 10 }
+        );
+      });
+    });
+
+    it('should log error when submitQuestionCorrection fails', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const mockError = new Error('Correction failed');
+      mockSubmitQuestionCorrection.mockRejectedValueOnce(mockError);
+
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Corrigir atividade')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Corrigir atividade'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('correct-activity-modal')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('submit-question-correction'));
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Failed to submit question correction:',
+          mockError
+        );
+      });
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -484,6 +484,7 @@ const createPendingPromise = <T,>(): Promise<T> => new Promise<T>(() => {});
 describe('ActivityDetails', () => {
   const mockFetchActivityDetails = jest.fn();
   const mockFetchStudentCorrection = jest.fn();
+  const mockFetchStudentFeedback = jest.fn();
   const mockSubmitObservation = jest.fn();
   const mockSubmitQuestionCorrection = jest.fn();
   const mockOnBack = jest.fn();
@@ -525,6 +526,7 @@ describe('ActivityDetails', () => {
       },
     };
     mockFetchStudentCorrection.mockResolvedValue(apiResponse);
+    mockFetchStudentFeedback.mockResolvedValue({ teacherFeedback: null, attachment: null });
     mockSubmitObservation.mockResolvedValue(undefined);
     mockSubmitQuestionCorrection.mockResolvedValue(undefined);
     mockMapSubjectNameToEnum.mockReturnValue('MATEMATICA');
@@ -533,6 +535,7 @@ describe('ActivityDetails', () => {
     (useActivityDetails as jest.Mock).mockReturnValue({
       fetchActivityDetails: mockFetchActivityDetails,
       fetchStudentCorrection: mockFetchStudentCorrection,
+      fetchStudentFeedback: mockFetchStudentFeedback,
       submitObservation: mockSubmitObservation,
       submitQuestionCorrection: mockSubmitQuestionCorrection,
     });
@@ -659,6 +662,7 @@ describe('ActivityDetails', () => {
       (useActivityDetails as jest.Mock).mockReturnValue({
         fetchActivityDetails: mockFetchActivityDetailsZero,
         fetchStudentCorrection: jest.fn(),
+        fetchStudentFeedback: jest.fn().mockResolvedValue({ teacherFeedback: null, attachment: null }),
         submitObservation: jest.fn(),
         submitQuestionCorrection: jest.fn(),
       });
@@ -693,6 +697,7 @@ describe('ActivityDetails', () => {
       (useActivityDetails as jest.Mock).mockReturnValue({
         fetchActivityDetails: mockFetchActivityDetailsWithCount,
         fetchStudentCorrection: jest.fn(),
+        fetchStudentFeedback: jest.fn().mockResolvedValue({ teacherFeedback: null, attachment: null }),
         submitObservation: jest.fn(),
         submitQuestionCorrection: jest.fn(),
       });

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -251,7 +251,7 @@ export const ActivityDetails = ({
   const {
     fetchActivityDetails,
     fetchStudentCorrection,
-    fetchStudentFeedback,
+    safeFetchStudentFeedback,
     submitObservation,
     submitQuestionCorrection,
   } = useActivityDetails(apiClient);
@@ -327,18 +327,10 @@ export const ActivityDetails = ({
       setCorrectionError(null);
       try {
         const apiResponse = await fetchStudentCorrection(activityId, studentId);
-        let feedbackResponse: {
-          teacherFeedback: string | null;
-          attachment: string | null;
-        } = {
-          teacherFeedback: null,
-          attachment: null,
-        };
-        try {
-          feedbackResponse = await fetchStudentFeedback(activityId, studentId);
-        } catch {
-          // noop
-        }
+        const feedbackResponse = (await safeFetchStudentFeedback(
+          activityId,
+          studentId
+        )) ?? { teacherFeedback: null, attachment: null };
         // Convert API response to StudentActivityCorrectionData format
         const correction = convertApiResponseToCorrectionData(
           apiResponse,
@@ -358,7 +350,12 @@ export const ActivityDetails = ({
         );
       }
     },
-    [data?.students, activityId, fetchStudentCorrection, fetchStudentFeedback]
+    [
+      data?.students,
+      activityId,
+      fetchStudentCorrection,
+      safeFetchStudentFeedback,
+    ]
   );
 
   /**
@@ -381,15 +378,10 @@ export const ActivityDetails = ({
         const file = files.length > 0 ? files[0] : null;
         await submitObservation(activityId, studentId, observation, file);
 
-        let feedbackResponse: {
-          teacherFeedback: string | null;
-          attachment: string | null;
-        } | null = null;
-        try {
-          feedbackResponse = await fetchStudentFeedback(activityId, studentId);
-        } catch {
-          // noop
-        }
+        const feedbackResponse = await safeFetchStudentFeedback(
+          activityId,
+          studentId
+        );
         setCorrectionData((prev) =>
           prev
             ? {
@@ -397,11 +389,11 @@ export const ActivityDetails = ({
                 observation:
                   feedbackResponse === null
                     ? prev.observation
-                    : feedbackResponse.teacherFeedback ?? undefined,
+                    : (feedbackResponse.teacherFeedback ?? undefined),
                 attachment:
                   feedbackResponse === null
                     ? prev.attachment
-                    : feedbackResponse.attachment ?? undefined,
+                    : (feedbackResponse.attachment ?? undefined),
               }
             : prev
         );
@@ -409,7 +401,7 @@ export const ActivityDetails = ({
         console.error('Failed to submit observation:', err);
       }
     },
-    [activityId, submitObservation, fetchStudentFeedback]
+    [activityId, submitObservation, safeFetchStudentFeedback]
   );
 
   /**

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -376,12 +376,16 @@ export const ActivityDetails = ({
         await submitObservation(activityId, studentId, observation, file);
 
         // Fetch updated feedback from server after successful PATCH
-        const feedbackResponse = await fetchStudentFeedback(activityId, studentId);
+        const feedbackResponse = await fetchStudentFeedback(
+          activityId,
+          studentId
+        ).catch(() => ({ teacherFeedback: null, attachment: null }));
         setCorrectionData((prev) =>
           prev
             ? {
                 ...prev,
-                observation: feedbackResponse.teacherFeedback ?? prev.observation,
+                observation:
+                  feedbackResponse.teacherFeedback ?? prev.observation,
                 attachment: feedbackResponse.attachment ?? prev.attachment,
               }
             : prev

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -251,6 +251,7 @@ export const ActivityDetails = ({
   const {
     fetchActivityDetails,
     fetchStudentCorrection,
+    fetchStudentFeedback,
     submitObservation,
     submitQuestionCorrection,
   } = useActivityDetails(apiClient);
@@ -325,12 +326,20 @@ export const ActivityDetails = ({
 
       setCorrectionError(null);
       try {
-        const apiResponse = await fetchStudentCorrection(activityId, studentId);
+        const [apiResponse, feedbackResponse] = await Promise.all([
+          fetchStudentCorrection(activityId, studentId),
+          fetchStudentFeedback(activityId, studentId).catch(() => ({
+            teacherFeedback: null,
+            attachment: null,
+          })),
+        ]);
         // Convert API response to StudentActivityCorrectionData format
         const correction = convertApiResponseToCorrectionData(
           apiResponse,
           studentId,
-          student.studentName || 'Aluno'
+          student.studentName || 'Aluno',
+          feedbackResponse.teacherFeedback ?? undefined,
+          feedbackResponse.attachment ?? undefined
         );
         setCorrectionData(correction);
         setIsModalOpen(true);
@@ -343,7 +352,7 @@ export const ActivityDetails = ({
         );
       }
     },
-    [data?.students, activityId, fetchStudentCorrection]
+    [data?.students, activityId, fetchStudentCorrection, fetchStudentFeedback]
   );
 
   /**
@@ -365,11 +374,23 @@ export const ActivityDetails = ({
       try {
         const file = files.length > 0 ? files[0] : null;
         await submitObservation(activityId, studentId, observation, file);
+
+        // Fetch updated feedback from server after successful PATCH
+        const feedbackResponse = await fetchStudentFeedback(activityId, studentId);
+        setCorrectionData((prev) =>
+          prev
+            ? {
+                ...prev,
+                observation: feedbackResponse.teacherFeedback ?? prev.observation,
+                attachment: feedbackResponse.attachment ?? prev.attachment,
+              }
+            : prev
+        );
       } catch (err) {
         console.error('Failed to submit observation:', err);
       }
     },
-    [activityId, submitObservation]
+    [activityId, submitObservation, fetchStudentFeedback]
   );
 
   /**

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -333,9 +333,7 @@ export const ActivityDetails = ({
         };
         try {
           feedbackResponse = await fetchStudentFeedback(activityId, studentId);
-        } catch {
-          // fallback already set
-        }
+        } catch {}
         // Convert API response to StudentActivityCorrectionData format
         const correction = convertApiResponseToCorrectionData(
           apiResponse,
@@ -378,16 +376,13 @@ export const ActivityDetails = ({
         const file = files.length > 0 ? files[0] : null;
         await submitObservation(activityId, studentId, observation, file);
 
-        // Fetch updated feedback from server after successful PATCH
         let feedbackResponse: { teacherFeedback: string | null; attachment: string | null } = {
           teacherFeedback: null,
           attachment: null,
         };
         try {
           feedbackResponse = await fetchStudentFeedback(activityId, studentId);
-        } catch {
-          // fallback already set
-        }
+        } catch {}
         setCorrectionData((prev) =>
           prev
             ? {

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -326,13 +326,16 @@ export const ActivityDetails = ({
 
       setCorrectionError(null);
       try {
-        const [apiResponse, feedbackResponse] = await Promise.all([
-          fetchStudentCorrection(activityId, studentId),
-          fetchStudentFeedback(activityId, studentId).catch(() => ({
-            teacherFeedback: null,
-            attachment: null,
-          })),
-        ]);
+        const apiResponse = await fetchStudentCorrection(activityId, studentId);
+        let feedbackResponse: { teacherFeedback: string | null; attachment: string | null } = {
+          teacherFeedback: null,
+          attachment: null,
+        };
+        try {
+          feedbackResponse = await fetchStudentFeedback(activityId, studentId);
+        } catch {
+          // fallback already set
+        }
         // Convert API response to StudentActivityCorrectionData format
         const correction = convertApiResponseToCorrectionData(
           apiResponse,
@@ -376,10 +379,15 @@ export const ActivityDetails = ({
         await submitObservation(activityId, studentId, observation, file);
 
         // Fetch updated feedback from server after successful PATCH
-        const feedbackResponse = await fetchStudentFeedback(
-          activityId,
-          studentId
-        ).catch(() => ({ teacherFeedback: null, attachment: null }));
+        let feedbackResponse: { teacherFeedback: string | null; attachment: string | null } = {
+          teacherFeedback: null,
+          attachment: null,
+        };
+        try {
+          feedbackResponse = await fetchStudentFeedback(activityId, studentId);
+        } catch {
+          // fallback already set
+        }
         setCorrectionData((prev) =>
           prev
             ? {

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -327,13 +327,18 @@ export const ActivityDetails = ({
       setCorrectionError(null);
       try {
         const apiResponse = await fetchStudentCorrection(activityId, studentId);
-        let feedbackResponse: { teacherFeedback: string | null; attachment: string | null } = {
+        let feedbackResponse: {
+          teacherFeedback: string | null;
+          attachment: string | null;
+        } = {
           teacherFeedback: null,
           attachment: null,
         };
         try {
           feedbackResponse = await fetchStudentFeedback(activityId, studentId);
-        } catch {}
+        } catch {
+          // noop
+        }
         // Convert API response to StudentActivityCorrectionData format
         const correction = convertApiResponseToCorrectionData(
           apiResponse,
@@ -376,13 +381,18 @@ export const ActivityDetails = ({
         const file = files.length > 0 ? files[0] : null;
         await submitObservation(activityId, studentId, observation, file);
 
-        let feedbackResponse: { teacherFeedback: string | null; attachment: string | null } = {
+        let feedbackResponse: {
+          teacherFeedback: string | null;
+          attachment: string | null;
+        } = {
           teacherFeedback: null,
           attachment: null,
         };
         try {
           feedbackResponse = await fetchStudentFeedback(activityId, studentId);
-        } catch {}
+        } catch {
+          // noop
+        }
         setCorrectionData((prev) =>
           prev
             ? {

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -326,18 +326,18 @@ export const ActivityDetails = ({
 
       setCorrectionError(null);
       try {
-        const apiResponse = await fetchStudentCorrection(activityId, studentId);
-        const feedbackResponse = (await safeFetchStudentFeedback(
-          activityId,
-          studentId
-        )) ?? { teacherFeedback: null, attachment: null };
+        const [apiResponse, feedbackResponse] = await Promise.all([
+          fetchStudentCorrection(activityId, studentId),
+          safeFetchStudentFeedback(activityId, studentId),
+        ]);
+
         // Convert API response to StudentActivityCorrectionData format
         const correction = convertApiResponseToCorrectionData(
           apiResponse,
           studentId,
           student.studentName || 'Aluno',
-          feedbackResponse.teacherFeedback ?? undefined,
-          feedbackResponse.attachment ?? undefined
+          feedbackResponse?.teacherFeedback ?? undefined,
+          feedbackResponse?.attachment ?? undefined
         );
         setCorrectionData(correction);
         setIsModalOpen(true);
@@ -376,12 +376,11 @@ export const ActivityDetails = ({
       if (!activityId || !studentId) return;
       try {
         const file = files.length > 0 ? files[0] : null;
-        await submitObservation(activityId, studentId, observation, file);
+        const [_, feedbackResponse] = await Promise.all([
+          submitObservation(activityId, studentId, observation, file),
+          safeFetchStudentFeedback(activityId, studentId),
+        ]);
 
-        const feedbackResponse = await safeFetchStudentFeedback(
-          activityId,
-          studentId
-        );
         setCorrectionData((prev) =>
           prev
             ? {

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -384,10 +384,7 @@ export const ActivityDetails = ({
         let feedbackResponse: {
           teacherFeedback: string | null;
           attachment: string | null;
-        } = {
-          teacherFeedback: null,
-          attachment: null,
-        };
+        } | null = null;
         try {
           feedbackResponse = await fetchStudentFeedback(activityId, studentId);
         } catch {
@@ -398,8 +395,13 @@ export const ActivityDetails = ({
             ? {
                 ...prev,
                 observation:
-                  feedbackResponse.teacherFeedback ?? prev.observation,
-                attachment: feedbackResponse.attachment ?? prev.attachment,
+                  feedbackResponse === null
+                    ? prev.observation
+                    : feedbackResponse.teacherFeedback ?? undefined,
+                attachment:
+                  feedbackResponse === null
+                    ? prev.attachment
+                    : feedbackResponse.attachment ?? undefined,
               }
             : prev
         );

--- a/src/hooks/useActivityDetails.test.ts
+++ b/src/hooks/useActivityDetails.test.ts
@@ -305,13 +305,64 @@ describe('useActivityDetails', () => {
     });
   });
 
+  describe('fetchStudentFeedback', () => {
+    it('should fetch student feedback successfully', async () => {
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
+        data: {
+          data: {
+            teacherFeedback: 'Ótimo trabalho!',
+            attachment: 'https://s3.amazonaws.com/bucket/file.pdf',
+          },
+        },
+      });
+
+      const { result } = renderHook(() => useActivityDetails(mockApiClient));
+
+      const feedback = await result.current.fetchStudentFeedback(
+        'activity-123',
+        'student-1'
+      );
+
+      expect(mockApiClient.get).toHaveBeenCalledWith(
+        '/activities/activity-123/students/student-1/feedback'
+      );
+      expect(feedback).toEqual({
+        teacherFeedback: 'Ótimo trabalho!',
+        attachment: 'https://s3.amazonaws.com/bucket/file.pdf',
+      });
+    });
+
+    it('should propagate error when API fails', async () => {
+      const errorMessage = 'Feedback not found';
+      const mockError = new Error(errorMessage);
+      (mockApiClient.get as jest.Mock).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useActivityDetails(mockApiClient));
+
+      let caughtError: Error | null = null;
+      await act(async () => {
+        try {
+          await result.current.fetchStudentFeedback(
+            'activity-123',
+            'student-1'
+          );
+        } catch (error) {
+          caughtError = error as Error;
+        }
+      });
+
+      expect(caughtError).toBeInstanceOf(Error);
+      expect((caughtError as unknown as Error).message).toBe(errorMessage);
+    });
+  });
+
   describe('submitObservation', () => {
     it('should submit observation without file successfully', async () => {
       (mockApiClient.patch as jest.Mock).mockResolvedValueOnce({});
 
       const { result } = renderHook(() => useActivityDetails(mockApiClient));
 
-      await result.current.submitObservation(
+      const returnValue = await result.current.submitObservation(
         'activity-123',
         'student-1',
         'Great work!',
@@ -326,6 +377,7 @@ describe('useActivityDetails', () => {
         }
       );
       expect(mockApiClient.patch).toHaveBeenCalledTimes(1);
+      expect(returnValue).toBeNull();
     });
 
     it('should submit observation with file successfully', async () => {
@@ -345,7 +397,7 @@ describe('useActivityDetails', () => {
 
       const { result } = renderHook(() => useActivityDetails(mockApiClient));
 
-      await result.current.submitObservation(
+      const returnValue = await result.current.submitObservation(
         'activity-123',
         'student-1',
         'Great work!',
@@ -377,6 +429,7 @@ describe('useActivityDetails', () => {
           attachment: 'https://s3.amazonaws.com/bucket/file-key-123',
         }
       );
+      expect(returnValue).toBe('https://s3.amazonaws.com/bucket/file-key-123');
     });
 
     it('should handle presigned URL fetch failure', async () => {
@@ -593,6 +646,7 @@ describe('useActivityDetails', () => {
       const firstRender = {
         fetchActivityDetails: result.current.fetchActivityDetails,
         fetchStudentCorrection: result.current.fetchStudentCorrection,
+        fetchStudentFeedback: result.current.fetchStudentFeedback,
         submitObservation: result.current.submitObservation,
         submitQuestionCorrection: result.current.submitQuestionCorrection,
       };
@@ -604,6 +658,9 @@ describe('useActivityDetails', () => {
       );
       expect(result.current.fetchStudentCorrection).toBe(
         firstRender.fetchStudentCorrection
+      );
+      expect(result.current.fetchStudentFeedback).toBe(
+        firstRender.fetchStudentFeedback
       );
       expect(result.current.submitObservation).toBe(
         firstRender.submitObservation

--- a/src/hooks/useActivityDetails.test.ts
+++ b/src/hooks/useActivityDetails.test.ts
@@ -356,6 +356,55 @@ describe('useActivityDetails', () => {
     });
   });
 
+  describe('safeFetchStudentFeedback', () => {
+    it('should return feedback data on success', async () => {
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
+        data: {
+          data: {
+            teacherFeedback: 'Ótimo trabalho!',
+            attachment: 'https://s3.amazonaws.com/bucket/file.pdf',
+          },
+        },
+      });
+
+      const { result } = renderHook(() => useActivityDetails(mockApiClient));
+
+      const feedback = await result.current.safeFetchStudentFeedback(
+        'activity-123',
+        'student-1'
+      );
+
+      expect(feedback).toEqual({
+        teacherFeedback: 'Ótimo trabalho!',
+        attachment: 'https://s3.amazonaws.com/bucket/file.pdf',
+      });
+    });
+
+    it('should return null and log warn when API fails', async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const mockError = new Error('Feedback not found');
+      (mockApiClient.get as jest.Mock).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useActivityDetails(mockApiClient));
+
+      const feedback = await result.current.safeFetchStudentFeedback(
+        'activity-123',
+        'student-1'
+      );
+
+      expect(feedback).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Failed to fetch student feedback:',
+        mockError
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
   describe('submitObservation', () => {
     it('should submit observation without file successfully', async () => {
       (mockApiClient.patch as jest.Mock).mockResolvedValueOnce({});
@@ -647,6 +696,7 @@ describe('useActivityDetails', () => {
         fetchActivityDetails: result.current.fetchActivityDetails,
         fetchStudentCorrection: result.current.fetchStudentCorrection,
         fetchStudentFeedback: result.current.fetchStudentFeedback,
+        safeFetchStudentFeedback: result.current.safeFetchStudentFeedback,
         submitObservation: result.current.submitObservation,
         submitQuestionCorrection: result.current.submitQuestionCorrection,
       };
@@ -661,6 +711,9 @@ describe('useActivityDetails', () => {
       );
       expect(result.current.fetchStudentFeedback).toBe(
         firstRender.fetchStudentFeedback
+      );
+      expect(result.current.safeFetchStudentFeedback).toBe(
+        firstRender.safeFetchStudentFeedback
       );
       expect(result.current.submitObservation).toBe(
         firstRender.submitObservation

--- a/src/hooks/useActivityDetails.test.ts
+++ b/src/hooks/useActivityDetails.test.ts
@@ -555,6 +555,36 @@ describe('useActivityDetails', () => {
       ).rejects.toThrow('Falha ao fazer upload do arquivo');
     });
 
+    it('should normalize URL when url has no trailing slash', async () => {
+      const mockFile = new File(['test content'], 'test.pdf', {
+        type: 'application/pdf',
+      });
+
+      (mockApiClient.post as jest.Mock).mockResolvedValueOnce({
+        data: {
+          data: {
+            url: 'https://s3.amazonaws.com/bucket',
+            fields: { key: 'file-key-123', 'Content-Type': 'application/pdf' },
+          },
+        },
+      });
+      (mockApiClient.patch as jest.Mock).mockResolvedValueOnce({});
+
+      // eslint-disable-next-line no-undef
+      global.fetch = jest.fn().mockResolvedValueOnce({ ok: true } as Response);
+
+      const { result } = renderHook(() => useActivityDetails(mockApiClient));
+
+      const returnValue = await result.current.submitObservation(
+        'activity-123',
+        'student-1',
+        'Great work!',
+        mockFile
+      );
+
+      expect(returnValue).toBe('https://s3.amazonaws.com/bucket/file-key-123');
+    });
+
     it('should normalize URL construction correctly', async () => {
       const mockFile = new File(['test content'], 'test.pdf', {
         type: 'application/pdf',

--- a/src/hooks/useActivityDetails.ts
+++ b/src/hooks/useActivityDetails.ts
@@ -15,6 +15,11 @@ import type {
 /**
  * Hook return type for activity details
  */
+export interface StudentFeedbackResponse {
+  teacherFeedback: string | null;
+  attachment: string | null;
+}
+
 export interface UseActivityDetailsReturn {
   /**
    * Fetch activity details from API
@@ -37,18 +42,29 @@ export interface UseActivityDetailsReturn {
     studentId: string
   ) => Promise<QuestionsAnswersByStudentResponse>;
   /**
+   * Fetch teacher feedback for a student activity
+   * @param activityId - Activity ID
+   * @param studentId - Student ID
+   * @returns Teacher feedback and attachment
+   */
+  fetchStudentFeedback: (
+    activityId: string,
+    studentId: string
+  ) => Promise<StudentFeedbackResponse>;
+  /**
    * Submit observation for student activity
    * @param actId - Activity ID
    * @param studentId - Student ID
    * @param observation - Observation text
    * @param file - Attached file (optional)
+   * @returns The attachment URL if a file was uploaded, null otherwise
    */
   submitObservation: (
     actId: string,
     studentId: string,
     observation: string,
     file: File | null
-  ) => Promise<void>;
+  ) => Promise<string | null>;
   /**
    * Submit question correction for student activity
    * @param activityId - Activity ID
@@ -148,11 +164,31 @@ export const useActivityDetails = (
   );
 
   /**
+   * Fetch teacher feedback for a student activity
+   * @param activityId - Activity ID
+   * @param studentId - Student ID
+   * @returns Teacher feedback and attachment
+   */
+  const fetchStudentFeedback = useCallback(
+    async (
+      activityId: string,
+      studentId: string
+    ): Promise<StudentFeedbackResponse> => {
+      const response = await apiClient.get<{
+        data: { teacherFeedback: string | null; attachment: string | null };
+      }>(`/activities/${activityId}/students/${studentId}/feedback`);
+      return response.data.data;
+    },
+    [apiClient]
+  );
+
+  /**
    * Submit observation for student activity
    * @param actId - Activity ID
    * @param studentId - Student ID
    * @param observation - Observation text
    * @param file - Attached file (optional)
+   * @returns The attachment URL if a file was uploaded, null otherwise
    */
   const submitObservation = useCallback(
     async (
@@ -160,7 +196,7 @@ export const useActivityDetails = (
       studentId: string,
       observation: string,
       file: File | null
-    ): Promise<void> => {
+    ): Promise<string | null> => {
       let attachmentUrl: string | null = null;
 
       if (file) {
@@ -205,6 +241,8 @@ export const useActivityDetails = (
           attachment: attachmentUrl,
         }
       );
+
+      return attachmentUrl;
     },
     [apiClient]
   );
@@ -232,6 +270,7 @@ export const useActivityDetails = (
   return {
     fetchActivityDetails,
     fetchStudentCorrection,
+    fetchStudentFeedback,
     submitObservation,
     submitQuestionCorrection,
   };

--- a/src/hooks/useActivityDetails.ts
+++ b/src/hooks/useActivityDetails.ts
@@ -52,6 +52,16 @@ export interface UseActivityDetailsReturn {
     studentId: string
   ) => Promise<StudentFeedbackResponse>;
   /**
+   * Fetch teacher feedback for a student activity, returning null on error
+   * @param activityId - Activity ID
+   * @param studentId - Student ID
+   * @returns Teacher feedback and attachment, or null if fetch fails
+   */
+  safeFetchStudentFeedback: (
+    activityId: string,
+    studentId: string
+  ) => Promise<StudentFeedbackResponse | null>;
+  /**
    * Submit observation for student activity
    * @param actId - Activity ID
    * @param studentId - Student ID
@@ -182,6 +192,21 @@ export const useActivityDetails = (
     [apiClient]
   );
 
+  const safeFetchStudentFeedback = useCallback(
+    async (
+      activityId: string,
+      studentId: string
+    ): Promise<StudentFeedbackResponse | null> => {
+      try {
+        return await fetchStudentFeedback(activityId, studentId);
+      } catch (err) {
+        console.warn('Failed to fetch student feedback:', err);
+        return null;
+      }
+    },
+    [fetchStudentFeedback]
+  );
+
   /**
    * Submit observation for student activity
    * @param actId - Activity ID
@@ -271,6 +296,7 @@ export const useActivityDetails = (
     fetchActivityDetails,
     fetchStudentCorrection,
     fetchStudentFeedback,
+    safeFetchStudentFeedback,
     submitObservation,
     submitQuestionCorrection,
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity correction flow now fetches teacher feedback and attachments and refreshes feedback after submitting an observation; observation submit can return an attachment URL.

* **Bug Fixes**
  * Correction modal remains usable when feedback fetch fails; failures are logged and do not block the modal.

* **Tests**
  * Added tests for feedback fetching, safe-error handling, observation submission (including attachment URL behavior), modal flows, and memoization stability.

* **Chores**
  * Patch version bumped (1.3.63 → 1.3.64)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->