### PR TITLE
AE-2580: add title modal to save model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.93",
+  "version": "1.3.94",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ActivityCreate/ActivityCreate.test.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.test.tsx
@@ -148,7 +148,6 @@ jest.mock('../ActivityFilters/ActivityFilters', () => ({
     onClearFilters?: () => void;
     apiClient: BaseApiClient;
     institutionId: string;
-    initialFilters?: ActivityFiltersData | null;
     triggerLabel?: string;
   }) => (
     <div data-testid="activity-filters-popover">
@@ -229,13 +228,14 @@ jest.mock('../Menu/Menu', () => {
       variant?: string;
       onClick?: () => void;
     }) => (
-      <li
+      <button
+        type="button"
         data-testid={`menu-item-${value}`}
         data-variant={variant}
         onClick={onClick}
       >
         {children}
-      </li>
+      </button>
     ),
   };
 });
@@ -344,11 +344,10 @@ jest.mock('./components/ActivityCreateHeader', () => {
 
       const activityTypeLabel = getActivityTypeLabel(activityType);
       const formattedTime = lastSavedAt ? formatTime(lastSavedAt) : '';
+      const idleStatusText = isSaving ? 'Salvando...' : 'Nenhum rascunho salvo';
       const saveStatusText = lastSavedAt
         ? `${activityTypeLabel} salvo às ${formattedTime}`
-        : isSaving
-          ? 'Salvando...'
-          : 'Nenhum rascunho salvo';
+        : idleStatusText;
 
       return React.createElement(
         'div',
@@ -585,6 +584,36 @@ jest.mock('../SendActivityModal/SendActivityModal', () => ({
     ) : null,
 }));
 
+jest.mock('../SaveActivityModelModal/SaveActivityModelModal', () => ({
+  SaveActivityModelModal: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    isLoading,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (title: string) => void;
+    isLoading?: boolean;
+  }) =>
+    isOpen ? (
+      <div data-testid="save-model-modal">
+        <button data-testid="save-model-modal-close" onClick={onClose}>
+          Cancel
+        </button>
+        <button
+          data-testid="save-model-modal-confirm"
+          onClick={() => onConfirm('Modelo Customizado')}
+        >
+          Confirm
+        </button>
+        <div data-testid="save-model-modal-loading">
+          {isLoading ? 'Loading' : 'Not Loading'}
+        </div>
+      </div>
+    ) : null,
+}));
+
 // Mock UI components - this needs to be after the hook mocks
 
 // Mock utility function
