### PR TITLE
fix: hide ProfileMenuInfo when empty and update pagination range format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.67",
+  "version": "1.3.68",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   waitFor,
   renderHook,
+  within,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DropdownMenu, {
@@ -908,9 +909,8 @@ describe('ProfileMenu component', () => {
       );
 
       const info = screen.getByTestId('profile-info');
-      const separator = info.querySelector('p.text-xs.align-middle');
+      const separator = within(info).getByText('●');
       expect(separator).toBeInTheDocument();
-      expect(separator).toHaveTextContent('●');
     });
 
     it('renders ProfileMenuInfo with correct data-component attribute', () => {

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -973,6 +973,81 @@ describe('ProfileMenu component', () => {
       const emptySpan = info.querySelector('span.w-16.h-16');
       expect(emptySpan).toBeInTheDocument();
     });
+
+    it('renders nothing when all props are empty strings', () => {
+      const { container } = render(
+        <DropdownMenu open>
+          <ProfileMenuTrigger />
+          <DropdownMenuContent>
+            <ProfileMenuInfo
+              data-testid="profile-info"
+              schoolName=""
+              classYearName=""
+              schoolYearName=""
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      expect(container.querySelector('[data-component="ProfileMenuInfo"]')).not.toBeInTheDocument();
+    });
+
+    it('hides separator bullet when only classYearName is provided', () => {
+      render(
+        <DropdownMenu open>
+          <ProfileMenuTrigger />
+          <DropdownMenuContent>
+            <ProfileMenuInfo
+              data-testid="profile-info"
+              schoolName=""
+              classYearName="1º Ano A"
+              schoolYearName=""
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      expect(screen.getByText('1º Ano A')).toBeInTheDocument();
+      expect(screen.queryByText('●')).not.toBeInTheDocument();
+    });
+
+    it('hides separator bullet when only schoolYearName is provided', () => {
+      render(
+        <DropdownMenu open>
+          <ProfileMenuTrigger />
+          <DropdownMenuContent>
+            <ProfileMenuInfo
+              data-testid="profile-info"
+              schoolName=""
+              classYearName=""
+              schoolYearName="2024"
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      expect(screen.getByText('2024')).toBeInTheDocument();
+      expect(screen.queryByText('●')).not.toBeInTheDocument();
+    });
+
+    it('renders only schoolName when classYearName and schoolYearName are empty', () => {
+      render(
+        <DropdownMenu open>
+          <ProfileMenuTrigger />
+          <DropdownMenuContent>
+            <ProfileMenuInfo
+              data-testid="profile-info"
+              schoolName="Escola Municipal"
+              classYearName=""
+              schoolYearName=""
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      expect(screen.getByText('Escola Municipal')).toBeInTheDocument();
+      expect(screen.queryByText('●')).not.toBeInTheDocument();
+    });
   });
 
   describe('ProfileMenuSection behavior', () => {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -671,7 +671,7 @@ const ProfileMenuInfo = forwardRef<
                 </Text>
               )}
               {classYearName && schoolYearName && (
-                <p className="text-text-600 text-xs align-middle">●</p>
+                <Text size="md" color="text-text-600">●</Text>
               )}
               {schoolYearName && (
                 <Text size="md" color="text-text-600">

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -644,6 +644,10 @@ const ProfileMenuInfo = forwardRef<
     },
     ref
   ) => {
+    if (!schoolName && !classYearName && !schoolYearName) {
+      return null;
+    }
+
     return (
       <div
         ref={ref}
@@ -653,19 +657,29 @@ const ProfileMenuInfo = forwardRef<
       >
         <span className="w-16 h-16" />
         <div className="flex flex-col ">
-          <Text size="md" color="text-text-600">
-            {schoolName}
-          </Text>
+          {schoolName && (
+            <Text size="md" color="text-text-600">
+              {schoolName}
+            </Text>
+          )}
 
-          <span className="flex flex-row items-center gap-2">
-            <Text size="md" color="text-text-600">
-              {classYearName}
-            </Text>
-            <p className="text-text-600 text-xs align-middle">●</p>
-            <Text size="md" color="text-text-600">
-              {schoolYearName}
-            </Text>
-          </span>
+          {(classYearName || schoolYearName) && (
+            <span className="flex flex-row items-center gap-2">
+              {classYearName && (
+                <Text size="md" color="text-text-600">
+                  {classYearName}
+                </Text>
+              )}
+              {classYearName && schoolYearName && (
+                <p className="text-text-600 text-xs align-middle">●</p>
+              )}
+              {schoolYearName && (
+                <Text size="md" color="text-text-600">
+                  {schoolYearName}
+                </Text>
+              )}
+            </span>
+          )}
         </div>
       </div>
     );

--- a/src/components/Table/TablePagination.test.tsx
+++ b/src/components/Table/TablePagination.test.tsx
@@ -81,6 +81,32 @@ describe('TablePagination', () => {
 
       expect(screen.getByText(/alunos/)).toBeInTheDocument();
     });
+
+    it('should display 0 - 0 when totalItems is 0', () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          totalItems={0}
+          totalPages={0}
+          currentPage={1}
+        />
+      );
+
+      expect(screen.getByText(/0 - 0 de 0 itens/)).toBeInTheDocument();
+    });
+
+    it('should display correct range for partial last page', () => {
+      render(
+        <TablePagination
+          {...defaultProps}
+          totalItems={95}
+          totalPages={10}
+          currentPage={10}
+        />
+      );
+
+      expect(screen.getByText(/91 - 95 de 95 itens/)).toBeInTheDocument();
+    });
   });
 
   describe('Page info text', () => {

--- a/src/components/Table/TablePagination.test.tsx
+++ b/src/components/Table/TablePagination.test.tsx
@@ -19,7 +19,7 @@ describe('TablePagination', () => {
     it('should render with required props', () => {
       render(<TablePagination {...defaultProps} />);
 
-      expect(screen.getByText(/41 de 100 itens/)).toBeInTheDocument();
+      expect(screen.getByText(/41 - 50 de 100 itens/)).toBeInTheDocument();
       expect(screen.getByText(/Página 5 de 10/)).toBeInTheDocument();
       expect(screen.getByLabelText('Página anterior')).toBeInTheDocument();
       expect(screen.getByLabelText('Próxima página')).toBeInTheDocument();
@@ -37,7 +37,7 @@ describe('TablePagination', () => {
         />
       );
 
-      expect(screen.getByText(/41 de 100 escolas/)).toBeInTheDocument();
+      expect(screen.getByText(/41 - 50 de 100 escolas/)).toBeInTheDocument();
       expect(screen.getByLabelText('Items por página')).toBeInTheDocument();
     });
 
@@ -55,19 +55,19 @@ describe('TablePagination', () => {
     it('should display correct start item for first page', () => {
       render(<TablePagination {...defaultProps} currentPage={1} />);
 
-      expect(screen.getByText(/1 de 100 itens/)).toBeInTheDocument();
+      expect(screen.getByText(/1 - 10 de 100 itens/)).toBeInTheDocument();
     });
 
     it('should display correct start item for middle page', () => {
       render(<TablePagination {...defaultProps} currentPage={5} />);
 
-      expect(screen.getByText(/41 de 100 itens/)).toBeInTheDocument();
+      expect(screen.getByText(/41 - 50 de 100 itens/)).toBeInTheDocument();
     });
 
     it('should display correct start item for last page', () => {
       render(<TablePagination {...defaultProps} currentPage={10} />);
 
-      expect(screen.getByText(/91 de 100 itens/)).toBeInTheDocument();
+      expect(screen.getByText(/91 - 100 de 100 itens/)).toBeInTheDocument();
     });
 
     it('should use default itemLabel when not provided', () => {
@@ -319,7 +319,7 @@ describe('TablePagination', () => {
         />
       );
 
-      expect(screen.getByText(/991 de 10000 itens/)).toBeInTheDocument();
+      expect(screen.getByText(/991 - 1000 de 10000 itens/)).toBeInTheDocument();
       expect(screen.getByText('Página 100 de 1000')).toBeInTheDocument();
     });
 

--- a/src/components/Table/TablePagination.tsx
+++ b/src/components/Table/TablePagination.tsx
@@ -71,6 +71,7 @@ const TablePagination = ({
   ...props
 }: TablePaginationProps) => {
   const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
 
   const handlePrevious = () => {
     if (currentPage > 1) {
@@ -104,7 +105,7 @@ const TablePagination = ({
     >
       {/* Items count - isolado à esquerda no desktop */}
       <span className="font-normal text-xs leading-[14px] text-text-800">
-        {startItem} de {totalItems} {itemLabel}
+        {startItem} - {endItem} de {totalItems} {itemLabel}
       </span>
 
       {/* Grupo direita: selector + page info + botões */}

--- a/src/components/Table/TablePagination.tsx
+++ b/src/components/Table/TablePagination.tsx
@@ -70,8 +70,8 @@ const TablePagination = ({
   className,
   ...props
 }: TablePaginationProps) => {
-  const startItem = (currentPage - 1) * itemsPerPage + 1;
-  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
+  const startItem = totalItems === 0 ? 0 : (currentPage - 1) * itemsPerPage + 1;
+  const endItem = totalItems === 0 ? 0 : Math.min(currentPage * itemsPerPage, totalItems);
 
   const handlePrevious = () => {
     if (currentPage > 1) {


### PR DESCRIPTION
- ProfileMenuInfo returns null when all props are empty strings, removing floating dot and blank space in profile menu
- TablePagination now shows range format "X - Y de Z items" instead of "X de Z items"
- Bump version to 1.3.68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination display to show item range (e.g., "41-50 de 100 itens") instead of single count.
  * Profile menu info no longer displays empty containers when information is unavailable.

* **Chores**
  * Bumped version to 1.3.71.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->