### PR TITLE
Fix/prova presencial ajustes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.93",
+  "version": "1.3.96",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ActivityCreate/ActivityCreate.utils.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.ts
@@ -288,8 +288,8 @@ export function buildSendActivityPayload(
     finalDate: finalDateTime,
     canRetry: formData.canRetry,
     isDigital:
-      formData.mode !== undefined
-        ? formData.mode === ActivityMode.ONLINE
-        : undefined,
+      formData.mode === undefined
+        ? undefined
+        : formData.mode === ActivityMode.ONLINE,
   };
 }

--- a/src/components/ActivityCreate/ActivityCreate.utils.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.ts
@@ -4,6 +4,7 @@ import type {
   QuestionActivity as Question,
   SendActivityFormData,
 } from '../..';
+import { ActivityMode } from '../SendActivityModal/types';
 import { QUESTION_TYPE } from '../Quiz/useQuizStore';
 import type { BackendFiltersFormat } from './ActivityCreate.types';
 import { ActivityType } from './ActivityCreate.types';
@@ -286,6 +287,9 @@ export function buildSendActivityPayload(
     startDate: startDateTime,
     finalDate: finalDateTime,
     canRetry: formData.canRetry,
-    mode: formData.mode,
+    isDigital:
+      formData.mode !== undefined
+        ? formData.mode === ActivityMode.ONLINE
+        : undefined,
   };
 }

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -2,7 +2,6 @@ import type { HTMLAttributes, ReactNode, Ref } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { STUDENT_ACTIVITY_STATUS } from '../../types/activityDetails';
-import { ActivityMode } from '../SendActivityModal/types';
 import {
   getStatusBadgeConfig,
   formatTimeSpent,
@@ -2287,7 +2286,8 @@ describe('ActivityDetails', () => {
         year: '2024',
         subjectName: 'Matemática',
         className: '9º Ano B',
-        mode: ActivityMode.PRESENCIAL,
+        subtype: 'PROVA',
+        isDigital: false,
       },
       students: [
         {

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -33,6 +33,7 @@ import {
   type ActivityStudentTableItem,
   type StudentActivityStatus,
 } from '../../types/activityDetails';
+import { ActivitySubtype } from '../SendActivityModal/types';
 import {
   getStatusBadgeConfig,
   formatTimeSpent,
@@ -67,7 +68,7 @@ export interface ActivityDetailsProps {
   mapSubjectNameToEnum?: (subjectName: string) => SubjectEnum | null;
   /**
    * Callback for downloading the answer sheet for a student.
-   * Presencial mode is determined by `activity.isDigital === false && activity.subtype === 'PROVA'`,
+   * Presencial mode is determined by `activity.isDigital === false && activity.subtype === ActivitySubtype.PROVA`,
    * not by the presence of this callback. When the activity is presencial:
    * - Hides the "Duração" column
    * - Renames "Respondido em" → "Gabarito recebido em"
@@ -501,7 +502,8 @@ export const ActivityDetails = ({
   );
 
   const isPresencial =
-    data?.activity?.isDigital === false && data?.activity?.subtype === 'PROVA';
+    data?.activity?.isDigital === false &&
+    data?.activity?.subtype === ActivitySubtype.PROVA;
 
   /**
    * Convert student data to table format.

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -39,7 +39,6 @@ import {
   formatQuestionNumbers,
   formatDateToBrazilian,
 } from '../../utils/activityDetailsUtils';
-import { ActivityMode } from '../SendActivityModal/types';
 import type { BaseApiClient } from '../../types/api';
 import { useActivityDetails } from '../../hooks/useActivityDetails';
 import {
@@ -68,8 +67,8 @@ export interface ActivityDetailsProps {
   mapSubjectNameToEnum?: (subjectName: string) => SubjectEnum | null;
   /**
    * Callback for downloading the answer sheet for a student.
-   * Presencial mode is determined by `activity.mode === ActivityMode.PRESENCIAL`, not by
-   * the presence of this callback. When the activity is presencial:
+   * Presencial mode is determined by `activity.isDigital === false && activity.subtype === 'PROVA'`,
+   * not by the presence of this callback. When the activity is presencial:
    * - Hides the "Duração" column
    * - Renames "Respondido em" → "Gabarito recebido em"
    * - Shows a "Gabarito" column (before "Resultado"); button is disabled when callback is absent
@@ -501,7 +500,8 @@ export const ActivityDetails = ({
     [activityId, submitQuestionCorrection]
   );
 
-  const isPresencial = data?.activity?.mode === ActivityMode.PRESENCIAL;
+  const isPresencial =
+    data?.activity?.isDigital === false && data?.activity?.subtype === 'PROVA';
 
   /**
    * Convert student data to table format.

--- a/src/components/CheckBoxGroup/CheckBoxGroup.test.tsx
+++ b/src/components/CheckBoxGroup/CheckBoxGroup.test.tsx
@@ -1070,8 +1070,8 @@ describe('CheckboxGroup', () => {
       );
       const endTime = performance.now();
 
-      // Should render within reasonable time (less than 3 seconds)
-      expect(endTime - startTime).toBeLessThan(3000);
+      // Should render within reasonable time (less than 5 seconds)
+      expect(endTime - startTime).toBeLessThan(5000);
     });
   });
 

--- a/src/components/SendActivityModal/SendActivityModal.test.tsx
+++ b/src/components/SendActivityModal/SendActivityModal.test.tsx
@@ -252,6 +252,7 @@ describe('SendActivityModal', () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   describe('rendering', () => {
@@ -1004,8 +1005,6 @@ describe('SendActivityModal', () => {
           submitError
         );
       });
-
-      consoleSpy.mockRestore();
     });
 
     it('should not call onError when submission succeeds', async () => {

--- a/src/components/SendActivityModal/SendActivityModal.test.tsx
+++ b/src/components/SendActivityModal/SendActivityModal.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import SendActivityModal from './SendActivityModal';
-import { ActivitySubtype, CategoryConfig, Item } from './types';
+import { ActivitySubtype, ActivityMode, CategoryConfig, Item } from './types';
 import { useSendActivityModalStore } from './hooks/useSendActivityModal';
 
 /**
@@ -186,6 +186,47 @@ const mockCategoriesMultiple: CategoryConfig[] = [
       },
     ],
     selectedIds: [],
+  },
+];
+
+const categoriesWithAllSelected: CategoryConfig[] = [
+  {
+    key: 'escola',
+    label: 'Escola',
+    itens: [{ id: 'school-1', name: 'Escola Teste' }],
+    selectedIds: ['school-1'],
+  },
+  {
+    key: 'serie',
+    label: 'Série',
+    dependsOn: ['escola'],
+    filteredBy: [{ key: 'escola', internalField: 'schoolId' }],
+    itens: [{ id: 'year-1', name: '2025', schoolId: 'school-1' }],
+    selectedIds: ['year-1'],
+  },
+  {
+    key: 'turma',
+    label: 'Turma',
+    dependsOn: ['serie'],
+    filteredBy: [{ key: 'serie', internalField: 'yearId' }],
+    itens: [{ id: 'class-1', name: 'Turma A', yearId: 'year-1' }],
+    selectedIds: ['class-1'],
+  },
+  {
+    key: 'students',
+    label: 'Alunos',
+    dependsOn: ['turma'],
+    filteredBy: [{ key: 'turma', internalField: 'classId' }],
+    itens: [
+      {
+        id: 'student-1',
+        name: 'Aluno 1',
+        classId: 'class-1',
+        studentId: 'student-1',
+        userInstitutionId: 'ui-1',
+      },
+    ],
+    selectedIds: ['student-1'],
   },
 ];
 
@@ -891,6 +932,82 @@ describe('SendActivityModal', () => {
       });
     });
 
+    it('should not call onSubmit when step 3 validation fails due to missing dates', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      render(
+        <SendActivityModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          categories={categoriesWithAllSelected}
+        />
+      );
+
+      // Navigate to step 3
+      fireEvent.click(screen.getByText('Tarefa'));
+      fireEvent.change(
+        screen.getByPlaceholderText('Digite o título da atividade'),
+        { target: { value: 'Test' } }
+      );
+      fireEvent.click(screen.getByText('Próximo'));
+      fireEvent.click(screen.getByText('Próximo'));
+
+      // Submit WITHOUT filling dates → isValid=false → early return (line 219)
+      fireEvent.click(
+        screen.getByRole('button', { name: /Enviar atividade/i })
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should log to console.error when submission fails and onError is not provided', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const submitError = new Error('Submission failed');
+      const onSubmit = jest.fn().mockRejectedValue(submitError);
+
+      render(
+        <SendActivityModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          categories={categoriesWithAllSelected}
+        />
+      );
+
+      // Navigate to step 3
+      fireEvent.click(screen.getByText('Tarefa'));
+      fireEvent.change(
+        screen.getByPlaceholderText('Digite o título da atividade'),
+        { target: { value: 'Test' } }
+      );
+      fireEvent.click(screen.getByText('Próximo'));
+      fireEvent.click(screen.getByText('Próximo'));
+
+      // Fill dates and submit
+      fireEvent.change(screen.getByTestId('start-datetime-input'), {
+        target: { value: '2025-01-20T00:00' },
+      });
+      fireEvent.change(screen.getByTestId('final-datetime-input'), {
+        target: { value: '2025-01-25T23:59' },
+      });
+      fireEvent.click(
+        screen.getByRole('button', { name: /Enviar atividade/i })
+      );
+
+      // Without onError prop: else branch calls console.error (lines 225, 228)
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Falha ao enviar atividade:',
+          submitError
+        );
+      });
+
+      consoleSpy.mockRestore();
+    });
+
     it('should not call onError when submission succeeds', async () => {
       const onSubmit = jest.fn().mockResolvedValue(undefined);
       const onError = jest.fn();
@@ -1074,6 +1191,25 @@ describe('SendActivityModal', () => {
       expect(tarefaChip.closest('button')).toHaveClass('bg-info-background');
     });
 
+    it('should use empty string defaults when title and notification are not provided', () => {
+      render(
+        <SendActivityModal
+          {...defaultProps}
+          initialData={{ subtype: ActivitySubtype.TAREFA }}
+        />
+      );
+
+      // title ?? '' and notification ?? '' both take the falsy branch (line 118)
+      expect(
+        screen.getByPlaceholderText('Digite o título da atividade')
+      ).toHaveValue('');
+      expect(
+        screen.getByPlaceholderText(
+          'Digite uma mensagem para a notificação (opcional)'
+        )
+      ).toHaveValue('');
+    });
+
     it('should pre-fill again when modal reopens with different initialData', () => {
       const { rerender } = render(
         <SendActivityModal
@@ -1147,6 +1283,57 @@ describe('SendActivityModal', () => {
       expect(
         screen.getByPlaceholderText('Digite o título da atividade')
       ).toHaveValue('Mesma Prova');
+    });
+  });
+
+  describe('step rendering edge cases', () => {
+    it('should render nothing for an invalid step number (default switch case)', () => {
+      render(<SendActivityModal {...defaultProps} />);
+
+      // Force an invalid step directly in the store (covers line 398 default: return null)
+      act(() => {
+        useSendActivityModalStore.setState({ currentStep: 99 });
+      });
+
+      expect(screen.queryByText('Tipo de atividade*')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Para quem você vai enviar a atividade?')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Iniciar em*')).not.toBeInTheDocument();
+    });
+
+    it('should render step 3 with undefined startTime and finalTime covering the falsy || branch', () => {
+      render(
+        <SendActivityModal
+          {...defaultProps}
+          categories={categoriesWithAllSelected}
+        />
+      );
+
+      // The initialState sets startTime='00:00' and finalTime='23:59' (always truthy).
+      // Clear them to cover the falsy branch of `startTime || ''` and `finalTime || ''` (lines 382, 384)
+      act(() => {
+        useSendActivityModalStore.setState((state) => ({
+          formData: {
+            ...state.formData,
+            startTime: undefined,
+            finalTime: undefined,
+          },
+        }));
+      });
+
+      // Navigate to step 3
+      fireEvent.click(screen.getByText('Tarefa'));
+      fireEvent.change(
+        screen.getByPlaceholderText('Digite o título da atividade'),
+        { target: { value: 'Test' } }
+      );
+      fireEvent.click(screen.getByText('Próximo'));
+      fireEvent.click(screen.getByText('Próximo'));
+
+      // Step 3 renders with startTime=undefined and finalTime=undefined → `|| ''` takes the falsy branch
+      expect(screen.getByTestId('start-datetime-input')).toBeInTheDocument();
+      expect(screen.getByTestId('final-datetime-input')).toBeInTheDocument();
     });
   });
 
@@ -1226,6 +1413,38 @@ describe('SendActivityModal', () => {
   });
 
   describe('enableExamMode', () => {
+    it('should set canRetry to false and not show retry option on step 3 when PRESENCIAL mode is selected', async () => {
+      render(
+        <SendActivityModal
+          {...defaultProps}
+          enableExamMode
+          categories={categoriesWithAllSelected}
+        />
+      );
+
+      // Step 1: select PROVA, fill title, select PRESENCIAL mode
+      fireEvent.click(screen.getByText('Prova'));
+      fireEvent.change(
+        screen.getByPlaceholderText('Digite o título da atividade'),
+        { target: { value: 'Prova Presencial' } }
+      );
+      fireEvent.click(screen.getByText('Presencial'));
+
+      // Verify store sets canRetry=false when PRESENCIAL selected (line 178)
+      expect(useSendActivityModalStore.getState().formData.mode).toBe(
+        ActivityMode.PRESENCIAL
+      );
+      expect(useSendActivityModalStore.getState().formData.canRetry).toBe(false);
+
+      fireEvent.click(screen.getByText('Próximo'));
+
+      // Step 2: advance to step 3
+      fireEvent.click(screen.getByText('Próximo'));
+
+      // Step 3: retry option should NOT be rendered (lines 315-316)
+      expect(screen.queryByText('Permitir refazer?')).not.toBeInTheDocument();
+    });
+
     it('should show "Modo de prova" selector when enableExamMode=true and subtype is PROVA', () => {
       render(<SendActivityModal {...defaultProps} enableExamMode />);
 

--- a/src/components/SendActivityModal/SendActivityModal.tsx
+++ b/src/components/SendActivityModal/SendActivityModal.tsx
@@ -175,9 +175,7 @@ const SendActivityModal = ({
   const handleModeSelect = useCallback(
     (mode: ActivityMode) => {
       const update: Partial<SendActivityFormData> =
-        mode === ActivityMode.PRESENCIAL
-          ? { mode, canRetry: false }
-          : { mode };
+        mode === ActivityMode.PRESENCIAL ? { mode, canRetry: false } : { mode };
       store.setFormData(update);
     },
     [store]

--- a/src/components/SendActivityModal/SendActivityModal.tsx
+++ b/src/components/SendActivityModal/SendActivityModal.tsx
@@ -174,7 +174,11 @@ const SendActivityModal = ({
    */
   const handleModeSelect = useCallback(
     (mode: ActivityMode) => {
-      store.setFormData({ mode });
+      const update: Partial<SendActivityFormData> =
+        mode === ActivityMode.PRESENCIAL
+          ? { mode, canRetry: false }
+          : { mode };
+      store.setFormData(update);
     },
     [store]
   );
@@ -309,43 +313,49 @@ const SendActivityModal = ({
   /**
    * Render retry option for deadline step
    */
-  const renderRetryOption = () => (
-    <div>
-      <Text size="sm" weight="medium" color="text-text-700" className="mb-3">
-        Permitir refazer?
-      </Text>
-      <RadioGroup
-        value={store.formData.canRetry ? 'yes' : 'no'}
-        onValueChange={handleRetryChange}
-        className="flex flex-row gap-6"
-      >
-        <div className="flex items-center gap-2">
-          <RadioGroupItem value="yes" id="radio-item-yes" />
-          <Text
-            as="label"
-            size="sm"
-            color="text-text-700"
-            className="cursor-pointer"
-            htmlFor="radio-item-yes"
-          >
-            Sim
-          </Text>
-        </div>
-        <div className="flex items-center gap-2">
-          <RadioGroupItem value="no" id="radio-item-no" />
-          <Text
-            as="label"
-            size="sm"
-            color="text-text-700"
-            className="cursor-pointer"
-            htmlFor="radio-item-no"
-          >
-            Não
-          </Text>
-        </div>
-      </RadioGroup>
-    </div>
-  );
+  const renderRetryOption = () => {
+    if (enableExamMode && store.formData.mode === ActivityMode.PRESENCIAL) {
+      return null;
+    }
+
+    return (
+      <div>
+        <Text size="sm" weight="medium" color="text-text-700" className="mb-3">
+          Permitir refazer?
+        </Text>
+        <RadioGroup
+          value={store.formData.canRetry ? 'yes' : 'no'}
+          onValueChange={handleRetryChange}
+          className="flex flex-row gap-6"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="yes" id="radio-item-yes" />
+            <Text
+              as="label"
+              size="sm"
+              color="text-text-700"
+              className="cursor-pointer"
+              htmlFor="radio-item-yes"
+            >
+              Sim
+            </Text>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="no" id="radio-item-no" />
+            <Text
+              as="label"
+              size="sm"
+              color="text-text-700"
+              className="cursor-pointer"
+              htmlFor="radio-item-no"
+            >
+              Não
+            </Text>
+          </div>
+        </RadioGroup>
+      </div>
+    );
+  };
 
   /**
    * Render current step content

--- a/src/hooks/useSendActivity.ts
+++ b/src/hooks/useSendActivity.ts
@@ -8,9 +8,10 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
 import dayjs from 'dayjs';
 import type { CategoryConfig } from '../components/CheckBoxGroup/CheckBoxGroup';
-import type {
-  SendActivityFormData,
-  SendActivityModalInitialData,
+import {
+  ActivityMode,
+  type SendActivityFormData,
+  type SendActivityModalInitialData,
 } from '../components/SendActivityModal/types';
 import type {
   UseSendActivityConfig,
@@ -224,7 +225,10 @@ export function useSendActivity(
           subjectId: selectedModel.subjectId,
           questionIds,
           subtype: data.subtype,
-          mode: data.mode,
+          isDigital:
+            data.mode !== undefined
+              ? data.mode === ActivityMode.ONLINE
+              : undefined,
           notification: data.notification,
           startDate: toISODateTime(data.startDate, data.startTime),
           finalDate: toISODateTime(data.finalDate, data.finalTime),

--- a/src/hooks/useSendActivity.ts
+++ b/src/hooks/useSendActivity.ts
@@ -226,9 +226,9 @@ export function useSendActivity(
           questionIds,
           subtype: data.subtype,
           isDigital:
-            data.mode !== undefined
-              ? data.mode === ActivityMode.ONLINE
-              : undefined,
+            data.mode === undefined
+              ? undefined
+              : data.mode === ActivityMode.ONLINE,
           notification: data.notification,
           startDate: toISODateTime(data.startDate, data.startTime),
           finalDate: toISODateTime(data.finalDate, data.finalTime),

--- a/src/types/activityDetails.ts
+++ b/src/types/activityDetails.ts
@@ -82,7 +82,8 @@ export interface ActivityMetadata {
   id: string;
   title: string;
   type?: string;
-  mode?: string | null;
+  subtype?: string;
+  isDigital?: boolean | null;
   startDate: string | null;
   finalDate: string | null;
   schoolName: string;

--- a/src/types/sendActivity.ts
+++ b/src/types/sendActivity.ts
@@ -45,7 +45,7 @@ export interface CreateActivityPayload {
   subjectId: string | null;
   questionIds: string[];
   subtype: string;
-  mode?: string;
+  isDigital?: boolean;
   notification?: string;
   startDate: string;
   finalDate: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.3.96.

* **Refactor**
  * Activity metadata now uses subtype and isDigital instead of mode for mode detection and payloads.

* **Bug Fixes / UX**
  * Details view, column visibility and gating updated for presencial activities.
  * Retry option hidden and canRetry forced off when exam mode + presencial are selected.
  * Submission validates missing dates and logs errors on failure.

* **Tests**
  * Added coverage for send flow, exam-mode behavior, edge cases; relaxed a performance assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->