@@ -782,9 +811,9 @@ jest.mock('../..', () => {
 
 describe('CreateActivity', () => {
   // Mock window.innerWidth for responsive tests
-  const originalInnerWidth = window.innerWidth;
+  const originalInnerWidth = globalThis.innerWidth;
   beforeAll(() => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       writable: true,
       configurable: true,
       value: 1400, // Default to desktop size
@@ -792,7 +821,7 @@ describe('CreateActivity', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       writable: true,
       configurable: true,
       value: originalInnerWidth,
@@ -1582,14 +1611,14 @@ describe('CreateActivity', () => {
       });
     });
 
-    it('should save immediately when activityType changes to MODELO', async () => {
+    it('should open the save model modal and save with the user provided title', async () => {
       const mockResponse = {
         data: {
           data: {
             draft: {
               id: 'draft1',
               type: ActivityType.MODELO,
-              title: 'Modelo - Matemática',
+              title: 'Modelo Customizado',
               creatorUserInstitutionId: 'user1',
               subjectId: 'subject1',
               filters: {},
@@ -1619,8 +1648,15 @@ describe('CreateActivity', () => {
 
       jest.clearAllMocks();
 
-      // Click save model button
+      // Click save model button — opens the modal but does not save yet
       fireEvent.click(screen.getByText('Salvar modelo'));
+
+      expect(screen.getByTestId('save-model-modal')).toBeInTheDocument();
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+
+      // Confirm the modal — sends the user-provided title to the backend
+      fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -1633,11 +1669,58 @@ describe('CreateActivity', () => {
           expect.stringContaining('/activity-drafts/'),
           expect.objectContaining({
             type: ActivityType.MODELO,
+            title: 'Modelo Customizado',
           })
         );
         // POST should not be called after first save
         expect(mockApiClient.post).not.toHaveBeenCalled();
       });
+    });
+
+    it('should close the save model modal without saving when canceled', async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            draft: {
+              id: 'draft1',
+              type: ActivityType.RASCUNHO,
+              title: 'Rascunho - Matemática',
+              creatorUserInstitutionId: 'user1',
+              subjectId: 'subject1',
+              filters: {},
+              createdAt: '2025-01-01',
+              updatedAt: '2025-01-01',
+            },
+            questionsLinked: 1,
+          },
+        },
+      };
+
+      mockApiClient.post = jest.fn().mockResolvedValue(mockResponse);
+      mockApiClient.patch = jest.fn().mockResolvedValue(mockResponse);
+
+      render(<CreateActivity {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId('add-question'));
+
+      act(() => {
+        jest.advanceTimersByTime(600);
+      });
+
+      await waitFor(() => {
+        expect(mockApiClient.post).toHaveBeenCalled();
+      });
+
+      jest.clearAllMocks();
+
+      fireEvent.click(screen.getByText('Salvar modelo'));
+      expect(screen.getByTestId('save-model-modal')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('save-model-modal-close'));
+
+      expect(screen.queryByTestId('save-model-modal')).not.toBeInTheDocument();
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+      expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
     it('should show saving message when isSaving is true', () => {
@@ -2747,8 +2830,9 @@ describe('CreateActivity', () => {
 
       jest.clearAllMocks();
 
-      // Click save model button - this will trigger PATCH with MODELO type
+      // Click save model button — opens the modal then confirms with custom title
       fireEvent.click(screen.getByText('Salvar modelo'));
+      fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -2859,8 +2943,9 @@ describe('CreateActivity', () => {
 
       jest.clearAllMocks();
 
-      // Click save model button - this will trigger PATCH with MODELO type
+      // Click save model button — opens the modal then confirms with custom title
       fireEvent.click(screen.getByText('Salvar modelo'));
+      fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
 
       act(() => {
         jest.advanceTimersByTime(100);
@@ -2920,6 +3005,7 @@ describe('CreateActivity', () => {
       });
 
       fireEvent.click(screen.getByText('Salvar modelo'));
+      fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
 
       await waitFor(() => {
         expect(mockApiClient.post).toHaveBeenCalled();

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -173,6 +173,7 @@ const CreateActivity = ({
   const [isSaving, setIsSaving] = useState(false);
   const [isSendModalOpen, setIsSendModalOpen] = useState(false);
   const [isSaveModelModalOpen, setIsSaveModelModalOpen] = useState(false);
+  const [isSavingModel, setIsSavingModel] = useState(false);
   const [categories, setCategories] = useState<CategoryConfig[]>([]);
   const [isSendingActivity, setIsSendingActivity] = useState(false);
 
@@ -766,8 +767,13 @@ const CreateActivity = ({
    */
   const handleConfirmSaveModel = useCallback(
     async (title: string) => {
-      setIsSaveModelModalOpen(false);
-      await saveDraft(ActivityType.MODELO, title);
+      setIsSavingModel(true);
+      try {
+        setIsSaveModelModalOpen(false);
+        await saveDraft(ActivityType.MODELO, title);
+      } finally {
+        setIsSavingModel(false);
+      }
     },
     [saveDraft]
   );
@@ -1420,7 +1426,7 @@ const CreateActivity = ({
         isOpen={isSaveModelModalOpen}
         onClose={() => setIsSaveModelModalOpen(false)}
         onConfirm={handleConfirmSaveModel}
-        isLoading={isSaving}
+        isLoading={isSavingModel}
       />
 
       {/* Send Activity Modal */}

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -10,6 +10,7 @@ import {
   useQuestionFiltersStore,
   createUseActivityFiltersData,
   SendActivityModal,
+  SaveActivityModelModal,
   CategoryConfig,
   useToastStore,
   Modal,
@@ -171,6 +172,7 @@ const CreateActivity = ({
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isSendModalOpen, setIsSendModalOpen] = useState(false);
+  const [isSaveModelModalOpen, setIsSaveModelModalOpen] = useState(false);
   const [categories, setCategories] = useState<CategoryConfig[]>([]);
   const [isSendingActivity, setIsSendingActivity] = useState(false);
 
@@ -666,10 +668,14 @@ const CreateActivity = ({
   /**
    * Save draft to backend
    * @param typeOverride - Override the activity type for this save
+   * @param customTitle - Optional user-provided title; falls back to auto-generated when empty
    * @returns The draft ID (existing or newly created), or undefined if save failed
    */
   const saveDraft = useCallback(
-    async (typeOverride?: ActivityType): Promise<string | undefined> => {
+    async (
+      typeOverride?: ActivityType,
+      customTitle?: string
+    ): Promise<string | undefined> => {
       if (!validateSaveConditions()) {
         return draftId || undefined;
       }
@@ -685,7 +691,11 @@ const CreateActivity = ({
           if (!subjectId) {
             throw new Error('Subject ID não encontrado');
           }
-          const title = generateTitle(typeOverride, subjectId, knowledgeAreas);
+          const trimmedCustomTitle = customTitle?.trim();
+          const title =
+            trimmedCustomTitle && trimmedCustomTitle.length > 0
+              ? trimmedCustomTitle
+              : generateTitle(typeOverride, subjectId, knowledgeAreas);
           payload = {
             ...payload,
             type: typeOverride,
@@ -742,11 +752,23 @@ const CreateActivity = ({
   );
 
   /**
-   * Handle save model button click
+   * Open the "save as model" modal so the user can provide a custom title
    */
-  const handleSaveModel = useCallback(async () => {
-    setActivityType(ActivityType.MODELO);
+  const handleSaveModel = useCallback(() => {
+    setIsSaveModelModalOpen(true);
   }, []);
+
+  /**
+   * Persist the draft as MODELO using the title provided by the user
+   */
+  const handleConfirmSaveModel = useCallback(
+    async (title: string) => {
+      setIsSaveModelModalOpen(false);
+      setActivityType(ActivityType.MODELO);
+      await saveDraft(ActivityType.MODELO, title);
+    },
+    [saveDraft]
+  );
 
   /**
    * Get endpoint for recommended class based on class type
@@ -994,18 +1016,6 @@ const CreateActivity = ({
       }
     };
   }, [questions, appliedFilters, activityType, loadingInitialQuestions]);
-
-  /**
-   * Save immediately when activityType changes to MODELO
-   */
-  useEffect(() => {
-    if (activityType === ActivityType.MODELO && hasFirstSaveBeenDone.current) {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
-      saveDraftRef.current();
-    }
-  }, [activityType]);
 
   /**
    * Handle adding a question to the activity
@@ -1402,6 +1412,14 @@ const CreateActivity = ({
           </div>
         </div>
       )}
+
+      {/* Save Activity Model Modal */}
+      <SaveActivityModelModal
+        isOpen={isSaveModelModalOpen}
+        onClose={() => setIsSaveModelModalOpen(false)}
+        onConfirm={handleConfirmSaveModel}
+        isLoading={isSaving}
+      />
 
       {/* Send Activity Modal */}
       <SendActivityModal

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -759,12 +759,14 @@ const CreateActivity = ({
   }, []);
 
   /**
-   * Persist the draft as MODELO using the title provided by the user
+   * Persist the draft as MODELO using the title provided by the user.
+   * activityType is updated by the save helpers (updateExistingDraft /
+   * updateStateAfterSave) only after the backend confirms the save, keeping
+   * UI state consistent with persisted state on failure.
    */
   const handleConfirmSaveModel = useCallback(
     async (title: string) => {
       setIsSaveModelModalOpen(false);
-      setActivityType(ActivityType.MODELO);
       await saveDraft(ActivityType.MODELO, title);
     },
     [saveDraft]

--- a/src/components/SaveActivityModelModal/SaveActivityModelModal.stories.tsx
+++ b/src/components/SaveActivityModelModal/SaveActivityModelModal.stories.tsx
@@ -1,0 +1,78 @@
+import type { Story } from '@ladle/react';
+import { useState } from 'react';
+import { SaveActivityModelModal } from './SaveActivityModelModal';
+import Button from '../Button/Button';
+
+/**
+ * Basic SaveActivityModelModal usage. The user opens the modal, types a title
+ * and confirms to "save" the activity as a reusable template.
+ */
+export const Basic: Story = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [savedTitle, setSavedTitle] = useState<string | null>(null);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Button onClick={() => setIsOpen(true)}>Salvar modelo</Button>
+
+      {savedTitle && (
+        <div className="p-4 bg-background-50 rounded-lg">
+          <p className="text-sm font-medium text-text-900">
+            Último título salvo:
+          </p>
+          <p className="text-sm text-text-700">{savedTitle}</p>
+        </div>
+      )}
+
+      <SaveActivityModelModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onConfirm={(title) => {
+          setSavedTitle(title);
+          setIsOpen(false);
+        }}
+      />
+    </div>
+  );
+};
+
+/**
+ * Modal pre-filled with an initial title (used when editing an existing draft).
+ */
+export const WithInitialTitle: Story = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Button onClick={() => setIsOpen(true)}>Editar título do modelo</Button>
+
+      <SaveActivityModelModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        initialTitle="Modelo - Frações para o 7º ano"
+      />
+    </div>
+  );
+};
+
+/**
+ * Modal in a loading state — both action buttons are disabled while the save
+ * request is in flight.
+ */
+export const Loading: Story = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Button onClick={() => setIsOpen(true)}>Abrir modal (loading)</Button>
+
+      <SaveActivityModelModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        isLoading
+      />
+    </div>
+  );
+};

--- a/src/components/SaveActivityModelModal/SaveActivityModelModal.stories.tsx
+++ b/src/components/SaveActivityModelModal/SaveActivityModelModal.stories.tsx
@@ -2,6 +2,7 @@ import type { Story } from '@ladle/react';
 import { useState } from 'react';
 import { SaveActivityModelModal } from './SaveActivityModelModal';
 import Button from '../Button/Button';
+import Text from '../Text/Text';
 
 /**
  * Basic SaveActivityModelModal usage. The user opens the modal, types a title
@@ -17,10 +18,12 @@ export const Basic: Story = () => {
 
       {savedTitle && (
         <div className="p-4 bg-background-50 rounded-lg">
-          <p className="text-sm font-medium text-text-900">
+          <Text size="sm" weight="medium" color="text-text-900">
             Último título salvo:
-          </p>
-          <p className="text-sm text-text-700">{savedTitle}</p>
+          </Text>
+          <Text size="sm" color="text-text-700">
+            {savedTitle}
+          </Text>
         </div>
       )}
 

--- a/src/components/SaveActivityModelModal/SaveActivityModelModal.test.tsx
+++ b/src/components/SaveActivityModelModal/SaveActivityModelModal.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SaveActivityModelModal } from './SaveActivityModelModal';
+
+describe('SaveActivityModelModal', () => {
+  const setup = (
+    overrides: Partial<Parameters<typeof SaveActivityModelModal>[0]> = {}
+  ) => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const utils = render(
+      <SaveActivityModelModal
+        isOpen
+        onClose={onClose}
+        onConfirm={onConfirm}
+        {...overrides}
+      />
+    );
+    return { onClose, onConfirm, ...utils };
+  };
+
+  it('does not render when isOpen is false', () => {
+    render(
+      <SaveActivityModelModal
+        isOpen={false}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Salvar modelo')).not.toBeInTheDocument();
+  });
+
+  it('renders title field with placeholder when opened', () => {
+    setup();
+
+    const input = screen.getByPlaceholderText('Digite o título do modelo');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('');
+  });
+
+  it('uses initialTitle when provided', () => {
+    setup({ initialTitle: 'Modelo de Frações' });
+
+    expect(
+      screen.getByPlaceholderText('Digite o título do modelo')
+    ).toHaveValue('Modelo de Frações');
+  });
+
+  it('resets title and error every time the modal reopens', () => {
+    const onConfirm = jest.fn();
+    const { rerender } = render(
+      <SaveActivityModelModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+        initialTitle="Inicial"
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Digite o título do modelo');
+    fireEvent.change(input, { target: { value: 'editado' } });
+    expect(input).toHaveValue('editado');
+
+    rerender(
+      <SaveActivityModelModal
+        isOpen={false}
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+        initialTitle="Inicial"
+      />
+    );
+
+    rerender(
+      <SaveActivityModelModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+        initialTitle="Inicial"
+      />
+    );
+
+    expect(
+      screen.getByPlaceholderText('Digite o título do modelo')
+    ).toHaveValue('Inicial');
+  });
+
+  it('shows validation error when confirming with empty title', () => {
+    const { onConfirm } = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Salvar modelo' }));
+
+    expect(
+      screen.getByText('Informe um título para o modelo')
+    ).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when title is only whitespace', () => {
+    const { onConfirm } = setup();
+
+    const input = screen.getByPlaceholderText('Digite o título do modelo');
+    fireEvent.change(input, { target: { value: '    ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Salvar modelo' }));
+
+    expect(
+      screen.getByText('Informe um título para o modelo')
+    ).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('clears error message when user types again', () => {
+    setup();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Salvar modelo' }));
+    expect(
+      screen.getByText('Informe um título para o modelo')
+    ).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText('Digite o título do modelo');
+    fireEvent.change(input, { target: { value: 'a' } });
+
+    expect(
+      screen.queryByText('Informe um título para o modelo')
+    ).not.toBeInTheDocument();
+  });
+
+  it('confirms with the trimmed title when valid', () => {
+    const { onConfirm } = setup();
+
+    const input = screen.getByPlaceholderText('Digite o título do modelo');
+    fireEvent.change(input, { target: { value: '  Modelo de Frações  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Salvar modelo' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith('Modelo de Frações');
+  });
+
+  it('rejects titles longer than 255 characters after trimming', () => {
+    const { onConfirm } = setup();
+
+    // Bypass the maxLength HTML attribute by injecting via change event directly
+    const input = screen.getByPlaceholderText(
+      'Digite o título do modelo'
+    ) as HTMLInputElement;
+    const longTitle = 'a'.repeat(256);
+    fireEvent.change(input, { target: { value: longTitle } });
+
+    // jsdom respects maxLength on user input but we forced a value via fireEvent.
+    // We assert the validation regardless of what value the input ended up with.
+    fireEvent.click(screen.getByRole('button', { name: 'Salvar modelo' }));
+
+    if (input.value.length > 255) {
+      expect(
+        screen.getByText('O título deve ter no máximo 255 caracteres')
+      ).toBeInTheDocument();
+      expect(onConfirm).not.toHaveBeenCalled();
+    } else {
+      // jsdom truncated to maxLength; confirm went through with 255 chars
+      expect(onConfirm).toHaveBeenCalledWith('a'.repeat(255));
+    }
+  });
+
+  it('calls onClose when clicking cancel', () => {
+    const { onClose, onConfirm } = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('disables both action buttons while loading', () => {
+    setup({ isLoading: true });
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancelar' });
+    const confirmButton = screen.getByRole('button', { name: 'Salvar modelo' });
+
+    expect(cancelButton).toBeDisabled();
+    expect(confirmButton).toBeDisabled();
+  });
+});

--- a/src/components/SaveActivityModelModal/SaveActivityModelModal.tsx
+++ b/src/components/SaveActivityModelModal/SaveActivityModelModal.tsx
@@ -1,0 +1,104 @@
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import Modal from '../Modal/Modal';
+import Input from '../Input/Input';
+import Button from '../Button/Button';
+
+const TITLE_MAX_LENGTH = 255;
+
+/**
+ * SaveActivityModelModal component props
+ */
+export interface SaveActivityModelModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Callback to close the modal without saving */
+  onClose: () => void;
+  /** Callback called with the validated title when the user confirms */
+  onConfirm: (title: string) => void;
+  /** Disables actions and shows loading state on confirm button */
+  isLoading?: boolean;
+  /** Optional initial title value (used when editing an existing draft) */
+  initialTitle?: string;
+}
+
+/**
+ * Modal that prompts the user for the activity model title before saving it
+ * as a reusable template (ActivityType.MODELO).
+ *
+ * Validates the title locally with the same constraints as the backend schema
+ * (1–255 characters after trimming).
+ */
+export const SaveActivityModelModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading = false,
+  initialTitle = '',
+}: SaveActivityModelModalProps) => {
+  const [title, setTitle] = useState(initialTitle);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  // Reset internal state every time the modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(initialTitle);
+      setError(undefined);
+    }
+  }, [isOpen, initialTitle]);
+
+  const handleChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value);
+    setError(undefined);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    const trimmed = title.trim();
+
+    if (trimmed.length === 0) {
+      setError('Informe um título para o modelo');
+      return;
+    }
+
+    if (trimmed.length > TITLE_MAX_LENGTH) {
+      setError(`O título deve ter no máximo ${TITLE_MAX_LENGTH} caracteres`);
+      return;
+    }
+
+    onConfirm(trimmed);
+  }, [title, onConfirm]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Salvar modelo"
+      size="sm"
+      footer={
+        <>
+          <Button variant="outline" onClick={onClose} disabled={isLoading}>
+            Cancelar
+          </Button>
+          <Button variant="solid" onClick={handleConfirm} disabled={isLoading}>
+            Salvar modelo
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <Input
+          label="Título"
+          placeholder="Digite o título do modelo"
+          value={title}
+          onChange={handleChange}
+          variant="rounded"
+          required
+          maxLength={TITLE_MAX_LENGTH}
+          errorMessage={error}
+          autoFocus
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default SaveActivityModelModal;

--- a/src/components/SaveActivityModelModal/index.ts
+++ b/src/components/SaveActivityModelModal/index.ts
@@ -1,0 +1,2 @@
+export { SaveActivityModelModal } from './SaveActivityModelModal';
+export type { SaveActivityModelModalProps } from './SaveActivityModelModal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -980,6 +980,10 @@ export {
 export { ChooseActivityModelModal } from './components/ChooseActivityModelModal';
 export type { ChooseActivityModelModalProps } from './components/ChooseActivityModelModal';
 
+// SaveActivityModelModal Component
+export { SaveActivityModelModal } from './components/SaveActivityModelModal';
+export type { SaveActivityModelModalProps } from './components/SaveActivityModelModal';
+
 // SendLessonModal Component
 export { SendLessonModal } from './components/SendLessonModal';
 export { useSendLessonModal } from './components/SendLessonModal';


### PR DESCRIPTION
<img width="1462" height="959" alt="Captura de Tela 2026-05-04 às 14 50 08" src="https://github.com/user-attachments/assets/da9b94a8-93e5-4c4b-aa93-530c57b6b198" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "Save as model" modal allowing users to enter a custom title when saving an activity as a model; validates non-empty and max‑255 chars and supports a loading state.
  * Saves now occur only after user confirmation in the modal (no automatic model save).

* **Tests & Stories**
  * Added component stories and comprehensive tests for the modal and updated save-flow tests.

* **Chores**
  * Version bumped to 1.3.94.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->