### PR TITLE
AE-2482 - feat: validate image format and size in alert message step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.72",
+  "version": "1.3.73",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/AlertManager/AlertSteps/MessageStep.tsx
+++ b/src/components/AlertManager/AlertSteps/MessageStep.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import Input from '../../Input/Input';
 import TextArea from '../../TextArea/TextArea';
 import ImageUpload from '../../ImageUpload/ImageUpload';
+import Text from '../../Text/Text';
 import { useAlertFormStore } from '../useAlertForm';
 import { LabelsConfig } from '../types';
 
@@ -10,10 +12,15 @@ interface MessageStepProps {
   allowImageAttachment?: boolean;
 }
 
+const ACCEPTED_IMAGE_EXTENSIONS = '.jpg,.jpeg,.png,.gif,.webp,.svg';
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGE_SIZE_LABEL = '5MB';
+
 export const MessageStep = ({
   labels,
   allowImageAttachment = true,
 }: MessageStepProps) => {
+  const [imageError, setImageError] = useState<string | null>(null);
   const { title, message, image, setTitle, setMessage, setImage } =
     useAlertFormStore(
       useShallow((state) => ({
@@ -27,11 +34,25 @@ export const MessageStep = ({
     );
 
   const handleFileSelect = (file: File) => {
+    setImageError(null);
     setImage(file);
   };
 
   const handleRemoveFile = () => {
+    setImageError(null);
     setImage(null);
+  };
+
+  const handleTypeError = () => {
+    setImageError(
+      'Formato de imagem não suportado. Use jpg, jpeg, png, gif, webp ou svg.'
+    );
+  };
+
+  const handleSizeError = () => {
+    setImageError(
+      `Imagem muito grande. O tamanho máximo permitido é ${MAX_IMAGE_SIZE_LABEL}.`
+    );
   };
 
   const isImageFile = image instanceof File;
@@ -55,11 +76,22 @@ export const MessageStep = ({
       />
 
       {allowImageAttachment && (
-        <ImageUpload
-          selectedFile={isImageFile ? image : null}
-          onFileSelect={handleFileSelect}
-          onRemoveFile={handleRemoveFile}
-        />
+        <div className="flex flex-col gap-2">
+          <ImageUpload
+            selectedFile={isImageFile ? image : null}
+            onFileSelect={handleFileSelect}
+            onRemoveFile={handleRemoveFile}
+            accept={ACCEPTED_IMAGE_EXTENSIONS}
+            maxSize={MAX_IMAGE_SIZE_BYTES}
+            onTypeError={handleTypeError}
+            onSizeError={handleSizeError}
+          />
+          {imageError && (
+            <Text size="sm" className="text-error-600" role="alert">
+              {imageError}
+            </Text>
+          )}
+        </div>
       )}
     </section>
   );

--- a/src/components/AlertManager/AlertSteps/MessageStep.tsx
+++ b/src/components/AlertManager/AlertSteps/MessageStep.tsx
@@ -12,7 +12,8 @@ interface MessageStepProps {
   allowImageAttachment?: boolean;
 }
 
-const ACCEPTED_IMAGE_EXTENSIONS = '.jpg,.jpeg,.png,.gif,.webp,.svg';
+const ACCEPTED_IMAGE_EXTENSIONS =
+  'image/jpeg,image/png,image/gif,image/webp,image/svg+xml,.jpg,.jpeg,.png,.gif,.webp,.svg';
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 const MAX_IMAGE_SIZE_LABEL = '5MB';
 

--- a/src/components/AlertManager/AlertSteps/tests/MessageStep.test.tsx
+++ b/src/components/AlertManager/AlertSteps/tests/MessageStep.test.tsx
@@ -28,6 +28,10 @@ interface MockImageUploadProps {
   selectedFile?: File | null;
   onFileSelect?: (file: File) => void;
   onRemoveFile?: () => void;
+  onTypeError?: (file: File) => void;
+  onSizeError?: (file: File, maxSize: number) => void;
+  accept?: string;
+  maxSize?: number;
 }
 
 // Mock components
@@ -76,8 +80,16 @@ jest.mock('../../../ImageUpload/ImageUpload', () => ({
     selectedFile,
     onFileSelect,
     onRemoveFile,
+    onTypeError,
+    onSizeError,
+    accept,
+    maxSize,
   }: MockImageUploadProps) => (
-    <div data-testid="image-upload">
+    <div
+      data-testid="image-upload"
+      data-accept={accept}
+      data-max-size={maxSize}
+    >
       <button
         onClick={() => {
           const mockFile = new File(['content'], 'test.png', {
@@ -88,6 +100,28 @@ jest.mock('../../../ImageUpload/ImageUpload', () => ({
         data-testid="select-file-button"
       >
         Select File
+      </button>
+      <button
+        onClick={() => {
+          const invalidFile = new File(['content'], 'test.jfif', {
+            type: 'image/jpeg',
+          });
+          onTypeError?.(invalidFile);
+        }}
+        data-testid="trigger-type-error-button"
+      >
+        Trigger Type Error
+      </button>
+      <button
+        onClick={() => {
+          const oversizedFile = new File(['content'], 'big.png', {
+            type: 'image/png',
+          });
+          onSizeError?.(oversizedFile, maxSize ?? 0);
+        }}
+        data-testid="trigger-size-error-button"
+      >
+        Trigger Size Error
       </button>
       {selectedFile && (
         <div>
@@ -265,6 +299,89 @@ describe('MessageStep', () => {
       expect(screen.getByTestId('selected-file-name')).toHaveTextContent(
         'test.png'
       );
+    });
+
+    it('should restrict accepted image types to supported formats', () => {
+      render(<MessageStep />);
+
+      const upload = screen.getByTestId('image-upload');
+      expect(upload).toHaveAttribute(
+        'data-accept',
+        '.jpg,.jpeg,.png,.gif,.webp,.svg'
+      );
+    });
+
+    it('should configure max image size to 5MB', () => {
+      render(<MessageStep />);
+
+      const upload = screen.getByTestId('image-upload');
+      expect(upload).toHaveAttribute(
+        'data-max-size',
+        String(5 * 1024 * 1024)
+      );
+    });
+
+    it('should display error message when unsupported file type is selected', () => {
+      render(<MessageStep />);
+
+      fireEvent.click(screen.getByTestId('trigger-type-error-button'));
+
+      expect(
+        screen.getByText(
+          'Formato de imagem não suportado. Use jpg, jpeg, png, gif, webp ou svg.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message when file is too large', () => {
+      render(<MessageStep />);
+
+      fireEvent.click(screen.getByTestId('trigger-size-error-button'));
+
+      expect(
+        screen.getByText(
+          'Imagem muito grande. O tamanho máximo permitido é 5MB.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('should clear error message when a valid file is selected after error', () => {
+      render(<MessageStep />);
+
+      fireEvent.click(screen.getByTestId('trigger-type-error-button'));
+      expect(
+        screen.getByText(
+          'Formato de imagem não suportado. Use jpg, jpeg, png, gif, webp ou svg.'
+        )
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('select-file-button'));
+
+      expect(
+        screen.queryByText(
+          'Formato de imagem não suportado. Use jpg, jpeg, png, gif, webp ou svg.'
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it('should clear error message when file is removed', () => {
+      render(<MessageStep />);
+
+      fireEvent.click(screen.getByTestId('select-file-button'));
+      fireEvent.click(screen.getByTestId('trigger-type-error-button'));
+      expect(
+        screen.getByText(
+          'Formato de imagem não suportado. Use jpg, jpeg, png, gif, webp ou svg.'
+        )
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('remove-file-button'));
+
+      expect(
+        screen.queryByText(
+          'Formato de imagem não suportado. Use jpg, jpeg, png, gif, webp ou svg.'
+        )
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/AlertManager/AlertSteps/tests/MessageStep.test.tsx
+++ b/src/components/AlertManager/AlertSteps/tests/MessageStep.test.tsx
@@ -307,7 +307,7 @@ describe('MessageStep', () => {
       const upload = screen.getByTestId('image-upload');
       expect(upload).toHaveAttribute(
         'data-accept',
-        '.jpg,.jpeg,.png,.gif,.webp,.svg'
+        'image/jpeg,image/png,image/gif,image/webp,image/svg+xml,.jpg,.jpeg,.png,.gif,.webp,.svg'
       );
     });
 
@@ -315,10 +315,7 @@ describe('MessageStep', () => {
       render(<MessageStep />);
 
       const upload = screen.getByTestId('image-upload');
-      expect(upload).toHaveAttribute(
-        'data-max-size',
-        String(5 * 1024 * 1024)
-      );
+      expect(upload).toHaveAttribute('data-max-size', String(5 * 1024 * 1024));
     });
 
     it('should display error message when unsupported file type is selected', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image uploads now validate file types (.jpg, .jpeg, .png, .gif, .webp, .svg) and enforce a 5MB size limit with clear error messages that clear upon retry.

* **Tests**
  * Added comprehensive test coverage for image upload validation functionality.

* **Chores**
  * Version updated to 1.3.73.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->