### PR TITLE
AE-2589: add title to recommended lessons models and fix success toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.3.98",
+  "version": "1.3.99",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ActivityCreate/ActivityCreate.test.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.test.tsx
@@ -1675,6 +1675,18 @@ describe('CreateActivity', () => {
         // POST should not be called after first save
         expect(mockApiClient.post).not.toHaveBeenCalled();
       });
+
+      // Success toast confirms the save to the user
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith({
+          title: 'Modelo salvo com sucesso',
+          description:
+            'O modelo da atividade está disponível para reutilização.',
+          variant: 'solid',
+          action: 'success',
+          position: 'top-right',
+        });
+      });
     });
 
     it('should close the save model modal without saving when canceled', async () => {

--- a/src/components/ActivityCreate/ActivityCreate.test.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.test.tsx
@@ -1735,6 +1735,38 @@ describe('CreateActivity', () => {
       expect(mockApiClient.post).not.toHaveBeenCalled();
     });
 
+    it('should not emit success toast when save is skipped by validateSaveConditions', async () => {
+      // No questions added → validateSaveConditions returns false → save skipped.
+      // Even though confirm fires, no PATCH/POST happens and the success toast
+      // must not be emitted.
+      mockApiClient.post = jest.fn();
+      mockApiClient.patch = jest.fn();
+
+      render(<CreateActivity {...defaultProps} />);
+
+      fireEvent.click(screen.getByText('Salvar modelo'));
+      expect(screen.getByTestId('save-model-modal')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      // No network call happened
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+
+      // No success toast fired (the modal-action toast we'd see is success;
+      // any other prior toasts are unrelated to this confirm flow)
+      const successToastCalls = mockAddToast.mock.calls.filter(
+        ([payload]) =>
+          (payload as { action?: string })?.action === 'success' &&
+          (payload as { title?: string })?.title === 'Modelo salvo com sucesso'
+      );
+      expect(successToastCalls).toHaveLength(0);
+    });
+
     it('should show saving message when isSaving is true', () => {
       render(<CreateActivity {...defaultProps} />);
 

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -770,12 +770,22 @@ const CreateActivity = ({
       setIsSavingModel(true);
       try {
         setIsSaveModelModalOpen(false);
-        await saveDraft(ActivityType.MODELO, title);
+        const savedId = await saveDraft(ActivityType.MODELO, title);
+        if (savedId) {
+          addToast({
+            title: 'Modelo salvo com sucesso',
+            description:
+              'O modelo da atividade está disponível para reutilização.',
+            variant: 'solid',
+            action: 'success',
+            position: 'top-right',
+          });
+        }
       } finally {
         setIsSavingModel(false);
       }
     },
-    [saveDraft]
+    [saveDraft, addToast]
   );
 
   /**

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -670,7 +670,11 @@ const CreateActivity = ({
    * Save draft to backend
    * @param typeOverride - Override the activity type for this save
    * @param customTitle - Optional user-provided title; falls back to auto-generated when empty
-   * @returns The draft ID (existing or newly created), or undefined if save failed
+   * @returns The persisted draft ID (existing or newly created) on success.
+   *   Returns undefined when no persistence happened — either because the save
+   *   failed or because validateSaveConditions skipped it. Callers triggering
+   *   an explicit override (e.g. "save as MODELO") rely on this to gate
+   *   success feedback so they don't show a toast for a save that never ran.
    */
   const saveDraft = useCallback(
     async (
@@ -678,7 +682,8 @@ const CreateActivity = ({
       customTitle?: string
     ): Promise<string | undefined> => {
       if (!validateSaveConditions()) {
-        return draftId || undefined;
+        // For explicit override flows, skipped saves must not signal success.
+        return typeOverride ? undefined : draftId || undefined;
       }
 
       setIsSaving(true);

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.test.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.test.tsx
@@ -815,6 +815,38 @@ describe('RecommendedLessonCreate', () => {
       expect(mockApiClient.post).not.toHaveBeenCalled();
       expect(mockApiClient.patch).not.toHaveBeenCalled();
     });
+
+    it('should not emit success toast when save is skipped by validateSaveConditions', async () => {
+      // No lessons added → validateSaveConditions returns false → save skipped.
+      // Even though confirm fires, no PATCH/POST happens and the success toast
+      // must not be emitted.
+      await renderWithDesktopLayout(
+        <RecommendedLessonCreate {...defaultProps} />
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-model-btn'));
+      });
+      expect(screen.getByTestId('save-model-modal')).toBeInTheDocument();
+
+      jest.clearAllMocks();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
+      });
+
+      // No network call happened
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
+
+      // No success toast fired
+      const successToastCalls = mockAddToast.mock.calls.filter(
+        ([payload]) =>
+          (payload as { action?: string })?.action === 'success' &&
+          (payload as { title?: string })?.title === 'Modelo salvo com sucesso'
+      );
+      expect(successToastCalls).toHaveLength(0);
+    });
   });
 
   describe('send lesson modal', () => {

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.test.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.test.tsx
@@ -73,6 +73,33 @@ jest.mock('../..', () => ({
   CategoryConfig: {},
   useToastStore: (selector: (state: { addToast: jest.Mock }) => unknown) =>
     selector({ addToast: mockAddToast }),
+  SaveActivityModelModal: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    isLoading,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (title: string) => void;
+    isLoading?: boolean;
+  }) =>
+    isOpen ? (
+      <div data-testid="save-model-modal">
+        <button data-testid="save-model-modal-close" onClick={onClose}>
+          Cancel
+        </button>
+        <button
+          data-testid="save-model-modal-confirm"
+          onClick={() => onConfirm('Modelo Customizado')}
+        >
+          Confirm
+        </button>
+        <div data-testid="save-model-modal-loading">
+          {isLoading ? 'Loading' : 'Not Loading'}
+        </div>
+      </div>
+    ) : null,
   SendLessonModal: ({
     isOpen,
     onClose,
@@ -449,7 +476,7 @@ describe('RecommendedLessonCreate', () => {
   const renderWithDesktopLayout = async (
     ui: React.ReactElement
   ): Promise<ReturnType<typeof render>> => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       writable: true,
       configurable: true,
       value: 1400,
@@ -458,7 +485,7 @@ describe('RecommendedLessonCreate', () => {
     let result: ReturnType<typeof render>;
     await act(async () => {
       result = render(ui);
-      window.dispatchEvent(new Event('resize'));
+      globalThis.dispatchEvent(new Event('resize'));
     });
 
     return result!;
@@ -473,7 +500,7 @@ describe('RecommendedLessonCreate', () => {
     mockSearchParams.delete('id');
 
     // Set desktop width by default
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       writable: true,
       configurable: true,
       value: 1400,
@@ -754,7 +781,7 @@ describe('RecommendedLessonCreate', () => {
   });
 
   describe('save model', () => {
-    it('should change draft type to MODELO when save model is clicked', async () => {
+    it('should open the save model modal when save model is clicked', async () => {
       await renderWithDesktopLayout(
         <RecommendedLessonCreate {...defaultProps} />
       );
@@ -764,9 +791,29 @@ describe('RecommendedLessonCreate', () => {
         fireEvent.click(saveModelBtn);
       });
 
-      // The draft type change is internal state
-      // We can verify it was triggered by checking no errors occurred
-      expect(saveModelBtn).toBeInTheDocument();
+      // Clicking only opens the modal — no API call until the user confirms
+      expect(screen.getByTestId('save-model-modal')).toBeInTheDocument();
+    });
+
+    it('should close the save model modal without saving when canceled', async () => {
+      await renderWithDesktopLayout(
+        <RecommendedLessonCreate {...defaultProps} />
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-model-btn'));
+      });
+      expect(screen.getByTestId('save-model-modal')).toBeInTheDocument();
+
+      jest.clearAllMocks();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-model-modal-close'));
+      });
+
+      expect(screen.queryByTestId('save-model-modal')).not.toBeInTheDocument();
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+      expect(mockApiClient.patch).not.toHaveBeenCalled();
     });
   });
 
@@ -1020,7 +1067,7 @@ describe('RecommendedLessonCreate', () => {
     });
 
     it('should render small screen layout when width <= 1200', async () => {
-      Object.defineProperty(window, 'innerWidth', {
+      Object.defineProperty(globalThis, 'innerWidth', {
         writable: true,
         configurable: true,
         value: 1000,
@@ -1028,7 +1075,7 @@ describe('RecommendedLessonCreate', () => {
 
       await act(async () => {
         render(<RecommendedLessonCreate {...defaultProps} />);
-        window.dispatchEvent(new Event('resize'));
+        globalThis.dispatchEvent(new Event('resize'));
       });
 
       // Small screen layout should show menu
@@ -1279,34 +1326,30 @@ describe('RecommendedLessonCreate', () => {
     it('should save as MODELO type when save model is clicked', async () => {
       mockAppliedFilters = { subjectIds: ['subject-1'] };
 
-      // First POST creates draft
+      // First POST creates draft (shape consumed by extractDraftFromResponse)
       (mockApiClient.post as jest.Mock).mockResolvedValueOnce({
         data: {
           data: {
-            draft: {
-              id: 'draft-1',
-              type: RecommendedClassDraftType.RASCUNHO,
-              title: 'Test Draft',
-              subjectId: 'subject-1',
-              filters: {},
-              updatedAt: '2024-01-15T10:00:00Z',
-            },
+            id: 'draft-1',
+            type: RecommendedClassDraftType.RASCUNHO,
+            title: 'Test Draft',
+            subjectId: 'subject-1',
+            filters: {},
+            updatedAt: '2024-01-15T10:00:00Z',
           },
         },
       });
 
-      // Second POST/PATCH saves as MODELO
+      // PATCH saves as MODELO with the user-provided custom title
       (mockApiClient.patch as jest.Mock).mockResolvedValue({
         data: {
           data: {
-            draft: {
-              id: 'draft-1',
-              type: RecommendedClassDraftType.MODELO,
-              title: 'Modelo - Math',
-              subjectId: 'subject-1',
-              filters: {},
-              updatedAt: '2024-01-15T10:05:00Z',
-            },
+            id: 'draft-1',
+            type: RecommendedClassDraftType.MODELO,
+            title: 'Modelo Customizado',
+            subjectId: 'subject-1',
+            filters: {},
+            updatedAt: '2024-01-15T10:05:00Z',
           },
         },
       });
@@ -1321,24 +1364,50 @@ describe('RecommendedLessonCreate', () => {
         fireEvent.click(addLessonBtn);
       });
 
-      // Wait for first save
+      // Wait for first save (POST creates the RASCUNHO draft) — needs to
+      // fully settle so draftId state is populated before triggering MODELO save
       await act(async () => {
         jest.advanceTimersByTime(600);
       });
+      await waitFor(() => {
+        expect(mockApiClient.post).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('is-saving')).toHaveTextContent('idle');
+      });
 
-      // Click save model
+      // Click save model — opens the modal
       const saveModelBtn = screen.getByTestId('save-model-btn');
       await act(async () => {
         fireEvent.click(saveModelBtn);
       });
 
-      // Should trigger save with MODELO type
+      // Confirm the modal — sends the user-provided title to the backend
       await act(async () => {
-        jest.advanceTimersByTime(100);
+        fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
       });
 
-      // Verify the save was attempted
-      expect(saveModelBtn).toBeInTheDocument();
+      // Backend received the user-provided custom title and MODELO type
+      await waitFor(() => {
+        expect(mockApiClient.patch).toHaveBeenCalledWith(
+          expect.stringContaining('/recommended-class/drafts/'),
+          expect.objectContaining({
+            type: RecommendedClassDraftType.MODELO,
+            title: 'Modelo Customizado',
+          })
+        );
+      });
+
+      // Success toast confirms the save to the user
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith({
+          title: 'Modelo salvo com sucesso',
+          description: 'O modelo da aula está disponível para reutilização.',
+          variant: 'solid',
+          action: 'success',
+          position: 'top-right',
+        });
+      });
     });
 
     it('should call onSaveModel callback when saving as MODELO', async () => {
@@ -1404,10 +1473,15 @@ describe('RecommendedLessonCreate', () => {
         expect(screen.getByTestId('save-model-btn')).toBeInTheDocument();
       });
 
-      // Click save model
+      // Click save model — opens the modal
       const saveModelBtn = screen.getByTestId('save-model-btn');
       await act(async () => {
         fireEvent.click(saveModelBtn);
+      });
+
+      // Confirm the modal
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-model-modal-confirm'));
       });
 
       // Wait for save
@@ -1817,7 +1891,7 @@ describe('RecommendedLessonCreate', () => {
     const renderWithSmallScreen = async (
       ui: React.ReactElement
     ): Promise<ReturnType<typeof render>> => {
-      Object.defineProperty(window, 'innerWidth', {
+      Object.defineProperty(globalThis, 'innerWidth', {
         writable: true,
         configurable: true,
         value: 1000,
@@ -1826,7 +1900,7 @@ describe('RecommendedLessonCreate', () => {
       let result: ReturnType<typeof render>;
       await act(async () => {
         result = render(ui);
-        window.dispatchEvent(new Event('resize'));
+        globalThis.dispatchEvent(new Event('resize'));
       });
 
       return result!;
@@ -2202,12 +2276,7 @@ describe('RecommendedLessonCreate', () => {
         LessonPreview: ({
           onEditActivity,
         }: {
-          lessons: unknown[];
-          onRemoveAll: () => void;
-          onRemoveLesson: (id: string) => void;
-          onReorder: (lessons: unknown[]) => void;
           onEditActivity?: (activity: { id?: string; type?: string }) => void;
-          onCreateNewActivity?: () => void;
         }) => (
           <div data-testid="lesson-preview">
             <span data-testid="lessons-count">0</span>

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
@@ -7,6 +7,7 @@ import {
   CategoryConfig,
   useToastStore,
   SendLessonModal,
+  SaveActivityModelModal,
 } from '../..';
 import type { ActivityModelTableItem } from '../../types/activitiesHistory';
 import { ActivityType } from '../ActivityCreate/ActivityCreate.types';
@@ -141,6 +142,8 @@ const RecommendedLessonCreate = ({
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isSendModalOpen, setIsSendModalOpen] = useState(false);
+  const [isSaveModelModalOpen, setIsSaveModelModalOpen] = useState(false);
+  const [isSavingModel, setIsSavingModel] = useState(false);
   const [categories, setCategories] = useState<CategoryConfig[]>([]);
   const [isSendingLesson, setIsSendingLesson] = useState(false);
   const hasFirstSaveBeenDone = useRef(false);
@@ -759,65 +762,128 @@ const RecommendedLessonCreate = ({
 
   /**
    * Save draft to backend
+   * @param typeOverride - Override the draft type for this save
+   * @param customTitle - Optional user-provided title; falls back to auto-generated when empty
+   * @returns The draft ID (existing or newly created), or undefined if save failed
    */
-  const saveDraft = useCallback(async () => {
-    if (!validateSaveConditions()) {
-      return;
-    }
-
-    setIsSaving(true);
-
-    try {
-      const payload = createDraftPayload();
-
-      if (draftId) {
-        await updateExistingDraft(payload);
-        return;
+  const saveDraft = useCallback(
+    async (
+      typeOverride?: RecommendedClassDraftType,
+      customTitle?: string
+    ): Promise<string | undefined> => {
+      if (!validateSaveConditions()) {
+        return draftId || undefined;
       }
 
-      const response = await apiClient.post<RecommendedLessonDraftResponse>(
-        '/recommended-class/drafts',
-        payload
-      );
-      hasFirstSaveBeenDone.current = true;
+      setIsSaving(true);
 
-      const savedDraft = extractDraftFromResponse(response);
-      updateStateAfterSave(savedDraft, response?.data, true);
-    } catch (error) {
-      console.error('Error saving draft:', error);
+      try {
+        let payload = createDraftPayload();
 
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : 'Ocorreu um erro ao salvar o rascunho. Tente novamente.';
+        // Override type if provided
+        if (typeOverride) {
+          const subjectId = appliedFilters?.subjectIds?.[0];
+          if (!subjectId) {
+            throw new Error('Subject ID não encontrado');
+          }
+          const trimmedCustomTitle = customTitle?.trim();
+          const title =
+            trimmedCustomTitle && trimmedCustomTitle.length > 0
+              ? trimmedCustomTitle
+              : generateTitle(typeOverride, subjectId, knowledgeAreas, lessons);
+          payload = {
+            ...payload,
+            type: typeOverride,
+            title,
+          };
+        }
 
-      addToast({
-        title: 'Erro ao salvar rascunho',
-        description: errorMessage,
-        variant: 'solid',
-        action: 'warning',
-        position: 'top-right',
-      });
-    } finally {
-      setIsSaving(false);
-    }
-  }, [
-    validateSaveConditions,
-    createDraftPayload,
-    draftId,
-    updateExistingDraft,
-    apiClient,
-    extractDraftFromResponse,
-    updateStateAfterSave,
-    addToast,
-  ]);
+        if (draftId) {
+          await updateExistingDraft(payload);
+          return draftId;
+        }
+
+        const response = await apiClient.post<RecommendedLessonDraftResponse>(
+          '/recommended-class/drafts',
+          payload
+        );
+        hasFirstSaveBeenDone.current = true;
+
+        const savedDraft = extractDraftFromResponse(response);
+        updateStateAfterSave(savedDraft, response?.data, true);
+        return savedDraft.id;
+      } catch (error) {
+        console.error('Error saving draft:', error);
+
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Ocorreu um erro ao salvar o rascunho. Tente novamente.';
+
+        addToast({
+          title: 'Erro ao salvar rascunho',
+          description: errorMessage,
+          variant: 'solid',
+          action: 'warning',
+          position: 'top-right',
+        });
+        return undefined;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [
+      validateSaveConditions,
+      createDraftPayload,
+      draftId,
+      updateExistingDraft,
+      apiClient,
+      extractDraftFromResponse,
+      updateStateAfterSave,
+      addToast,
+      appliedFilters,
+      knowledgeAreas,
+      lessons,
+    ]
+  );
 
   /**
-   * Handle save model button click
+   * Open the "save as model" modal so the user can provide a custom title
    */
-  const handleSaveModel = useCallback(async () => {
-    setDraftType(RecommendedClassDraftType.MODELO);
+  const handleSaveModel = useCallback(() => {
+    setIsSaveModelModalOpen(true);
   }, []);
+
+  /**
+   * Persist the draft as MODELO using the title provided by the user.
+   * draftType is updated by the save helpers (updateExistingDraft /
+   * updateStateAfterSave) only after the backend confirms the save, keeping
+   * UI state consistent with persisted state on failure.
+   */
+  const handleConfirmSaveModel = useCallback(
+    async (title: string) => {
+      setIsSavingModel(true);
+      try {
+        setIsSaveModelModalOpen(false);
+        const savedId = await saveDraft(
+          RecommendedClassDraftType.MODELO,
+          title
+        );
+        if (savedId) {
+          addToast({
+            title: 'Modelo salvo com sucesso',
+            description: 'O modelo da aula está disponível para reutilização.',
+            variant: 'solid',
+            action: 'success',
+            position: 'top-right',
+          });
+        }
+      } finally {
+        setIsSavingModel(false);
+      }
+    },
+    [saveDraft, addToast]
+  );
 
   /**
    * Load initial lessons
@@ -922,21 +988,6 @@ const RecommendedLessonCreate = ({
       }
     };
   }, [lessons, appliedFilters, draftType, loadingInitialLessons]);
-
-  /**
-   * Save immediately when draftType changes to MODELO
-   */
-  useEffect(() => {
-    if (
-      draftType === RecommendedClassDraftType.MODELO &&
-      hasFirstSaveBeenDone.current
-    ) {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current);
-      }
-      saveDraftRef.current();
-    }
-  }, [draftType]);
 
   /**
    * Handle adding a lesson to the recommended lesson
@@ -1343,6 +1394,14 @@ const RecommendedLessonCreate = ({
           </div>
         </div>
       )}
+
+      {/* Save Lesson Model Modal */}
+      <SaveActivityModelModal
+        isOpen={isSaveModelModalOpen}
+        onClose={() => setIsSaveModelModalOpen(false)}
+        onConfirm={handleConfirmSaveModel}
+        isLoading={isSavingModel}
+      />
 
       {/* Send Lesson Modal */}
       <SendLessonModal

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
@@ -764,7 +764,11 @@ const RecommendedLessonCreate = ({
    * Save draft to backend
    * @param typeOverride - Override the draft type for this save
    * @param customTitle - Optional user-provided title; falls back to auto-generated when empty
-   * @returns The draft ID (existing or newly created), or undefined if save failed
+   * @returns The persisted draft ID (existing or newly created) on success.
+   *   Returns undefined when no persistence happened — either because the save
+   *   failed or because validateSaveConditions skipped it. Callers triggering
+   *   an explicit override (e.g. "save as MODELO") rely on this to gate
+   *   success feedback so they don't show a toast for a save that never ran.
    */
   const saveDraft = useCallback(
     async (
@@ -772,7 +776,8 @@ const RecommendedLessonCreate = ({
       customTitle?: string
     ): Promise<string | undefined> => {
       if (!validateSaveConditions()) {
-        return draftId || undefined;
+        // For explicit override flows, skipped saves must not signal success.
+        return typeOverride ? undefined : draftId || undefined;
       }
 
       setIsSaving(true);

--- a/src/components/SaveActivityModelModal/SaveActivityModelModal.tsx
+++ b/src/components/SaveActivityModelModal/SaveActivityModelModal.tsx
@@ -22,8 +22,9 @@ export interface SaveActivityModelModalProps {
 }
 
 /**
- * Modal that prompts the user for the activity model title before saving it
- * as a reusable template (ActivityType.MODELO).
+ * Modal that prompts the user for a model title before saving as a reusable
+ * template. Generic — used both by ActivityCreate (ActivityType.MODELO) and
+ * RecommendedLessonCreate (RecommendedClassDraftType.MODELO) flows.
  *
  * Validates the title locally with the same constraints as the backend schema
  * (1–255 characters after trimming).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added modal dialog to save activities as reusable models with custom titles.
  * Added success toast confirmation when models are saved.

* **Tests**
  * Enhanced test coverage for model-saving workflows and modal interactions.

* **Chores**
  * Bumped package version to 1.3.99.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->