### PR TITLE
fix(AE-2485): correct fallback navigation URLs in useNotifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.66",
+  "version": "1.3.67",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -94,7 +94,7 @@ describe('useNotifications', () => {
         result.current.handleNavigate('ACTIVITY', '123');
       });
 
-      expect(window.location.href).toBe('/atividades/123');
+      expect(window.location.href).toBe('/conteudo/atividades/123');
     });
 
     it('should navigate to recommendedClass page when entityType is RECOMMENDEDCLASS', () => {
@@ -104,7 +104,7 @@ describe('useNotifications', () => {
         result.current.handleNavigate('recommendedClass', '456');
       });
 
-      expect(window.location.href).toBe('/painel/trilhas/456');
+      expect(window.location.href).toBe('/plano/consultar');
     });
 
     it('should handle lowercase entity types', () => {
@@ -114,7 +114,7 @@ describe('useNotifications', () => {
         result.current.handleNavigate('activity', '789');
       });
 
-      expect(window.location.href).toBe('/atividades/789');
+      expect(window.location.href).toBe('/conteudo/atividades/789');
     });
 
     it('should not navigate when entityType or entityId is missing', () => {
@@ -153,7 +153,7 @@ describe('useNotifications', () => {
         result.current.handleNavigate('ACTIVITY', '123', mockCallback);
       });
 
-      expect(window.location.href).toBe('/atividades/123');
+      expect(window.location.href).toBe('/conteudo/atividades/123');
       expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 
@@ -227,7 +227,7 @@ describe('useNotifications', () => {
       });
 
       expect(markAsReadSpy).toHaveBeenCalledWith('notif1');
-      expect(window.location.href).toBe('/atividades/123');
+      expect(window.location.href).toBe('/conteudo/atividades/123');
     });
 
     it('should only mark as read when entityType or entityId is missing', async () => {
@@ -258,7 +258,7 @@ describe('useNotifications', () => {
       });
 
       expect(markAsReadSpy).toHaveBeenCalledWith('notif1');
-      expect(window.location.href).toBe('/atividades/123');
+      expect(window.location.href).toBe('/conteudo/atividades/123');
       expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -157,7 +157,7 @@ describe('useNotifications', () => {
       expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 
-    it('should not execute callback when navigation fails', () => {
+    it('should not navigate to activity when entityId is missing but still execute callback', () => {
       const { result } = renderHook(() => useNotifications());
       const mockCallback = jest.fn();
 
@@ -165,7 +165,10 @@ describe('useNotifications', () => {
         result.current.handleNavigate('ACTIVITY', undefined, mockCallback);
       });
 
-      expect(mockCallback).not.toHaveBeenCalled();
+      expect(window.location.href).not.toBe(
+        expect.stringContaining('/conteudo/atividades/')
+      );
+      expect(mockCallback).toHaveBeenCalledTimes(1);
     });
 
     it('should execute callback for unknown entity types if entityType and entityId are provided', () => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -48,10 +48,12 @@ export const createUseNotifications = (apiClient: NotificationApiClient) => {
         entityId?: string,
         onAfterNavigate?: () => void
       ) => {
-        if (entityType && entityId) {
+        if (entityType) {
           switch (entityType.toUpperCase()) {
             case NotificationEntityType.ACTIVITY:
-              window.location.href = `/conteudo/atividades/${entityId}`;
+              if (entityId) {
+                window.location.href = `/conteudo/atividades/${entityId}`;
+              }
               break;
             case NotificationEntityType.RECOMMENDEDCLASS:
               // Navigate to list since front-web detail page requires navigation state

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -36,7 +36,7 @@ export const createUseNotifications = (apiClient: NotificationApiClient) => {
 
     /**
      * Handle navigation based on notification entity type and ID
-     * Uses window.location.href for cross-framework compatibility
+     * Uses globalThis.location.href for cross-framework compatibility
      *
      * @param entityType - Type of entity (ACTIVITY, RECOMMENDEDCLASS)
      * @param entityId - ID of the entity
@@ -52,12 +52,12 @@ export const createUseNotifications = (apiClient: NotificationApiClient) => {
           switch (entityType.toUpperCase()) {
             case NotificationEntityType.ACTIVITY:
               if (entityId) {
-                window.location.href = `/conteudo/atividades/${entityId}`;
+                globalThis.location.href = `/conteudo/atividades/${entityId}`;
               }
               break;
             case NotificationEntityType.RECOMMENDEDCLASS:
               // Navigate to list since front-web detail page requires navigation state
-              window.location.href = `/plano/consultar`;
+              globalThis.location.href = `/plano/consultar`;
               break;
             default:
               break;

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -51,11 +51,11 @@ export const createUseNotifications = (apiClient: NotificationApiClient) => {
         if (entityType && entityId) {
           switch (entityType.toUpperCase()) {
             case NotificationEntityType.ACTIVITY:
-              window.location.href = `/atividades/${entityId}`;
+              window.location.href = `/conteudo/atividades/${entityId}`;
               break;
             case NotificationEntityType.RECOMMENDEDCLASS:
-            case 'RECOMMENDEDCLASS':
-              window.location.href = `/painel/trilhas/${entityId}`;
+              // Navigate to list since front-web detail page requires navigation state
+              window.location.href = `/plano/consultar`;
               break;
             default:
               break;
@@ -81,7 +81,6 @@ export const createUseNotifications = (apiClient: NotificationApiClient) => {
           case NotificationEntityType.ACTIVITY:
             return 'Ver atividade';
           case NotificationEntityType.RECOMMENDEDCLASS:
-          case 'RECOMMENDEDCLASS':
             return 'Ver meta';
           default:
             return undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now open the correct pages: activity links go to the content path and recommended-class notifications open the plan consultation page.
  * Improved handling for notifications without target IDs to prevent unwanted redirects while preserving callback behavior.
* **Chores**
  * Package version bumped to 1.3.67.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->