### PR TITLE
fix(Select): properly sync controlled `value` prop to internal store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -8,7 +8,7 @@ import Select, {
   getLabelAsNode,
   createSelectStore,
 } from './Select';
-import { ComponentProps } from 'react';
+import { ComponentProps, ReactElement } from 'react';
 
 describe('Select component', () => {
   const setup = (props?: Partial<ComponentProps<typeof Select>>) => {
@@ -1187,5 +1187,73 @@ describe('SelectItem selection behavior', () => {
     await userEvent.click(screen.getByRole('button'));
     await userEvent.click(screen.getByText('Option 2'));
     expect(onValueChange).toHaveBeenCalledWith('option2');
+  });
+});
+
+describe('Select controlled value sync', () => {
+  const renderControlled = (value: string | undefined) =>
+    render(
+      <Select value={value}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick something" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="option1">Option 1</SelectItem>
+          <SelectItem value="option2">Option 2</SelectItem>
+          <SelectItem value="option3">Option 3</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+  const rerenderControlled = (
+    rerender: (ui: ReactElement) => void,
+    value: string | undefined
+  ) =>
+    rerender(
+      <Select value={value}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick something" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="option1">Option 1</SelectItem>
+          <SelectItem value="option2">Option 2</SelectItem>
+          <SelectItem value="option3">Option 3</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+  it('should display the label matching the initial controlled value', () => {
+    renderControlled('option2');
+    expect(screen.getByRole('button')).toHaveTextContent('Option 2');
+  });
+
+  it('should update the displayed label when the controlled value changes', () => {
+    const { rerender } = renderControlled('option1');
+    expect(screen.getByRole('button')).toHaveTextContent('Option 1');
+
+    rerenderControlled(rerender, 'option3');
+    expect(screen.getByRole('button')).toHaveTextContent('Option 3');
+  });
+
+  it('should fall back to placeholder when controlled value becomes empty string', () => {
+    const { rerender } = renderControlled('option2');
+    expect(screen.getByRole('button')).toHaveTextContent('Option 2');
+
+    rerenderControlled(rerender, '');
+    expect(screen.getByRole('button')).toHaveTextContent('Pick something');
+  });
+
+  it('should clear an internally selected label when parent resets value to empty', async () => {
+    // Simulates the cascade scenario: parent programmatically resets the
+    // field after the user already clicked something (e.g. react-hook-form
+    // resetField triggered by a sibling field changing).
+    const { rerender } = renderControlled('option1');
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByText('Option 2'));
+    expect(screen.getByRole('button')).toHaveTextContent('Option 2');
+
+    rerenderControlled(rerender, '');
+    expect(screen.getByRole('button')).toHaveTextContent('Pick something');
   });
 });

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1243,6 +1243,14 @@ describe('Select controlled value sync', () => {
     expect(screen.getByRole('button')).toHaveTextContent('Pick something');
   });
 
+  it('should fall back to placeholder when controlled value has no matching SelectItem', () => {
+    const { rerender } = renderControlled('option1');
+    expect(screen.getByRole('button')).toHaveTextContent('Option 1');
+
+    rerenderControlled(rerender, 'value-with-no-matching-item');
+    expect(screen.getByRole('button')).toHaveTextContent('Pick something');
+  });
+
   it('should clear an internally selected label when parent resets value to empty', async () => {
     // Simulates the cascade scenario: parent programmatically resets the
     // field after the user already clicked something (e.g. react-hook-form

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -287,13 +287,11 @@ const Select = ({
     // Skip when the consumer isn't using controlled mode
     if (propValue === undefined) return;
     setValue(propValue);
-    // Empty string means "no selection" — clear label so placeholder shows
-    if (propValue === '') {
-      store.setState({ selectedLabel: '' });
-      return;
-    }
+    // Resolve the label for the new value; if it can't be resolved (empty
+    // value, or a value with no matching SelectItem), clear the stale label
+    // so the placeholder takes over.
     const label = findLabelForValue(children, propValue);
-    if (label) store.setState({ selectedLabel: label });
+    store.setState({ selectedLabel: label ?? '' });
   }, [propValue, children]);
 
   const sizeClasses = SIZE_CLASSES[size];

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -284,12 +284,17 @@ const Select = ({
   }, [open, selectId, setOpen]);
 
   useEffect(() => {
-    if (propValue) {
-      setValue(propValue);
-      const label = findLabelForValue(children, propValue);
-      if (label) store.setState({ selectedLabel: label });
+    // Skip when the consumer isn't using controlled mode
+    if (propValue === undefined) return;
+    setValue(propValue);
+    // Empty string means "no selection" — clear label so placeholder shows
+    if (propValue === '') {
+      store.setState({ selectedLabel: '' });
+      return;
     }
-  }, [propValue]);
+    const label = findLabelForValue(children, propValue);
+    if (label) store.setState({ selectedLabel: label });
+  }, [propValue, children]);
 
   const sizeClasses = SIZE_CLASSES[size];
 

--- a/src/store/modulesStore.test.ts
+++ b/src/store/modulesStore.test.ts
@@ -417,7 +417,12 @@ describe('ModulesStore', () => {
         data: {
           data: {
             featureFlags: {
-              version: { simulator: false, essay: false, forum: false, support: false },
+              version: {
+                simulator: false,
+                essay: false,
+                forum: false,
+                support: false,
+              },
             },
           },
         },
@@ -445,7 +450,12 @@ describe('ModulesStore', () => {
         data: {
           data: {
             featureFlags: {
-              version: { simulator: true, essay: true, forum: true, support: true },
+              version: {
+                simulator: true,
+                essay: true,
+                forum: true,
+                support: true,
+              },
             },
           },
         },


### PR DESCRIPTION
The controlled `value` prop was only partially honored: the existing
sync effect bailed when the value was falsy, so resetting to "" never
cleared the displayed label, and label changes weren't propagated when
the resolved label couldn't be found in children.

Now the effect:
- skips only when `value` is `undefined` (uncontrolled mode)
- clears both the stored value and `selectedLabel` when `value === ""`,
  letting the placeholder show again
- re-resolves the label when `children` change

Adds 4 tests covering: initial render, change between values, reset to
empty string, and external reset after an internal click.

Bumps version to 1.4.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.4.5

* **Bug Fixes**
  * Enhanced Select component's controlled mode to properly synchronize displayed label with value prop changes and display placeholder when value is cleared

* **Tests**
  * Added tests validating Select controlled value synchronization behavior, including label updates, placeholder fallback, and label clearing on parent reset
  * Reformatted test mock data for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->