### PR TITLE
AE-2482 - fix: use only extensions in image accept to block unsupported formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/AlertManager/AlertSteps/MessageStep.tsx
+++ b/src/components/AlertManager/AlertSteps/MessageStep.tsx
@@ -12,8 +12,7 @@ interface MessageStepProps {
   allowImageAttachment?: boolean;
 }
 
-const ACCEPTED_IMAGE_EXTENSIONS =
-  'image/jpeg,image/png,image/gif,image/webp,image/svg+xml,.jpg,.jpeg,.png,.gif,.webp,.svg';
+const ACCEPTED_IMAGE_EXTENSIONS = '.jpg,.jpeg,.png,.gif,.webp,.svg';
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 const MAX_IMAGE_SIZE_LABEL = '5MB';
 

--- a/src/components/AlertManager/AlertSteps/tests/MessageStep.test.tsx
+++ b/src/components/AlertManager/AlertSteps/tests/MessageStep.test.tsx
@@ -307,7 +307,7 @@ describe('MessageStep', () => {
       const upload = screen.getByTestId('image-upload');
       expect(upload).toHaveAttribute(
         'data-accept',
-        'image/jpeg,image/png,image/gif,image/webp,image/svg+xml,.jpg,.jpeg,.png,.gif,.webp,.svg'
+        '.jpg,.jpeg,.png,.gif,.webp,.svg'
       );
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image upload validation to use file extension-based filtering for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->