### PR TITLE
AE-2568 - feat: extend accessibility widget with text-to-speech support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.97",
+  "version": "1.3.98",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.94",
+  "version": "1.3.95",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/AccessibilityWidget/AccessibilityPanel.tsx
+++ b/src/components/AccessibilityWidget/AccessibilityPanel.tsx
@@ -10,11 +10,13 @@ import {
   BookOpenTextIcon,
   KeyboardIcon,
   PaletteIcon,
+  SpeakerHighIcon,
 } from '@phosphor-icons/react';
 import Text from '../Text/Text';
 import Button from '../Button/Button';
 import IconButton from '../IconButton/IconButton';
 import ToggleSwitch from '../ToggleSwitch/ToggleSwitch';
+import TTSSection from './TTSSection';
 import { cn } from '../../utils/utils';
 import {
   useAccessibilityStore,
@@ -384,6 +386,13 @@ export default function AccessibilityPanel({
         </Section>
 
         <Section
+          title="Leitor de texto"
+          icon={<SpeakerHighIcon size={18} weight="fill" />}
+        >
+          <TTSSection Segmented={Segmented} />
+        </Section>
+
+        <Section
           title="Outras opções"
           icon={<CursorIcon size={18} weight="fill" />}
         >
@@ -441,17 +450,17 @@ export default function AccessibilityPanel({
           variant="outline"
           action="secondary"
           size="small"
+          iconLeft={
+            <ArrowCounterClockwiseIcon
+              size={14}
+              weight="bold"
+              aria-hidden="true"
+            />
+          }
           onClick={resetPreferences}
           data-testid="a11y-reset"
         >
-          <ArrowCounterClockwiseIcon
-            size={14}
-            weight="bold"
-            aria-hidden="true"
-          />
-          <Text as="span" size="sm" className="ml-1">
-            Redefinir
-          </Text>
+          Redefinir
         </Button>
       </footer>
     </dialog>

--- a/src/components/AccessibilityWidget/AccessibilityWidget.tsx
+++ b/src/components/AccessibilityWidget/AccessibilityWidget.tsx
@@ -4,6 +4,7 @@ import AccessibilityFab, {
 import AccessibilityPanel from './AccessibilityPanel';
 import ReadingAid from './ReadingAid';
 import ColorBlindFilters from './ColorBlindFilters';
+import TTSController from './TTSController';
 import { useAccessibilityStore } from '../../store/accessibilityStore';
 import { useA11yPreferences } from '../../hooks/useA11yPreferences';
 import { useA11yKeyboardShortcut } from '../../hooks/useA11yKeyboardShortcut';
@@ -63,6 +64,7 @@ export default function AccessibilityWidget({
       />
       <ReadingAid />
       <ColorBlindFilters />
+      <TTSController />
     </>
   );
 }

--- a/src/components/AccessibilityWidget/ColorBlindFilters.test.tsx
+++ b/src/components/AccessibilityWidget/ColorBlindFilters.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ColorBlindFilters from './ColorBlindFilters';
+import {
+  ColorBlindMode,
+  getColorBlindFilterId,
+} from '../../store/accessibilityStore';
+
+describe('ColorBlindFilters', () => {
+  it('renders the hidden SVG with the colorblind testid', () => {
+    const { container } = render(<ColorBlindFilters />);
+    expect(
+      container.querySelector('[data-testid="a11y-colorblind-filters"]')
+    ).toBeInTheDocument();
+  });
+
+  it.each<Exclude<ColorBlindMode, ColorBlindMode.None>>([
+    ColorBlindMode.Protanopia,
+    ColorBlindMode.Deuteranopia,
+    ColorBlindMode.Tritanopia,
+  ])('exposes a <filter> definition for %s with feColorMatrix', (mode) => {
+    const { container } = render(<ColorBlindFilters />);
+    const id = getColorBlindFilterId(mode);
+    const filter = container.querySelector(`#${id}`);
+    expect(filter).toBeInTheDocument();
+    // Cada filter precisa ter ao menos uma matriz de cor
+    expect(filter?.querySelector('feColorMatrix')).toBeInTheDocument();
+  });
+
+  it('renders the SVG aria-hidden so it does not pollute screen readers', () => {
+    const { container } = render(<ColorBlindFilters />);
+    const svg = container.querySelector(
+      '[data-testid="a11y-colorblind-filters"]'
+    );
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/components/AccessibilityWidget/TTSController.test.tsx
+++ b/src/components/AccessibilityWidget/TTSController.test.tsx
@@ -1,0 +1,154 @@
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TTSController from './TTSController';
+import {
+  useAccessibilityStore,
+  DEFAULT_ACCESSIBILITY_PREFERENCES,
+} from '../../store/accessibilityStore';
+
+const speakMock = jest.fn();
+const stopMock = jest.fn();
+let isSupportedReturn = true;
+
+// Mocka o useTTS para isolar o TTSController do provider real.
+jest.mock('../../hooks/useTTS', () => ({
+  useTTS: () => ({
+    isSupported: isSupportedReturn,
+    voices: [],
+    hasPortugueseVoice: false,
+    speak: speakMock,
+    pause: jest.fn(),
+    resume: jest.fn(),
+    stop: stopMock,
+  }),
+}));
+
+describe('TTSController', () => {
+  beforeEach(() => {
+    speakMock.mockClear();
+    stopMock.mockClear();
+    isSupportedReturn = true;
+    useAccessibilityStore.setState({
+      ...DEFAULT_ACCESSIBILITY_PREFERENCES,
+      isPanelOpen: false,
+      ttsStatus: 'idle',
+    });
+  });
+
+  afterEach(() => {
+    document
+      .querySelectorAll('.a11y-tts-target')
+      .forEach((el) => el.classList.remove('a11y-tts-target'));
+  });
+
+  it('renders nothing visible (returns null)', () => {
+    const { container } = render(<TTSController />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not attach click handler when ttsMode is off', () => {
+    render(<TTSController />);
+    const target = document.createElement('p');
+    target.innerText = 'qualquer texto';
+    document.body.appendChild(target);
+
+    act(() => {
+      target.click();
+    });
+
+    expect(speakMock).not.toHaveBeenCalled();
+    target.remove();
+  });
+
+  it('reads element text on click when ttsMode is click-to-read', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    const p = document.createElement('p');
+    p.innerText = 'olá leitor';
+    document.body.appendChild(p);
+
+    act(() => {
+      p.click();
+    });
+
+    expect(speakMock).toHaveBeenCalledWith('olá leitor');
+    expect(p.classList.contains('a11y-tts-target')).toBe(true);
+    p.remove();
+  });
+
+  it('prefers aria-label over innerText when present', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', 'Fechar diálogo');
+    btn.innerText = 'X';
+    document.body.appendChild(btn);
+
+    act(() => {
+      btn.click();
+    });
+
+    expect(speakMock).toHaveBeenCalledWith('Fechar diálogo');
+    btn.remove();
+  });
+
+  it('ignores clicks inside the widget shield', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'a11y-widget-shield';
+    const child = document.createElement('button');
+    child.innerText = 'Botão do widget';
+    wrapper.appendChild(child);
+    document.body.appendChild(wrapper);
+
+    act(() => {
+      child.click();
+    });
+
+    expect(speakMock).not.toHaveBeenCalled();
+    wrapper.remove();
+  });
+
+  it('removes the highlight class when ttsStatus returns to idle', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    const p = document.createElement('p');
+    p.innerText = 'texto';
+    document.body.appendChild(p);
+
+    act(() => {
+      p.click();
+    });
+    expect(p.classList.contains('a11y-tts-target')).toBe(true);
+
+    act(() => {
+      useAccessibilityStore.getState().setTTSStatus('speaking');
+    });
+    act(() => {
+      useAccessibilityStore.getState().setTTSStatus('idle');
+    });
+    expect(p.classList.contains('a11y-tts-target')).toBe(false);
+    p.remove();
+  });
+
+  it('does not attach the click handler when synthesis is unsupported', () => {
+    isSupportedReturn = false;
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    const p = document.createElement('p');
+    p.innerText = 'texto';
+    document.body.appendChild(p);
+
+    act(() => {
+      p.click();
+    });
+    expect(speakMock).not.toHaveBeenCalled();
+    p.remove();
+  });
+});

--- a/src/components/AccessibilityWidget/TTSController.test.tsx
+++ b/src/components/AccessibilityWidget/TTSController.test.tsx
@@ -136,6 +136,27 @@ describe('TTSController', () => {
     p.remove();
   });
 
+  it('stops in-progress speech when ttsMode leaves click-to-read', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    const p = document.createElement('p');
+    p.innerText = 'texto';
+    document.body.appendChild(p);
+
+    act(() => {
+      p.click();
+    });
+    expect(speakMock).toHaveBeenCalled();
+
+    // Usuário desliga o modo — fala em andamento deve ser interrompida
+    act(() => {
+      useAccessibilityStore.getState().setTTSMode('off');
+    });
+    expect(stopMock).toHaveBeenCalled();
+    p.remove();
+  });
+
   it('does not attach the click handler when synthesis is unsupported', () => {
     isSupportedReturn = false;
     useAccessibilityStore.setState({ ttsMode: 'click-to-read' });

--- a/src/components/AccessibilityWidget/TTSController.test.tsx
+++ b/src/components/AccessibilityWidget/TTSController.test.tsx
@@ -77,6 +77,44 @@ describe('TTSController', () => {
     p.remove();
   });
 
+  it('walks up to ancestor with aria-label when target has no text (icon button)', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    // <button aria-label="Salvar"><svg></svg></button> — clica no SVG
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', 'Salvar');
+    const svg = document.createElement('span'); // jsdom não renderiza SVG bem; span vazio é equivalente
+    btn.appendChild(svg);
+    document.body.appendChild(btn);
+
+    act(() => {
+      svg.click();
+    });
+
+    expect(speakMock).toHaveBeenCalledWith('Salvar');
+    // Highlight deve marcar o botão (ancestral legível), não o SVG
+    expect(btn.classList.contains('a11y-tts-target')).toBe(true);
+    expect(svg.classList.contains('a11y-tts-target')).toBe(false);
+    btn.remove();
+  });
+
+  it('does not climb past body even if no readable ancestor is found', () => {
+    useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
+    render(<TTSController />);
+
+    // Elemento sem texto solto no body — não há ancestral legível
+    const empty = document.createElement('span');
+    document.body.appendChild(empty);
+
+    act(() => {
+      empty.click();
+    });
+
+    expect(speakMock).not.toHaveBeenCalled();
+    empty.remove();
+  });
+
   it('prefers aria-label over innerText when present', () => {
     useAccessibilityStore.setState({ ttsMode: 'click-to-read' });
     render(<TTSController />);

--- a/src/components/AccessibilityWidget/TTSController.tsx
+++ b/src/components/AccessibilityWidget/TTSController.tsx
@@ -1,0 +1,91 @@
+import { useEffect } from 'react';
+import { useAccessibilityStore } from '../../store/accessibilityStore';
+import { useTTS } from '../../hooks/useTTS';
+
+const HIGHLIGHT_CLASS = 'a11y-tts-target';
+
+/**
+ * Controller invisível que conecta o `ttsMode` do store ao DOM:
+ * - `click-to-read`: registra um listener global de clique. Ao clicar
+ *   em qualquer elemento (exceto o próprio widget), lê seu texto.
+ * - `read-selection`: lê o texto atualmente selecionado quando o store
+ *   sinaliza (via `pendingReadSelection`). UI/atalho disparam isso.
+ *
+ * Aplica a classe `.a11y-tts-target` no elemento sendo lido para
+ * destaque visual; remove ao terminar/parar.
+ */
+export default function TTSController() {
+  const ttsMode = useAccessibilityStore((s) => s.ttsMode);
+  const ttsStatus = useAccessibilityStore((s) => s.ttsStatus);
+  const { speak, stop, isSupported } = useTTS();
+
+  // Click-to-read: ouve cliques globais enquanto o modo está ativo
+  useEffect(() => {
+    if (!isSupported || ttsMode !== 'click-to-read') return;
+
+    const handler = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+
+      // Ignora cliques dentro do próprio widget
+      if (target.closest('.a11y-widget-shield')) return;
+
+      const text = extractReadableText(target);
+      if (!text) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      // Limpa highlight anterior e marca o novo alvo
+      document
+        .querySelectorAll(`.${HIGHLIGHT_CLASS}`)
+        .forEach((el) => el.classList.remove(HIGHLIGHT_CLASS));
+      target.classList.add(HIGHLIGHT_CLASS);
+
+      speak(text);
+    };
+
+    // capture: true → pegamos o clique antes do handler do app/link
+    document.addEventListener('click', handler, true);
+    return () => {
+      document.removeEventListener('click', handler, true);
+      document
+        .querySelectorAll(`.${HIGHLIGHT_CLASS}`)
+        .forEach((el) => el.classList.remove(HIGHLIGHT_CLASS));
+    };
+  }, [isSupported, ttsMode, speak]);
+
+  // Quando a fala termina (ttsStatus volta a 'idle'), limpa highlight
+  useEffect(() => {
+    if (ttsStatus === 'idle') {
+      document
+        .querySelectorAll(`.${HIGHLIGHT_CLASS}`)
+        .forEach((el) => el.classList.remove(HIGHLIGHT_CLASS));
+    }
+  }, [ttsStatus]);
+
+  // Para qualquer fala em curso quando o componente desmonta
+  useEffect(() => () => stop(), [stop]);
+
+  return null;
+}
+
+/**
+ * Extrai texto legível do elemento clicado. Prioriza:
+ * 1. `aria-label` se presente
+ * 2. `title`
+ * 3. `innerText` truncado
+ *
+ * `innerText` (e não `textContent`) respeita estilos como `display: none`
+ * e quebras de linha visuais — leitura mais natural.
+ */
+const extractReadableText = (el: HTMLElement): string => {
+  const aria = el.getAttribute('aria-label')?.trim();
+  if (aria) return aria;
+  const title = el.getAttribute('title')?.trim();
+  if (title) return title;
+  const text = el.innerText?.trim() ?? '';
+  // Limita comprimento para evitar leitura infinita ao clicar em
+  // contêineres grandes (ex.: <main>). 600 chars ≈ 1min de fala.
+  return text.length > 600 ? `${text.slice(0, 600)}...` : text;
+};

--- a/src/components/AccessibilityWidget/TTSController.tsx
+++ b/src/components/AccessibilityWidget/TTSController.tsx
@@ -24,14 +24,17 @@ export default function TTSController() {
     if (!isSupported || ttsMode !== 'click-to-read') return;
 
     const handler = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (!target) return;
+      const initialTarget = event.target as HTMLElement | null;
+      if (!initialTarget) return;
 
       // Ignora cliques dentro do próprio widget
-      if (target.closest('.a11y-widget-shield')) return;
+      if (initialTarget.closest('.a11y-widget-shield')) return;
 
-      const text = extractReadableText(target);
-      if (!text) return;
+      // Sobe pela árvore até achar o ancestral que tem texto legível.
+      // Cobre o caso comum de IconButtons com `<svg>` interno: clicar no
+      // SVG não retorna texto, mas o botão pai tem aria-label.
+      const found = findReadableAncestor(initialTarget);
+      if (!found) return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -40,9 +43,9 @@ export default function TTSController() {
       document
         .querySelectorAll(`.${HIGHLIGHT_CLASS}`)
         .forEach((el) => el.classList.remove(HIGHLIGHT_CLASS));
-      target.classList.add(HIGHLIGHT_CLASS);
+      found.node.classList.add(HIGHLIGHT_CLASS);
 
-      speak(text);
+      speak(found.text);
     };
 
     // capture: true → pegamos o clique antes do handler do app/link
@@ -92,4 +95,27 @@ const extractReadableText = (el: HTMLElement): string => {
   // Limita comprimento para evitar leitura infinita ao clicar em
   // contêineres grandes (ex.: <main>). 600 chars ≈ 1min de fala.
   return text.length > 600 ? `${text.slice(0, 600)}...` : text;
+};
+
+/** Quantos níveis de ancestralidade subimos buscando um nó legível. */
+const MAX_ANCESTOR_LOOKUP = 8;
+
+/**
+ * Caminha pela árvore a partir do elemento clicado até achar o ancestral
+ * mais próximo que tenha texto legível (`aria-label`, `title` ou
+ * `innerText`). Limita a profundidade e nunca retorna o `<body>` para
+ * evitar ler a página inteira ao clicar em ícones soltos.
+ */
+const findReadableAncestor = (
+  start: HTMLElement
+): { node: HTMLElement; text: string } | null => {
+  let node: HTMLElement | null = start;
+  let depth = 0;
+  while (node && depth < MAX_ANCESTOR_LOOKUP && node !== document.body) {
+    const text = extractReadableText(node);
+    if (text) return { node, text };
+    node = node.parentElement;
+    depth++;
+  }
+  return null;
 };

--- a/src/components/AccessibilityWidget/TTSController.tsx
+++ b/src/components/AccessibilityWidget/TTSController.tsx
@@ -52,8 +52,12 @@ export default function TTSController() {
       document
         .querySelectorAll(`.${HIGHLIGHT_CLASS}`)
         .forEach((el) => el.classList.remove(HIGHLIGHT_CLASS));
+      // Interrompe qualquer fala em curso ao sair do modo. Sem isso,
+      // desligar o "Clique para ler" deixaria a leitura terminando
+      // sozinha, contrariando a expectativa do usuário.
+      stop();
     };
-  }, [isSupported, ttsMode, speak]);
+  }, [isSupported, ttsMode, speak, stop]);
 
   // Quando a fala termina (ttsStatus volta a 'idle'), limpa highlight
   useEffect(() => {

--- a/src/components/AccessibilityWidget/TTSSection.test.tsx
+++ b/src/components/AccessibilityWidget/TTSSection.test.tsx
@@ -93,10 +93,13 @@ describe('TTSSection', () => {
     ).toBeInTheDocument();
   });
 
-  it('lists the available voices in the picker', () => {
+  it('lists the available voices in the picker once opened', async () => {
     renderSection();
-    const select = screen.getByTestId('a11y-tts-voice-select');
-    expect(select).toBeInTheDocument();
+    const trigger = screen.getByTestId('a11y-tts-voice-select');
+    expect(trigger).toBeInTheDocument();
+
+    // Select da lib só monta os items quando aberto
+    await userEvent.click(trigger);
     expect(screen.getByText(/Voz pt-BR/)).toBeInTheDocument();
     expect(screen.getByText(/Voice en-US/)).toBeInTheDocument();
   });

--- a/src/components/AccessibilityWidget/TTSSection.test.tsx
+++ b/src/components/AccessibilityWidget/TTSSection.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import TTSSection from './TTSSection';
+import {
+  useAccessibilityStore,
+  DEFAULT_ACCESSIBILITY_PREFERENCES,
+} from '../../store/accessibilityStore';
+import type { TTSVoice } from './tts/types';
+
+// Stubs do useTTS — controlados por cada teste.
+let voices: TTSVoice[] = [];
+let isSupported = true;
+let hasPortugueseVoice = true;
+const speakMock = jest.fn();
+const pauseMock = jest.fn();
+const resumeMock = jest.fn();
+const stopMock = jest.fn();
+
+jest.mock('../../hooks/useTTS', () => ({
+  useTTS: () => ({
+    isSupported,
+    voices,
+    hasPortugueseVoice,
+    speak: speakMock,
+    pause: pauseMock,
+    resume: resumeMock,
+    stop: stopMock,
+  }),
+}));
+
+// Segmented stub que renderiza radios simples para testes determinísticos.
+const StubSegmented = <T extends string | number>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (v: T) => void;
+  ariaLabel: string;
+}) => (
+  <div role="radiogroup" aria-label={ariaLabel}>
+    {options.map((opt) => (
+      <button
+        key={String(opt.value)}
+        type="button"
+        role="radio"
+        aria-checked={opt.value === value}
+        onClick={() => onChange(opt.value)}
+      >
+        {opt.label}
+      </button>
+    ))}
+  </div>
+);
+
+const renderSection = () => render(<TTSSection Segmented={StubSegmented} />);
+
+describe('TTSSection', () => {
+  beforeEach(() => {
+    voices = [
+      { id: 'pt', name: 'Voz pt-BR', lang: 'pt-BR', isLocal: true },
+      { id: 'en', name: 'Voice en-US', lang: 'en-US', isLocal: true },
+    ];
+    isSupported = true;
+    hasPortugueseVoice = true;
+    speakMock.mockClear();
+    pauseMock.mockClear();
+    resumeMock.mockClear();
+    stopMock.mockClear();
+    useAccessibilityStore.setState({
+      ...DEFAULT_ACCESSIBILITY_PREFERENCES,
+      isPanelOpen: false,
+      ttsStatus: 'idle',
+    });
+  });
+
+  it('shows an unsupported message when the synth is not available', () => {
+    isSupported = false;
+    renderSection();
+    expect(
+      screen.getByText(/síntese de voz não está disponível/i)
+    ).toBeInTheDocument();
+  });
+
+  it('warns the user when no portuguese voice is found', () => {
+    hasPortugueseVoice = false;
+    renderSection();
+    expect(
+      screen.getByText(/nenhuma voz em português foi encontrada/i)
+    ).toBeInTheDocument();
+  });
+
+  it('lists the available voices in the picker', () => {
+    renderSection();
+    const select = screen.getByTestId('a11y-tts-voice-select');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText(/Voz pt-BR/)).toBeInTheDocument();
+    expect(screen.getByText(/Voice en-US/)).toBeInTheDocument();
+  });
+
+  it('updates ttsMode through the segmented control', async () => {
+    renderSection();
+    await userEvent.click(
+      screen.getByRole('radio', { name: 'Clique para ler' })
+    );
+    expect(useAccessibilityStore.getState().ttsMode).toBe('click-to-read');
+  });
+
+  it('updates rate via the rate segmented', async () => {
+    renderSection();
+    await userEvent.click(screen.getByRole('radio', { name: 'Rápido' }));
+    expect(useAccessibilityStore.getState().ttsRate).toBe(1.25);
+  });
+
+  it('reads the current selection when clicking "Ler seleção"', async () => {
+    // Mocka window.getSelection para devolver texto.
+    const originalGetSelection = globalThis.getSelection;
+    (globalThis as unknown as { getSelection: () => unknown }).getSelection =
+      () => ({ toString: () => 'trecho selecionado' });
+
+    renderSection();
+    await userEvent.click(screen.getByTestId('a11y-tts-read-selection'));
+    expect(speakMock).toHaveBeenCalledWith('trecho selecionado');
+
+    (
+      globalThis as unknown as { getSelection: typeof originalGetSelection }
+    ).getSelection = originalGetSelection;
+  });
+
+  it('does not call speak when no text is selected', async () => {
+    const originalGetSelection = globalThis.getSelection;
+    (globalThis as unknown as { getSelection: () => unknown }).getSelection =
+      () => ({ toString: () => '   ' });
+
+    renderSection();
+    await userEvent.click(screen.getByTestId('a11y-tts-read-selection'));
+    expect(speakMock).not.toHaveBeenCalled();
+
+    (
+      globalThis as unknown as { getSelection: typeof originalGetSelection }
+    ).getSelection = originalGetSelection;
+  });
+
+  it('shows pause and stop buttons while speaking', async () => {
+    useAccessibilityStore.setState({ ttsStatus: 'speaking' });
+    renderSection();
+    expect(screen.getByTestId('a11y-tts-pause')).toBeInTheDocument();
+    expect(screen.getByTestId('a11y-tts-stop')).toBeInTheDocument();
+    expect(screen.queryByTestId('a11y-tts-resume')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('a11y-tts-pause'));
+    expect(pauseMock).toHaveBeenCalled();
+
+    await userEvent.click(screen.getByTestId('a11y-tts-stop'));
+    expect(stopMock).toHaveBeenCalled();
+  });
+
+  it('shows resume button while paused', async () => {
+    useAccessibilityStore.setState({ ttsStatus: 'paused' });
+    renderSection();
+    expect(screen.getByTestId('a11y-tts-resume')).toBeInTheDocument();
+    expect(screen.queryByTestId('a11y-tts-pause')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('a11y-tts-resume'));
+    expect(resumeMock).toHaveBeenCalled();
+  });
+});

--- a/src/components/AccessibilityWidget/TTSSection.tsx
+++ b/src/components/AccessibilityWidget/TTSSection.tsx
@@ -1,0 +1,191 @@
+import { useMemo, type ReactElement } from 'react';
+import {
+  PauseIcon,
+  PlayIcon,
+  SpeakerHighIcon,
+  StopIcon,
+} from '@phosphor-icons/react';
+import Button from '../Button/Button';
+import Text from '../Text/Text';
+import { cn } from '../../utils/utils';
+import { useAccessibilityStore } from '../../store/accessibilityStore';
+import { useTTS } from '../../hooks/useTTS';
+
+const TTS_SEGMENTED: { value: 'off' | 'click-to-read'; label: string }[] = [
+  { value: 'off', label: 'Desligado' },
+  { value: 'click-to-read', label: 'Clique para ler' },
+];
+
+const RATE_OPTIONS = [
+  { value: '0.75', label: 'Lento' },
+  { value: '1', label: 'Normal' },
+  { value: '1.25', label: 'Rápido' },
+  { value: '1.5', label: 'Muito rápido' },
+];
+
+export interface TTSSectionProps {
+  /** Reaproveita o componente de segmented do painel principal */
+  Segmented: <T extends string | number>(props: {
+    value: T;
+    options: { value: T; label: string }[];
+    ariaLabel: string;
+    onChange: (value: T) => void;
+  }) => ReactElement;
+}
+
+/**
+ * Bloco de controles do leitor de texto dentro do painel.
+ * Exibe estado da síntese, seletor de voz, velocidade e botões
+ * de play/pause/stop conforme o status atual.
+ */
+export default function TTSSection({ Segmented }: Readonly<TTSSectionProps>) {
+  const ttsMode = useAccessibilityStore((s) => s.ttsMode);
+  const ttsStatus = useAccessibilityStore((s) => s.ttsStatus);
+  const ttsRate = useAccessibilityStore((s) => s.ttsRate);
+  const ttsVoiceId = useAccessibilityStore((s) => s.ttsVoiceId);
+  const setTTSMode = useAccessibilityStore((s) => s.setTTSMode);
+  const setTTSRate = useAccessibilityStore((s) => s.setTTSRate);
+  const setTTSVoiceId = useAccessibilityStore((s) => s.setTTSVoiceId);
+
+  const {
+    isSupported,
+    voices,
+    hasPortugueseVoice,
+    speak,
+    pause,
+    resume,
+    stop,
+  } = useTTS();
+
+  // Preferimos vozes em português; demais ficam ao final.
+  const sortedVoices = useMemo(() => {
+    return [...voices].sort((a, b) => {
+      const aPt = a.lang.toLowerCase().startsWith('pt') ? 0 : 1;
+      const bPt = b.lang.toLowerCase().startsWith('pt') ? 0 : 1;
+      if (aPt !== bPt) return aPt - bPt;
+      return a.name.localeCompare(b.name);
+    });
+  }, [voices]);
+
+  if (!isSupported) {
+    return (
+      <Text size="2xs" className="text-text-600">
+        Síntese de voz não está disponível neste navegador.
+      </Text>
+    );
+  }
+
+  const handleReadSelection = () => {
+    const selection = globalThis.getSelection?.()?.toString().trim();
+    if (selection) speak(selection);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Segmented
+        ariaLabel="Modo do leitor de texto"
+        value={ttsMode === 'read-selection' ? 'off' : ttsMode}
+        options={TTS_SEGMENTED}
+        onChange={(v) => setTTSMode(v as 'off' | 'click-to-read')}
+      />
+
+      {!hasPortugueseVoice && (
+        <Text size="2xs" className="text-warning-700">
+          Nenhuma voz em português foi encontrada no seu sistema. A leitura será
+          feita com a voz padrão disponível.
+        </Text>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <Text size="2xs" className="text-text-700">
+          Voz
+        </Text>
+        <select
+          value={ttsVoiceId ?? ''}
+          onChange={(e) => setTTSVoiceId(e.target.value || null)}
+          aria-label="Voz da síntese de fala"
+          data-testid="a11y-tts-voice-select"
+          className={cn(
+            'w-full rounded-md border border-background-300 bg-background',
+            'px-2 py-1.5 text-sm text-text-900',
+            'focus:outline-none focus:ring-2 focus:ring-info-500'
+          )}
+        >
+          <option value="">Padrão do navegador</option>
+          {sortedVoices.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.name} — {v.lang}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Text size="2xs" className="text-text-700">
+          Velocidade
+        </Text>
+        <Segmented
+          ariaLabel="Velocidade da fala"
+          value={String(ttsRate)}
+          options={RATE_OPTIONS}
+          onChange={(v) => setTTSRate(Number(v))}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          action="secondary"
+          size="small"
+          iconLeft={
+            <SpeakerHighIcon size={14} weight="bold" aria-hidden="true" />
+          }
+          onClick={handleReadSelection}
+          data-testid="a11y-tts-read-selection"
+        >
+          Ler seleção
+        </Button>
+
+        {ttsStatus === 'speaking' && (
+          <Button
+            variant="outline"
+            action="secondary"
+            size="small"
+            iconLeft={<PauseIcon size={14} weight="bold" aria-hidden="true" />}
+            onClick={pause}
+            data-testid="a11y-tts-pause"
+          >
+            Pausar
+          </Button>
+        )}
+
+        {ttsStatus === 'paused' && (
+          <Button
+            variant="outline"
+            action="secondary"
+            size="small"
+            iconLeft={<PlayIcon size={14} weight="bold" aria-hidden="true" />}
+            onClick={resume}
+            data-testid="a11y-tts-resume"
+          >
+            Retomar
+          </Button>
+        )}
+
+        {ttsStatus !== 'idle' && (
+          <Button
+            variant="outline"
+            action="negative"
+            size="small"
+            iconLeft={<StopIcon size={14} weight="bold" aria-hidden="true" />}
+            onClick={stop}
+            data-testid="a11y-tts-stop"
+            className="ml-auto"
+          >
+            Parar
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AccessibilityWidget/TTSSection.tsx
+++ b/src/components/AccessibilityWidget/TTSSection.tsx
@@ -86,7 +86,7 @@ export default function TTSSection({ Segmented }: Readonly<TTSSectionProps>) {
         ariaLabel="Modo do leitor de texto"
         value={ttsMode === 'read-selection' ? 'off' : ttsMode}
         options={TTS_SEGMENTED}
-        onChange={(v) => setTTSMode(v as 'off' | 'click-to-read')}
+        onChange={setTTSMode}
       />
 
       {!hasPortugueseVoice && (

--- a/src/components/AccessibilityWidget/TTSSection.tsx
+++ b/src/components/AccessibilityWidget/TTSSection.tsx
@@ -7,7 +7,12 @@ import {
 } from '@phosphor-icons/react';
 import Button from '../Button/Button';
 import Text from '../Text/Text';
-import { cn } from '../../utils/utils';
+import Select, {
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '../Select/Select';
 import { useAccessibilityStore } from '../../store/accessibilityStore';
 import { useTTS } from '../../hooks/useTTS';
 
@@ -96,29 +101,27 @@ export default function TTSSection({ Segmented }: Readonly<TTSSectionProps>) {
         </Text>
       )}
 
-      <div className="flex flex-col gap-1">
-        <Text size="2xs" className="text-text-700">
-          Voz
-        </Text>
-        <select
-          value={ttsVoiceId ?? ''}
-          onChange={(e) => setTTSVoiceId(e.target.value || null)}
+      <Select
+        label="Voz"
+        size="small"
+        value={ttsVoiceId ?? ''}
+        onValueChange={(value) => setTTSVoiceId(value || null)}
+      >
+        <SelectTrigger
           aria-label="Voz da síntese de fala"
           data-testid="a11y-tts-voice-select"
-          className={cn(
-            'w-full rounded-md border border-background-300 bg-background',
-            'px-2 py-1.5 text-sm text-text-900',
-            'focus:outline-none focus:ring-2 focus:ring-info-500'
-          )}
         >
-          <option value="">Padrão do navegador</option>
+          <SelectValue placeholder="Padrão do navegador" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="">Padrão do navegador</SelectItem>
           {sortedVoices.map((v) => (
-            <option key={v.id} value={v.id}>
+            <SelectItem key={v.id} value={v.id}>
               {v.name} — {v.lang}
-            </option>
+            </SelectItem>
           ))}
-        </select>
-      </div>
+        </SelectContent>
+      </Select>
 
       <div className="flex flex-col gap-1">
         <Text size="2xs" className="text-text-700">

--- a/src/components/AccessibilityWidget/accessibility.css
+++ b/src/components/AccessibilityWidget/accessibility.css
@@ -169,6 +169,20 @@ html.a11y-dyslexia-font body * {
     sans-serif !important;
 }
 
+/* ---------- Destaque do elemento sendo lido (TTS) ----------
+ *
+ * Aplicado pelo TTSController enquanto o texto do elemento está sendo
+ * falado pelo leitor. Outline em amarelo para alta visibilidade,
+ * combinando com o destaque de links já usado pelo widget.
+ */
+
+.a11y-tts-target {
+  outline: 3px solid #facc15 !important;
+  outline-offset: 2px !important;
+  background-color: rgba(255, 235, 59, 0.18) !important;
+  transition: outline-color 100ms ease;
+}
+
 /* ---------- Cursor aumentado ----------
  *
  * Cursor SVG inline (32x32) com seta + contorno preto para alto contraste.

--- a/src/components/AccessibilityWidget/index.ts
+++ b/src/components/AccessibilityWidget/index.ts
@@ -12,3 +12,12 @@ export type { AccessibilityPanelProps } from './AccessibilityPanel';
 
 export { default as ReadingAid } from './ReadingAid';
 export { default as ColorBlindFilters } from './ColorBlindFilters';
+export { default as TTSController } from './TTSController';
+
+export { WebSpeechProvider } from './tts/WebSpeechProvider';
+export type {
+  TTSProvider,
+  TTSVoice,
+  TTSSpeakOptions,
+  TTSProviderEvents,
+} from './tts/types';

--- a/src/components/AccessibilityWidget/tts/WebSpeechProvider.test.ts
+++ b/src/components/AccessibilityWidget/tts/WebSpeechProvider.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable no-undef -- mesma limitação do source: tipos DOM
+   (SpeechSynthesis, SpeechSynthesisVoice) só são vistos pelo TS. */
+import { WebSpeechProvider } from './WebSpeechProvider';
+
+class MockUtterance {
+  text: string;
+  rate = 1;
+  pitch = 1;
+  lang = '';
+  voice: SpeechSynthesisVoice | null = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onpause: (() => void) | null = null;
+  onresume: (() => void) | null = null;
+  onerror: ((e: { error: string }) => void) | null = null;
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+const buildSynth = (
+  voices: Partial<SpeechSynthesisVoice>[] = []
+): SpeechSynthesis => {
+  const listeners: Record<string, ((e: Event) => void)[]> = {};
+  return {
+    speak: jest.fn((utterance: MockUtterance) => {
+      // Simula start/end imediatos
+      utterance.onstart?.();
+      utterance.onend?.();
+    }),
+    cancel: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    getVoices: () => voices as SpeechSynthesisVoice[],
+    addEventListener: (type: string, fn: (e: Event) => void) => {
+      listeners[type] = [...(listeners[type] ?? []), fn];
+    },
+    removeEventListener: (type: string, fn: (e: Event) => void) => {
+      listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+    },
+    speaking: false,
+    paused: false,
+    pending: false,
+    onvoiceschanged: null,
+    dispatchEvent: () => true,
+  } as unknown as SpeechSynthesis;
+};
+
+describe('WebSpeechProvider', () => {
+  let originalUtterance: typeof globalThis.SpeechSynthesisUtterance;
+
+  beforeAll(() => {
+    originalUtterance = globalThis.SpeechSynthesisUtterance;
+    (
+      globalThis as unknown as { SpeechSynthesisUtterance: unknown }
+    ).SpeechSynthesisUtterance = MockUtterance;
+  });
+
+  afterAll(() => {
+    (
+      globalThis as unknown as { SpeechSynthesisUtterance: unknown }
+    ).SpeechSynthesisUtterance = originalUtterance;
+  });
+
+  it('reports unsupported when synth is not available', () => {
+    const provider = new WebSpeechProvider(null);
+    expect(provider.isSupported()).toBe(false);
+  });
+
+  it('reports supported when synth is available', () => {
+    const provider = new WebSpeechProvider(buildSynth());
+    expect(provider.isSupported()).toBe(true);
+  });
+
+  it('returns the list of voices from the synth', async () => {
+    const provider = new WebSpeechProvider(
+      buildSynth([
+        {
+          voiceURI: 'v1',
+          name: 'Voz pt-BR',
+          lang: 'pt-BR',
+          localService: true,
+        },
+        {
+          voiceURI: 'v2',
+          name: 'Voice en-US',
+          lang: 'en-US',
+          localService: false,
+        },
+      ])
+    );
+    const voices = await provider.getVoices();
+    expect(voices).toEqual([
+      { id: 'v1', name: 'Voz pt-BR', lang: 'pt-BR', isLocal: true },
+      { id: 'v2', name: 'Voice en-US', lang: 'en-US', isLocal: false },
+    ]);
+  });
+
+  it('cancels current speech and starts a new utterance with options', () => {
+    const synth = buildSynth([
+      { voiceURI: 'v1', name: 'Voz pt-BR', lang: 'pt-BR', localService: true },
+    ]);
+    const provider = new WebSpeechProvider(synth);
+    const onStart = jest.fn();
+    const onEnd = jest.fn();
+
+    provider.speak('olá', { rate: 1.5, voiceId: 'v1' }, { onStart, onEnd });
+
+    expect(synth.cancel).toHaveBeenCalled();
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+    const utterance = (synth.speak as jest.Mock).mock.calls[0][0];
+    expect(utterance.text).toBe('olá');
+    expect(utterance.rate).toBe(1.5);
+    expect(onStart).toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalled();
+  });
+
+  it('skips empty text', () => {
+    const synth = buildSynth();
+    const provider = new WebSpeechProvider(synth);
+    provider.speak('   ');
+    expect(synth.speak).not.toHaveBeenCalled();
+  });
+
+  it('forwards pause/resume/stop to the synth', () => {
+    const synth = buildSynth();
+    const provider = new WebSpeechProvider(synth);
+    provider.pause();
+    provider.resume();
+    provider.stop();
+    expect(synth.pause).toHaveBeenCalled();
+    expect(synth.resume).toHaveBeenCalled();
+    expect(synth.cancel).toHaveBeenCalled();
+  });
+
+  it('reports error via onError when synth is missing', () => {
+    const provider = new WebSpeechProvider(null);
+    const onError = jest.fn();
+    provider.speak('olá', undefined, { onError });
+    expect(onError).toHaveBeenCalledWith(expect.any(String));
+  });
+});

--- a/src/components/AccessibilityWidget/tts/WebSpeechProvider.ts
+++ b/src/components/AccessibilityWidget/tts/WebSpeechProvider.ts
@@ -20,7 +20,7 @@ import type {
  *   exibir um aviso quando `getVoices()` não retornar voz nesse idioma.
  */
 export class WebSpeechProvider implements TTSProvider {
-  private synth: SpeechSynthesis | null;
+  private readonly synth: SpeechSynthesis | null;
   private currentUtterance: SpeechSynthesisUtterance | null = null;
 
   constructor(synth: SpeechSynthesis | null = getSynth()) {

--- a/src/components/AccessibilityWidget/tts/WebSpeechProvider.ts
+++ b/src/components/AccessibilityWidget/tts/WebSpeechProvider.ts
@@ -1,0 +1,139 @@
+/* eslint-disable no-undef -- DOM lib types (SpeechSynthesis, SpeechSynthesisVoice)
+   são reconhecidas pelo TypeScript mas não pelo `globals.browser` do ESLint. */
+import type {
+  TTSProvider,
+  TTSProviderEvents,
+  TTSSpeakOptions,
+  TTSVoice,
+} from './types';
+
+/**
+ * Provider default usando a Web Speech API (`window.speechSynthesis`).
+ *
+ * Notas de compatibilidade:
+ * - Disponível em Chrome, Edge, Firefox, Safari e iOS, mas a qualidade
+ *   das vozes varia muito por SO.
+ * - Em Safari/iOS, `getVoices()` é assíncrono — voltamos vazio na
+ *   primeira chamada e populamos no evento `voiceschanged`. O método
+ *   `getVoices()` deste provider já trata isso retornando uma `Promise`.
+ * - Em alguns SOs não há voz pt-BR pré-instalada — chamadores devem
+ *   exibir um aviso quando `getVoices()` não retornar voz nesse idioma.
+ */
+export class WebSpeechProvider implements TTSProvider {
+  private synth: SpeechSynthesis | null;
+  private currentUtterance: SpeechSynthesisUtterance | null = null;
+
+  constructor(synth: SpeechSynthesis | null = getSynth()) {
+    this.synth = synth;
+  }
+
+  isSupported(): boolean {
+    return this.synth !== null;
+  }
+
+  async getVoices(): Promise<TTSVoice[]> {
+    if (!this.synth) return [];
+
+    const synth = this.synth;
+    const collect = (): TTSVoice[] =>
+      synth.getVoices().map((v) => ({
+        id: v.voiceURI,
+        name: v.name,
+        lang: v.lang,
+        isLocal: v.localService,
+      }));
+
+    const initial = collect();
+    if (initial.length > 0) return initial;
+
+    // Safari/iOS: vozes carregam de forma assíncrona via 'voiceschanged'.
+    return new Promise<TTSVoice[]>((resolve) => {
+      const onChange = () => {
+        synth.removeEventListener('voiceschanged', onChange);
+        resolve(collect());
+      };
+      synth.addEventListener('voiceschanged', onChange);
+      // Fallback: timeout para ambientes que nunca disparam o evento.
+      setTimeout(() => {
+        synth.removeEventListener('voiceschanged', onChange);
+        resolve(collect());
+      }, 1500);
+    });
+  }
+
+  speak(
+    text: string,
+    options: TTSSpeakOptions = {},
+    events: TTSProviderEvents = {}
+  ): void {
+    if (!this.synth) {
+      events.onError?.('Síntese de voz não disponível neste navegador.');
+      return;
+    }
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    // Cancela qualquer fala em andamento (evita fila acumulando).
+    this.synth.cancel();
+
+    const utterance = new SpeechSynthesisUtterance(trimmed);
+    utterance.rate = options.rate ?? 1;
+    utterance.pitch = options.pitch ?? 1;
+
+    // Resolução de voz/idioma:
+    // 1. Se o usuário escolheu uma voz, usa ela e o `lang` dela
+    //    (para evitar mismatch — voz en-US com utterance.lang='pt-BR'
+    //    causa silêncio em alguns browsers).
+    // 2. Se não escolheu mas pediu um lang específico via options,
+    //    procuramos uma voz que cubra esse lang. Se não houver,
+    //    deixamos `lang` em branco para o browser usar a voz default.
+    const allVoices = this.synth.getVoices();
+    let chosenVoice: SpeechSynthesisVoice | undefined;
+    if (options.voiceId) {
+      chosenVoice = allVoices.find((v) => v.voiceURI === options.voiceId);
+    } else if (options.lang) {
+      chosenVoice = allVoices.find((v) =>
+        v.lang.toLowerCase().startsWith(options.lang!.toLowerCase())
+      );
+    }
+    if (chosenVoice) {
+      utterance.voice = chosenVoice;
+      utterance.lang = chosenVoice.lang;
+    }
+
+    utterance.onstart = () => events.onStart?.();
+    utterance.onend = () => {
+      this.currentUtterance = null;
+      events.onEnd?.();
+    };
+    utterance.onpause = () => events.onPause?.();
+    utterance.onresume = () => events.onResume?.();
+    utterance.onerror = (event) => {
+      this.currentUtterance = null;
+      events.onError?.(event.error || 'Erro desconhecido na síntese.');
+    };
+
+    this.currentUtterance = utterance;
+    this.synth.speak(utterance);
+  }
+
+  pause(): void {
+    this.synth?.pause();
+  }
+
+  resume(): void {
+    this.synth?.resume();
+  }
+
+  stop(): void {
+    this.synth?.cancel();
+    this.currentUtterance = null;
+  }
+}
+
+const getSynth = (): SpeechSynthesis | null => {
+  if (typeof globalThis === 'undefined') return null;
+  const synth = (globalThis as unknown as { speechSynthesis?: SpeechSynthesis })
+    .speechSynthesis;
+  return synth ?? null;
+};

--- a/src/components/AccessibilityWidget/tts/types.ts
+++ b/src/components/AccessibilityWidget/tts/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Voz disponível no provider de TTS.
+ */
+export interface TTSVoice {
+  /** Identificador único (ex.: voiceURI no caso da Web Speech API) */
+  id: string;
+  /** Nome amigável da voz (ex.: "Google português do Brasil") */
+  name: string;
+  /** Tag BCP47 do idioma (ex.: "pt-BR") */
+  lang: string;
+  /** Indica se a síntese roda 100% local (sem chamada de rede) */
+  isLocal: boolean;
+}
+
+export interface TTSSpeakOptions {
+  /** Voz a ser usada — se omitida, o provider escolhe (preferindo pt-BR) */
+  voiceId?: string;
+  /** Taxa de fala (1 = padrão, 0.5 = lento, 2 = rápido) */
+  rate?: number;
+  /** Tom (1 = padrão) */
+  pitch?: number;
+  /** Idioma alvo do trecho (BCP47) — usado quando a voz não cobre o idioma */
+  lang?: string;
+}
+
+export interface TTSProviderEvents {
+  onStart?: () => void;
+  onEnd?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
+  onError?: (message: string) => void;
+}
+
+/**
+ * Contrato do provider de Text-to-Speech. A lib fornece um
+ * `WebSpeechProvider` default; plataformas podem injetar um provider
+ * remoto (ex.: backend com Azure/Google) sem mudar a UI.
+ */
+export interface TTSProvider {
+  /** Indica se o provider funciona neste ambiente (ex.: API disponível). */
+  isSupported(): boolean;
+  /** Retorna a lista de vozes que o provider expõe. */
+  getVoices(): Promise<TTSVoice[]>;
+  /** Inicia a fala do texto informado. Cancela qualquer fala em andamento. */
+  speak(
+    text: string,
+    options?: TTSSpeakOptions,
+    events?: TTSProviderEvents
+  ): void;
+  /** Pausa a fala atual (se suportado). */
+  pause(): void;
+  /** Continua a fala pausada. */
+  resume(): void;
+  /** Interrompe e descarta qualquer fala em curso. */
+  stop(): void;
+}

--- a/src/hooks/useA11yPreferences.ts
+++ b/src/hooks/useA11yPreferences.ts
@@ -125,6 +125,9 @@ export const useA11yPreferences = () => {
   const readingAid = useAccessibilityStore((s) => s.readingAid);
   const keyboardShortcut = useAccessibilityStore((s) => s.keyboardShortcut);
   const colorBlindMode = useAccessibilityStore((s) => s.colorBlindMode);
+  const ttsMode = useAccessibilityStore((s) => s.ttsMode);
+  const ttsRate = useAccessibilityStore((s) => s.ttsRate);
+  const ttsVoiceId = useAccessibilityStore((s) => s.ttsVoiceId);
 
   useEffect(() => {
     syncDom({
@@ -140,6 +143,9 @@ export const useA11yPreferences = () => {
       readingAid,
       keyboardShortcut,
       colorBlindMode,
+      ttsMode,
+      ttsRate,
+      ttsVoiceId,
     });
   }, [
     contrastMode,

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -1,0 +1,120 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTTS } from './useTTS';
+import {
+  useAccessibilityStore,
+  DEFAULT_ACCESSIBILITY_PREFERENCES,
+} from '../store/accessibilityStore';
+import type { TTSProvider } from '../components/AccessibilityWidget/tts/types';
+
+const buildProvider = (overrides: Partial<TTSProvider> = {}): TTSProvider => ({
+  isSupported: () => true,
+  getVoices: async () => [
+    { id: 'pt', name: 'Voz pt-BR', lang: 'pt-BR', isLocal: true },
+    { id: 'en', name: 'Voice en-US', lang: 'en-US', isLocal: true },
+  ],
+  speak: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  stop: jest.fn(),
+  ...overrides,
+});
+
+describe('useTTS', () => {
+  beforeEach(() => {
+    useAccessibilityStore.setState({
+      ...DEFAULT_ACCESSIBILITY_PREFERENCES,
+      isPanelOpen: false,
+      ttsStatus: 'idle',
+    });
+  });
+
+  it('reports support and exposes voices from the provider', async () => {
+    const provider = buildProvider();
+    const { result } = renderHook(() => useTTS(provider));
+
+    await waitFor(() => {
+      expect(result.current.voices.length).toBe(2);
+    });
+
+    expect(result.current.isSupported).toBe(true);
+    expect(result.current.hasPortugueseVoice).toBe(true);
+  });
+
+  it('flags absence of portuguese voice', async () => {
+    const provider = buildProvider({
+      getVoices: async () => [
+        { id: 'en', name: 'Voice en-US', lang: 'en-US', isLocal: true },
+      ],
+    });
+    const { result } = renderHook(() => useTTS(provider));
+    await waitFor(() => {
+      expect(result.current.voices.length).toBe(1);
+    });
+    expect(result.current.hasPortugueseVoice).toBe(false);
+  });
+
+  it('forwards rate and voiceId from the store on speak', async () => {
+    const speak = jest.fn();
+    const provider = buildProvider({ speak });
+    const { result } = renderHook(() => useTTS(provider));
+
+    act(() => {
+      useAccessibilityStore.getState().setTTSRate(1.5);
+      useAccessibilityStore.getState().setTTSVoiceId('pt');
+    });
+
+    act(() => {
+      result.current.speak('olá mundo');
+    });
+
+    expect(speak).toHaveBeenCalledTimes(1);
+    const [, options] = speak.mock.calls[0];
+    expect(options.rate).toBe(1.5);
+    expect(options.voiceId).toBe('pt');
+    // O hook não força mais `lang` — quem manda é a voz escolhida.
+    // Forçar lang fixo causa silêncio em sistemas sem voz pt-BR.
+    expect(options.lang).toBeUndefined();
+  });
+
+  it('updates ttsStatus on provider events', async () => {
+    let onStartFn: (() => void) | undefined;
+    let onEndFn: (() => void) | undefined;
+    const provider = buildProvider({
+      speak: (_text, _opts, events) => {
+        onStartFn = events?.onStart;
+        onEndFn = events?.onEnd;
+      },
+    });
+    const { result } = renderHook(() => useTTS(provider));
+
+    act(() => {
+      result.current.speak('olá');
+    });
+    act(() => {
+      onStartFn?.();
+    });
+    expect(useAccessibilityStore.getState().ttsStatus).toBe('speaking');
+
+    act(() => {
+      onEndFn?.();
+    });
+    expect(useAccessibilityStore.getState().ttsStatus).toBe('idle');
+  });
+
+  it('pause/resume/stop update store status and call provider', async () => {
+    const provider = buildProvider();
+    const { result } = renderHook(() => useTTS(provider));
+
+    act(() => result.current.pause());
+    expect(useAccessibilityStore.getState().ttsStatus).toBe('paused');
+    expect(provider.pause).toHaveBeenCalled();
+
+    act(() => result.current.resume());
+    expect(useAccessibilityStore.getState().ttsStatus).toBe('speaking');
+    expect(provider.resume).toHaveBeenCalled();
+
+    act(() => result.current.stop());
+    expect(useAccessibilityStore.getState().ttsStatus).toBe('idle');
+    expect(provider.stop).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTTS.test.ts
+++ b/src/hooks/useTTS.test.ts
@@ -101,6 +101,24 @@ describe('useTTS', () => {
     expect(useAccessibilityStore.getState().ttsStatus).toBe('idle');
   });
 
+  it('does not call provider.stop on unmount when this instance never spoke', () => {
+    const provider = buildProvider();
+    const { unmount } = renderHook(() => useTTS(provider));
+    unmount();
+    expect(provider.stop).not.toHaveBeenCalled();
+  });
+
+  it('stops on unmount only when this instance was the active speaker', () => {
+    const provider = buildProvider();
+    const { result, unmount } = renderHook(() => useTTS(provider));
+
+    act(() => {
+      result.current.speak('olá');
+    });
+    unmount();
+    expect(provider.stop).toHaveBeenCalled();
+  });
+
   it('pause/resume/stop update store status and call provider', async () => {
     const provider = buildProvider();
     const { result } = renderHook(() => useTTS(provider));

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAccessibilityStore } from '../store/accessibilityStore';
+import { WebSpeechProvider } from '../components/AccessibilityWidget/tts/WebSpeechProvider';
+import type {
+  TTSProvider,
+  TTSVoice,
+} from '../components/AccessibilityWidget/tts/types';
+
+export interface UseTTSReturn {
+  /** Indica se a síntese de voz está disponível neste navegador */
+  isSupported: boolean;
+  /** Vozes carregadas do provider (resolvidas após o primeiro mount) */
+  voices: TTSVoice[];
+  /**
+   * Indica se há ao menos uma voz pt-BR/pt disponível. Útil para
+   * mostrar aviso quando o usuário do SO não tem vozes em português.
+   */
+  hasPortugueseVoice: boolean;
+  /** Lê o texto informado, respeitando rate/voiceId do store. */
+  speak: (text: string) => void;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+}
+
+/**
+ * Hook que liga o `TTSProvider` (default: `WebSpeechProvider`) ao store
+ * de acessibilidade — propaga eventos do provider para `ttsStatus` e
+ * fornece comandos `speak/pause/resume/stop` que já aplicam as
+ * preferências persistidas (`ttsRate`, `ttsVoiceId`).
+ *
+ * Aceita um provider custom para casos de TTS via backend (Azure,
+ * Google etc.) sem alterar a UI.
+ */
+export const useTTS = (providerOverride?: TTSProvider | null): UseTTSReturn => {
+  const setTTSStatus = useAccessibilityStore((s) => s.setTTSStatus);
+  const ttsRate = useAccessibilityStore((s) => s.ttsRate);
+  const ttsVoiceId = useAccessibilityStore((s) => s.ttsVoiceId);
+
+  // Garante uma única instância do provider durante o ciclo de vida do hook.
+  const provider = useMemo<TTSProvider>(
+    () => providerOverride ?? new WebSpeechProvider(),
+    [providerOverride]
+  );
+
+  const [voices, setVoices] = useState<TTSVoice[]>([]);
+
+  // Mantemos as preferências em refs para que callbacks de eventos
+  // (onstart/onend) leiam sempre o valor mais recente sem precisar
+  // recriar o handler — evita resetar a fala quando o usuário ajusta
+  // a velocidade no painel.
+  const rateRef = useRef(ttsRate);
+  const voiceIdRef = useRef(ttsVoiceId);
+  rateRef.current = ttsRate;
+  voiceIdRef.current = ttsVoiceId;
+
+  useEffect(() => {
+    let mounted = true;
+    if (provider.isSupported()) {
+      provider
+        .getVoices()
+        .then((list) => {
+          if (mounted) setVoices(list);
+        })
+        .catch(() => undefined);
+    }
+    return () => {
+      mounted = false;
+      provider.stop();
+      setTTSStatus('idle');
+    };
+  }, [provider, setTTSStatus]);
+
+  const hasPortugueseVoice = voices.some((v) =>
+    v.lang.toLowerCase().startsWith('pt')
+  );
+
+  /**
+   * IMPORTANTE: as funções abaixo são memoizadas com `useCallback` porque
+   * são frequentemente passadas para `useEffect` deps em consumidores
+   * (TTSController, etc.). Sem memoização, as referências mudam a cada
+   * render e disparam cleanups indesejados — incluindo o `stop()` que
+   * cancela a fala recém-iniciada (sintoma: ícone de áudio acende na aba
+   * do browser mas você não ouve nada).
+   */
+  const speak = useCallback(
+    (text: string) => {
+      provider.speak(
+        text,
+        {
+          rate: rateRef.current,
+          voiceId: voiceIdRef.current ?? undefined,
+          // Não fixamos `lang: 'pt-BR'` aqui — em sistemas sem voz pt-BR
+          // instalada, o browser fica tentando achar uma e nunca emite
+          // áudio. O provider usa o `voice.lang` quando há voz escolhida.
+        },
+        {
+          onStart: () => setTTSStatus('speaking'),
+          onEnd: () => setTTSStatus('idle'),
+          onPause: () => setTTSStatus('paused'),
+          onResume: () => setTTSStatus('speaking'),
+          onError: () => setTTSStatus('idle'),
+        }
+      );
+    },
+    [provider, setTTSStatus]
+  );
+
+  const pause = useCallback(() => {
+    provider.pause();
+    setTTSStatus('paused');
+  }, [provider, setTTSStatus]);
+
+  const resume = useCallback(() => {
+    provider.resume();
+    setTTSStatus('speaking');
+  }, [provider, setTTSStatus]);
+
+  const stop = useCallback(() => {
+    provider.stop();
+    setTTSStatus('idle');
+  }, [provider, setTTSStatus]);
+
+  return {
+    isSupported: provider.isSupported(),
+    voices,
+    hasPortugueseVoice,
+    speak,
+    pause,
+    resume,
+    stop,
+  };
+};

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -54,6 +54,19 @@ export const useTTS = (providerOverride?: TTSProvider | null): UseTTSReturn => {
   rateRef.current = ttsRate;
   voiceIdRef.current = ttsVoiceId;
 
+  /**
+   * Marca se ESTA instância de `useTTS` foi quem iniciou a fala atual.
+   *
+   * Necessário porque vários componentes podem chamar `useTTS()`
+   * independentemente (TTSController, TTSSection) e cada um cria seu
+   * próprio `WebSpeechProvider`, mas todos compartilham o mesmo
+   * `window.speechSynthesis` global. O `cancel()` é global — então,
+   * sem essa guarda, o cleanup de uma instância (ex.: TTSSection
+   * desmontando ao fechar o painel) cancelaria fala iniciada por outra
+   * (ex.: click-to-read em andamento no TTSController).
+   */
+  const isActiveSpeakerRef = useRef(false);
+
   useEffect(() => {
     let mounted = true;
     if (provider.isSupported()) {
@@ -66,8 +79,14 @@ export const useTTS = (providerOverride?: TTSProvider | null): UseTTSReturn => {
     }
     return () => {
       mounted = false;
-      provider.stop();
-      setTTSStatus('idle');
+      // Só interrompe a síntese se foi essa instância que a iniciou.
+      // Caso contrário, deixa o synth global em paz — outras instâncias
+      // podem estar usando.
+      if (isActiveSpeakerRef.current) {
+        provider.stop();
+        setTTSStatus('idle');
+        isActiveSpeakerRef.current = false;
+      }
     };
   }, [provider, setTTSStatus]);
 
@@ -85,6 +104,7 @@ export const useTTS = (providerOverride?: TTSProvider | null): UseTTSReturn => {
    */
   const speak = useCallback(
     (text: string) => {
+      isActiveSpeakerRef.current = true;
       provider.speak(
         text,
         {
@@ -96,10 +116,16 @@ export const useTTS = (providerOverride?: TTSProvider | null): UseTTSReturn => {
         },
         {
           onStart: () => setTTSStatus('speaking'),
-          onEnd: () => setTTSStatus('idle'),
+          onEnd: () => {
+            isActiveSpeakerRef.current = false;
+            setTTSStatus('idle');
+          },
           onPause: () => setTTSStatus('paused'),
           onResume: () => setTTSStatus('speaking'),
-          onError: () => setTTSStatus('idle'),
+          onError: () => {
+            isActiveSpeakerRef.current = false;
+            setTTSStatus('idle');
+          },
         }
       );
     },
@@ -117,6 +143,7 @@ export const useTTS = (providerOverride?: TTSProvider | null): UseTTSReturn => {
   }, [provider, setTTSStatus]);
 
   const stop = useCallback(() => {
+    isActiveSpeakerRef.current = false;
     provider.stop();
     setTTSStatus('idle');
   }, [provider, setTTSStatus]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1372,12 +1372,18 @@ export {
   AccessibilityPanel,
   ReadingAid,
   ColorBlindFilters,
+  TTSController,
+  WebSpeechProvider,
 } from './components/AccessibilityWidget';
 export type {
   AccessibilityWidgetProps,
   AccessibilityFabProps,
   AccessibilityFabPosition,
   AccessibilityPanelProps,
+  TTSProvider,
+  TTSVoice,
+  TTSSpeakOptions,
+  TTSProviderEvents,
 } from './components/AccessibilityWidget';
 
 // Accessibility Store + Hook
@@ -1398,9 +1404,13 @@ export type {
   FontSizeLevel,
   SpacingLevel,
   ReadingAid as ReadingAidMode,
+  TTSMode,
+  TTSStatus,
 } from './store/accessibilityStore';
 export { useA11yPreferences } from './hooks/useA11yPreferences';
 export { useA11yKeyboardShortcut } from './hooks/useA11yKeyboardShortcut';
+export { useTTS } from './hooks/useTTS';
+export type { UseTTSReturn } from './hooks/useTTS';
 
 // Forum Component
 export { Forum } from './components/Forum/Forum';

--- a/src/store/accessibilityStore.test.ts
+++ b/src/store/accessibilityStore.test.ts
@@ -28,7 +28,27 @@ describe('accessibilityStore', () => {
     expect(state.readingAid).toBe('none');
     expect(state.keyboardShortcut).toBe(true);
     expect(state.colorBlindMode).toBe(ColorBlindMode.None);
+    expect(state.ttsMode).toBe('off');
+    expect(state.ttsRate).toBe(1);
+    expect(state.ttsVoiceId).toBeNull();
+    expect(state.ttsStatus).toBe('idle');
     expect(state.isPanelOpen).toBe(false);
+  });
+
+  it('updates Phase 3 (TTS) preferences', () => {
+    const { setTTSMode, setTTSRate, setTTSVoiceId, setTTSStatus } =
+      useAccessibilityStore.getState();
+
+    setTTSMode('click-to-read');
+    setTTSRate(1.5);
+    setTTSVoiceId('voice-pt-br');
+    setTTSStatus('speaking');
+
+    const state = useAccessibilityStore.getState();
+    expect(state.ttsMode).toBe('click-to-read');
+    expect(state.ttsRate).toBe(1.5);
+    expect(state.ttsVoiceId).toBe('voice-pt-br');
+    expect(state.ttsStatus).toBe('speaking');
   });
 
   it('updates Phase 2 preferences', () => {

--- a/src/store/accessibilityStore.ts
+++ b/src/store/accessibilityStore.ts
@@ -20,6 +20,17 @@ export type SaturationMode = 'normal' | 'grayscale' | 'low';
 export type ReadingAid = 'none' | 'ruler' | 'mask';
 
 /**
+ * Modo do leitor de texto (TTS):
+ * - `off`: leitor desligado
+ * - `click-to-read`: usuário clica em um elemento e o widget lê o texto dele
+ * - `read-selection`: usuário pressiona "Ler seleção" para falar o texto selecionado
+ */
+export type TTSMode = 'off' | 'click-to-read' | 'read-selection';
+
+/** Status runtime da síntese de voz — não persistido. */
+export type TTSStatus = 'idle' | 'speaking' | 'paused';
+
+/**
  * Modos de daltonismo. Aplicam matrizes `<feColorMatrix>` (SVG) que
  * remapeiam cores para ajudar usuários com cada tipo de discromatopsia.
  *
@@ -80,11 +91,19 @@ export interface AccessibilityPreferences {
   keyboardShortcut: boolean;
   /** Modo de daltonismo aplicado (filtro SVG na página inteira) */
   colorBlindMode: ColorBlindMode;
+  /** Modo do leitor de texto (TTS) */
+  ttsMode: TTSMode;
+  /** Velocidade da fala (0.5 a 2.0) */
+  ttsRate: number;
+  /** Voz selecionada pelo usuário (id retornado pelo provider) ou null para padrão */
+  ttsVoiceId: string | null;
 }
 
 export interface AccessibilityState extends AccessibilityPreferences {
   /** Indica se o painel de acessibilidade está aberto */
   isPanelOpen: boolean;
+  /** Status runtime da síntese de voz — não persistido */
+  ttsStatus: TTSStatus;
 }
 
 export interface AccessibilityActions {
@@ -100,6 +119,10 @@ export interface AccessibilityActions {
   setReadingAid: (mode: ReadingAid) => void;
   setKeyboardShortcut: (value: boolean) => void;
   setColorBlindMode: (mode: ColorBlindMode) => void;
+  setTTSMode: (mode: TTSMode) => void;
+  setTTSRate: (rate: number) => void;
+  setTTSVoiceId: (id: string | null) => void;
+  setTTSStatus: (status: TTSStatus) => void;
   /** Restaura todas as preferências para o estado padrão */
   resetPreferences: () => void;
   openPanel: () => void;
@@ -122,6 +145,9 @@ export const DEFAULT_ACCESSIBILITY_PREFERENCES: AccessibilityPreferences = {
   readingAid: 'none',
   keyboardShortcut: true,
   colorBlindMode: ColorBlindMode.None,
+  ttsMode: 'off',
+  ttsRate: 1,
+  ttsVoiceId: null,
 };
 
 /**
@@ -135,6 +161,7 @@ export const useAccessibilityStore = create<AccessibilityStore>()(
       (set) => ({
         ...DEFAULT_ACCESSIBILITY_PREFERENCES,
         isPanelOpen: false,
+        ttsStatus: 'idle',
 
         setContrastMode: (contrastMode) => set({ contrastMode }),
         setSaturationMode: (saturationMode) => set({ saturationMode }),
@@ -148,6 +175,10 @@ export const useAccessibilityStore = create<AccessibilityStore>()(
         setReadingAid: (readingAid) => set({ readingAid }),
         setKeyboardShortcut: (keyboardShortcut) => set({ keyboardShortcut }),
         setColorBlindMode: (colorBlindMode) => set({ colorBlindMode }),
+        setTTSMode: (ttsMode) => set({ ttsMode }),
+        setTTSRate: (ttsRate) => set({ ttsRate }),
+        setTTSVoiceId: (ttsVoiceId) => set({ ttsVoiceId }),
+        setTTSStatus: (ttsStatus) => set({ ttsStatus }),
 
         resetPreferences: () => set({ ...DEFAULT_ACCESSIBILITY_PREFERENCES }),
 
@@ -171,6 +202,10 @@ export const useAccessibilityStore = create<AccessibilityStore>()(
           readingAid: state.readingAid,
           keyboardShortcut: state.keyboardShortcut,
           colorBlindMode: state.colorBlindMode,
+          ttsRate: state.ttsRate,
+          ttsVoiceId: state.ttsVoiceId,
+          // ttsMode NÃO é persistido: o leitor sempre começa desligado
+          // ao recarregar a página para evitar comportamento confuso
         }),
       }
     ),

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -198,6 +198,7 @@ export default defineConfig({
     'hooks/useA11yPreferences/index': 'src/hooks/useA11yPreferences.ts',
     'hooks/useA11yKeyboardShortcut/index':
       'src/hooks/useA11yKeyboardShortcut.ts',
+    'hooks/useTTS/index': 'src/hooks/useTTS.ts',
 
     // Styles
     styles: 'src/styles.css',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full text-to-speech controls to the Accessibility Widget: voice selection, speed control, play/pause/stop, “click-to-read”, and “read selection”
  * Visual highlight indicates the element currently being read

* **Tests**
  * Added comprehensive test suites covering TTS provider, hook, controller, section, and color-blind filters

* **Chores**
  * Package version bumped to 1.3.95
<!-- end of auto-generated comment: release notes by coderabbit.ai -->