### PR TITLE
feat: add userId prop to scope video progress localStorage keys per user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.81",
+  "version": "1.3.82",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/LessonBank/LessonBank.tsx
+++ b/src/components/LessonBank/LessonBank.tsx
@@ -14,6 +14,7 @@ interface LessonBankProps {
   className?: string;
   isFromTrailRoute?: boolean;
   lessonId?: string;
+  userId?: string;
   getInitialTimestamp?: (lessonId: string) => number;
   onVideoTimeUpdate?: (lessonId: string, time: number) => void;
   onVideoComplete?: (lessonId: string) => void;
@@ -32,6 +33,7 @@ export const LessonBank = ({
   className,
   isFromTrailRoute = false,
   lessonId,
+  userId,
   getInitialTimestamp,
   onVideoTimeUpdate,
   onVideoComplete,
@@ -210,6 +212,7 @@ export const LessonBank = ({
         isOpen={isWatchModalOpen}
         onClose={handleCloseModal}
         selectedLesson={selectedLesson}
+        userId={userId}
         getVideoData={getVideoData}
         getInitialTimestampValue={getInitialTimestampValue}
         handleVideoTimeUpdate={handleVideoTimeUpdate}

--- a/src/components/LessonPreview/LessonPreview.tsx
+++ b/src/components/LessonPreview/LessonPreview.tsx
@@ -56,6 +56,8 @@ interface LessonPreviewProps {
    * Get initial timestamp for a lesson
    */
   getInitialTimestamp?: (lessonId: string) => number;
+  /** User ID used to scope video-progress localStorage keys per user */
+  userId?: string;
   /**
    * Callback when create new activity is clicked
    */
@@ -94,6 +96,7 @@ export const LessonPreview = ({
   onVideoComplete,
   onPodcastEnded,
   getInitialTimestamp,
+  userId,
   onCreateNewActivity,
   apiClient,
   onActivitySelected,
@@ -521,6 +524,7 @@ export const LessonPreview = ({
         isOpen={isWatchModalOpen}
         onClose={handleCloseModal}
         selectedLesson={selectedLesson}
+        userId={userId}
         getVideoData={getVideoData}
         getInitialTimestampValue={getInitialTimestampValue}
         handleVideoTimeUpdate={handleVideoTimeUpdate}

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -58,6 +58,8 @@ interface VideoPlayerProps {
   autoSave?: boolean;
   /** localStorage key for saving progress */
   storageKey?: string;
+  /** User ID used to scope localStorage keys — prevents progress leaking between users */
+  userId?: string;
   /** Download content URLs for lesson materials */
   downloadContent?: DownloadContent;
   /** Show download button in header */
@@ -327,6 +329,7 @@ const VideoPlayer = ({
   className,
   autoSave = true,
   storageKey = 'video-progress',
+  userId,
   downloadContent,
   showDownloadButton = false,
   onDownloadStart,
@@ -620,8 +623,9 @@ const VideoPlayer = ({
         : undefined;
     }
 
+    const scopedKey = userId ? `${storageKey}-${userId}` : storageKey;
     const saved = Number(
-      localStorage.getItem(`${storageKey}-${src}`) || Number.NaN
+      localStorage.getItem(`${scopedKey}-${src}`) || Number.NaN
     );
     const hasValidInitial = Number.isFinite(initialTime) && initialTime >= 0;
     const hasValidSaved = Number.isFinite(saved) && saved >= 0;
@@ -629,7 +633,7 @@ const VideoPlayer = ({
     if (hasValidInitial) return initialTime;
     if (hasValidSaved) return saved;
     return undefined;
-  }, [autoSave, storageKey, src, initialTime]);
+  }, [autoSave, storageKey, userId, src, initialTime]);
 
   /**
    * Load saved progress from localStorage
@@ -651,11 +655,12 @@ const VideoPlayer = ({
 
       const now = Date.now();
       if (now - lastSaveTimeRef.current > 5000) {
-        localStorage.setItem(`${storageKey}-${src}`, time.toString());
+        const scopedKey = userId ? `${storageKey}-${userId}` : storageKey;
+        localStorage.setItem(`${scopedKey}-${src}`, time.toString());
         lastSaveTimeRef.current = now;
       }
     },
-    [autoSave, storageKey, src]
+    [autoSave, storageKey, userId, src]
   );
 
   /**

--- a/src/components/shared/LessonWatchModal/LessonWatchModal.tsx
+++ b/src/components/shared/LessonWatchModal/LessonWatchModal.tsx
@@ -91,6 +91,7 @@ const BoardImagesSection = ({
 
 interface VideoSectionProps {
   lesson: Lesson;
+  userId?: string;
   getVideoData: (lesson: Lesson | null) => {
     src: string;
     poster?: string;
@@ -113,6 +114,7 @@ interface VideoSectionProps {
  */
 const VideoSection = ({
   lesson,
+  userId,
   getVideoData,
   getInitialTimestampValue,
   handleVideoTimeUpdate,
@@ -145,6 +147,7 @@ const VideoSection = ({
         className="w-full h-full object-cover rounded-b-xl"
         autoSave={true}
         storageKey={`lesson-${lesson.id}`}
+        userId={userId}
       />
       <div className="flex flex-col gap-4">
         <Alert
@@ -172,6 +175,7 @@ export interface LessonWatchModalProps {
   isOpen: boolean;
   onClose: () => void;
   selectedLesson: Lesson | null;
+  userId?: string;
   getVideoData: (lesson: Lesson | null) => {
     src: string;
     poster?: string;
@@ -204,6 +208,7 @@ export const LessonWatchModal = ({
   isOpen,
   onClose,
   selectedLesson,
+  userId,
   getVideoData,
   getInitialTimestampValue,
   handleVideoTimeUpdate,
@@ -236,6 +241,7 @@ export const LessonWatchModal = ({
         {selectedLesson ? (
           <VideoSection
             lesson={selectedLesson}
+            userId={userId}
             getVideoData={getVideoData}
             getInitialTimestampValue={getInitialTimestampValue}
             handleVideoTimeUpdate={handleVideoTimeUpdate}

--- a/src/components/shared/LessonWatchModal/LessonWatchModal.tsx
+++ b/src/components/shared/LessonWatchModal/LessonWatchModal.tsx
@@ -11,11 +11,50 @@ import {
 import type { Lesson } from '../../../types/lessons';
 import type { WhiteboardImage } from '../../Whiteboard/Whiteboard';
 
-interface PodcastSectionProps {
-  lesson: Lesson;
+export interface LessonWatchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedLesson: Lesson | null;
+  userId?: string;
+  getVideoData: (lesson: Lesson | null) => {
+    src: string;
+    poster?: string;
+    subtitles?: string;
+  };
+  getInitialTimestampValue: (lessonId: string) => number;
+  handleVideoTimeUpdate: (time: number) => void;
+  handleVideoCompleteCallback: () => void;
   getPodcastData: (lesson: Lesson | null) => { src: string; title: string };
   onPodcastEnded: () => void;
+  getBoardImages: (lesson: Lesson | null) => WhiteboardImage[];
+  getBoardImageRef: (
+    index: number,
+    total: number
+  ) => RefObject<HTMLDivElement | null> | null;
+  /**
+   * Custom footer content. If not provided, defaults to a Cancel button.
+   */
+  footer?: React.ReactNode;
+  /**
+   * Modal title. Defaults to selectedLesson?.title || 'Assistir Aula'
+   */
+  title?: string;
 }
+
+type PodcastSectionProps = Pick<
+  LessonWatchModalProps,
+  'getPodcastData' | 'onPodcastEnded'
+> & { lesson: Lesson };
+
+type BoardImagesSectionProps = Pick<
+  LessonWatchModalProps,
+  'getBoardImages' | 'getBoardImageRef'
+> & { lesson: Lesson };
+
+type VideoSectionProps = Omit<
+  LessonWatchModalProps,
+  'isOpen' | 'onClose' | 'selectedLesson' | 'footer' | 'title'
+> & { lesson: Lesson };
 
 /**
  * Renders podcast section if available
@@ -42,15 +81,6 @@ const PodcastSection = ({
     </div>
   );
 };
-
-interface BoardImagesSectionProps {
-  lesson: Lesson;
-  getBoardImages: (lesson: Lesson | null) => WhiteboardImage[];
-  getBoardImageRef: (
-    index: number,
-    total: number
-  ) => RefObject<HTMLDivElement | null> | null;
-}
 
 /**
  * Renders board images section if available
@@ -88,26 +118,6 @@ const BoardImagesSection = ({
     </div>
   );
 };
-
-interface VideoSectionProps {
-  lesson: Lesson;
-  userId?: string;
-  getVideoData: (lesson: Lesson | null) => {
-    src: string;
-    poster?: string;
-    subtitles?: string;
-  };
-  getInitialTimestampValue: (lessonId: string) => number;
-  handleVideoTimeUpdate: (time: number) => void;
-  handleVideoCompleteCallback: () => void;
-  getPodcastData: (lesson: Lesson | null) => { src: string; title: string };
-  onPodcastEnded: () => void;
-  getBoardImages: (lesson: Lesson | null) => WhiteboardImage[];
-  getBoardImageRef: (
-    index: number,
-    total: number
-  ) => RefObject<HTMLDivElement | null> | null;
-}
 
 /**
  * Renders video section with player, podcast, and board images
@@ -170,36 +180,6 @@ const VideoSection = ({
     </>
   );
 };
-
-export interface LessonWatchModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  selectedLesson: Lesson | null;
-  userId?: string;
-  getVideoData: (lesson: Lesson | null) => {
-    src: string;
-    poster?: string;
-    subtitles?: string;
-  };
-  getInitialTimestampValue: (lessonId: string) => number;
-  handleVideoTimeUpdate: (time: number) => void;
-  handleVideoCompleteCallback: () => void;
-  getPodcastData: (lesson: Lesson | null) => { src: string; title: string };
-  onPodcastEnded: () => void;
-  getBoardImages: (lesson: Lesson | null) => WhiteboardImage[];
-  getBoardImageRef: (
-    index: number,
-    total: number
-  ) => RefObject<HTMLDivElement | null> | null;
-  /**
-   * Custom footer content. If not provided, defaults to a Cancel button.
-   */
-  footer?: React.ReactNode;
-  /**
-   * Modal title. Defaults to selectedLesson?.title || 'Assistir Aula'
-   */
-  title?: string;
-}
 
 /**
  * Modal component for watching lessons with video, podcast, and board images

--- a/src/hooks/useRecommendedLessonDetails.ts
+++ b/src/hooks/useRecommendedLessonDetails.ts
@@ -261,7 +261,10 @@ export const handleLessonDetailsFetchError = (error: unknown): string => {
 export const createUseRecommendedLessonDetails = (
   apiClient: LessonDetailsApiClient
 ) => {
-  return (lessonId: string | undefined): UseRecommendedLessonDetailsReturn => {
+  return (
+    lessonId: string | undefined,
+    userId?: string
+  ): UseRecommendedLessonDetailsReturn => {
     const [state, setState] = useState<UseRecommendedLessonDetailsState>({
       data: null,
       loading: true,
@@ -339,7 +342,7 @@ export const createUseRecommendedLessonDetails = (
           error: errorMessage,
         });
       }
-    }, [lessonId]);
+    }, [lessonId, userId]);
 
     // Fetch on mount and when lessonId changes
     useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-user support for video progress tracking. Each user's playback position and viewing history are now independently saved and restored, allowing multiple users to maintain separate progress records within the same application instance.

* **Chores**
  * Version bump to 1.3.82.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->