### PR TITLE
AE-2614: add retry option when sending activities from recommended lessons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/SendLessonModal/SendLessonModal.test.tsx
+++ b/src/components/SendLessonModal/SendLessonModal.test.tsx
@@ -838,12 +838,18 @@ describe('SendLessonModal', () => {
     it('should render null for invalid step', () => {
       render(<SendLessonModal {...defaultProps} />);
 
-      // Force store to invalid step
-      const store = useSendLessonModalStore.getState();
-      store.goToStep(5);
+      // Bypass goToStep guard (it clamps to 1..3) by writing directly into
+      // the store, forcing the switch default branch in renderStepContent.
+      act(() => {
+        useSendLessonModalStore.setState({ currentStep: 5 });
+      });
 
-      // Re-render won't show any step content (but modal still shows)
+      // Modal chrome still renders, but no step-specific content is visible.
       expect(screen.getByText('Enviar aula recomendada')).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText('Digite o título da aula')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Iniciar em*')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/SendLessonModal/SendLessonModal.test.tsx
+++ b/src/components/SendLessonModal/SendLessonModal.test.tsx
@@ -425,6 +425,88 @@ describe('SendLessonModal', () => {
 
       expect(finalTimeInput).toHaveValue('18:45');
     });
+
+    it('should not render "Permitir refazer?" by default', () => {
+      expect(screen.queryByText('Permitir refazer?')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('step 3 - Retry option (when activities are attached)', () => {
+    const advanceToStep3 = () => {
+      const titleInput = screen.getByPlaceholderText('Digite o título da aula');
+      fireEvent.change(titleInput, { target: { value: 'Aula com atividade' } });
+      fireEvent.click(screen.getByText('Próximo')); // Step 1 -> 2
+      fireEvent.click(screen.getByText('Próximo')); // Step 2 -> 3
+    };
+
+    it('should render "Permitir refazer?" when hasAttachedActivities=true', () => {
+      render(
+        <SendLessonModal
+          {...defaultProps}
+          categories={mockCategoriesWithSelection}
+          hasAttachedActivities
+        />
+      );
+      advanceToStep3();
+      expect(screen.getByText('Permitir refazer?')).toBeInTheDocument();
+    });
+
+    it('should submit canRetry=true when "Sim" is selected', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      render(
+        <SendLessonModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          categories={mockCategoriesWithSelection}
+          hasAttachedActivities
+        />
+      );
+      advanceToStep3();
+
+      fireEvent.change(screen.getByTestId('start-datetime-input'), {
+        target: { value: '2025-01-20T10:00' },
+      });
+      fireEvent.change(screen.getByTestId('final-datetime-input'), {
+        target: { value: '2025-01-25T18:00' },
+      });
+
+      const yesRadio = screen.getByLabelText('Sim');
+      fireEvent.click(yesRadio);
+
+      fireEvent.click(screen.getByRole('button', { name: /Enviar aula/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+      expect(onSubmit.mock.calls[0][0]).toMatchObject({ canRetry: true });
+    });
+
+    it('should submit canRetry=false by default', async () => {
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+      render(
+        <SendLessonModal
+          {...defaultProps}
+          onSubmit={onSubmit}
+          categories={mockCategoriesWithSelection}
+          hasAttachedActivities
+        />
+      );
+      advanceToStep3();
+
+      fireEvent.change(screen.getByTestId('start-datetime-input'), {
+        target: { value: '2025-01-20T10:00' },
+      });
+      fireEvent.change(screen.getByTestId('final-datetime-input'), {
+        target: { value: '2025-01-25T18:00' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /Enviar aula/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+      expect(onSubmit.mock.calls[0][0]).toMatchObject({ canRetry: false });
+    });
   });
 
   describe('navigation', () => {
@@ -758,7 +840,7 @@ describe('SendLessonModal', () => {
 
       // Force store to invalid step
       const store = useSendLessonModalStore.getState();
-      store.goToStep(5 as unknown as number);
+      store.goToStep(5);
 
       // Re-render won't show any step content (but modal still shows)
       expect(screen.getByText('Enviar aula recomendada')).toBeInTheDocument();

--- a/src/components/SendLessonModal/SendLessonModal.tsx
+++ b/src/components/SendLessonModal/SendLessonModal.tsx
@@ -3,6 +3,8 @@ import Modal from '../Modal/Modal';
 import Stepper from '../Stepper/Stepper';
 import Input from '../Input/Input';
 import TextArea from '../TextArea/TextArea';
+import Text from '../Text/Text';
+import { RadioGroup, RadioGroupItem } from '../Radio/Radio';
 import { useSendLessonModalStore } from './hooks/useSendLessonModal';
 import {
   SendLessonModalProps,
@@ -51,6 +53,7 @@ const SendLessonModal = ({
   isLoading = false,
   onError,
   modalTitle: modalTitleProp,
+  hasAttachedActivities = false,
 }: SendLessonModalProps) => {
   const store = useSendLessonModalStore();
   const reset = useSendLessonModalStore((state) => state.reset);
@@ -129,6 +132,63 @@ const SendLessonModal = ({
   );
 
   /**
+   * Handle retry option change (only relevant when activities are attached)
+   */
+  const handleRetryChange = useCallback(
+    (value: string) => {
+      store.setFormData({ canRetry: value === 'yes' });
+    },
+    [store]
+  );
+
+  /**
+   * Render retry option for the deadline step.
+   * Only visible when the selected model has activity drafts attached —
+   * otherwise the radio would have no effect on backend state.
+   */
+  const renderRetryOption = () => {
+    if (!hasAttachedActivities) return null;
+
+    return (
+      <div>
+        <Text size="sm" weight="medium" color="text-text-700" className="mb-3">
+          Permitir refazer?
+        </Text>
+        <RadioGroup
+          value={store.formData.canRetry ? 'yes' : 'no'}
+          onValueChange={handleRetryChange}
+          className="flex flex-row gap-6"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="yes" id="send-lesson-retry-yes" />
+            <Text
+              as="label"
+              size="sm"
+              color="text-text-700"
+              className="cursor-pointer"
+              htmlFor="send-lesson-retry-yes"
+            >
+              Sim
+            </Text>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="no" id="send-lesson-retry-no" />
+            <Text
+              as="label"
+              size="sm"
+              color="text-text-700"
+              className="cursor-pointer"
+              htmlFor="send-lesson-retry-no"
+            >
+              Não
+            </Text>
+          </div>
+        </RadioGroup>
+      </div>
+    );
+  };
+
+  /**
    * Handle form submission
    */
   const handleSubmit = useCallback(async () => {
@@ -202,20 +262,23 @@ const SendLessonModal = ({
         );
       case 3:
         return (
-          <DeadlineStep
-            startDate={store.formData.startDate || ''}
-            startTime={store.formData.startTime || ''}
-            finalDate={store.formData.finalDate || ''}
-            finalTime={store.formData.finalTime || ''}
-            onStartDateChange={handleStartDateChange}
-            onStartTimeChange={handleStartTimeChange}
-            onFinalDateChange={handleFinalDateChange}
-            onFinalTimeChange={handleFinalTimeChange}
-            errors={{
-              startDate: store.errors.startDate,
-              finalDate: store.errors.finalDate,
-            }}
-          />
+          <div className="flex flex-col gap-6">
+            <DeadlineStep
+              startDate={store.formData.startDate || ''}
+              startTime={store.formData.startTime || ''}
+              finalDate={store.formData.finalDate || ''}
+              finalTime={store.formData.finalTime || ''}
+              onStartDateChange={handleStartDateChange}
+              onStartTimeChange={handleStartTimeChange}
+              onFinalDateChange={handleFinalDateChange}
+              onFinalTimeChange={handleFinalTimeChange}
+              errors={{
+                startDate: store.errors.startDate,
+                finalDate: store.errors.finalDate,
+              }}
+            />
+            {renderRetryOption()}
+          </div>
         );
       default:
         return null;

--- a/src/components/SendLessonModal/hooks/useSendLessonModal.ts
+++ b/src/components/SendLessonModal/hooks/useSendLessonModal.ts
@@ -45,6 +45,7 @@ const initialState = {
   formData: {
     startTime: '00:00',
     finalTime: '23:59',
+    canRetry: false,
   } as Partial<SendLessonFormData>,
   currentStep: 1,
   completedSteps: [] as number[],

--- a/src/components/SendLessonModal/types.ts
+++ b/src/components/SendLessonModal/types.ts
@@ -24,6 +24,9 @@ export interface SendLessonFormData {
   finalDate: string;
   /** End time in HH:MM format (Step 3) */
   finalTime: string;
+  /** Whether attached activities can be retried by the student.
+   *  Only relevant when the model has activity drafts attached. */
+  canRetry?: boolean;
 }
 
 /**
@@ -46,6 +49,10 @@ export interface SendLessonModalProps {
   onError?: (error: unknown) => void;
   /** Modal title for display */
   modalTitle?: string;
+  /** When true, render the "Permitir refazer?" radio on step 3.
+   *  Caller decides based on whether the selected model has any
+   *  activity drafts attached. Defaults to false (no radio shown). */
+  hasAttachedActivities?: boolean;
 }
 
 /**

--- a/src/hooks/useRecommendedClassModels.ts
+++ b/src/hooks/useRecommendedClassModels.ts
@@ -27,6 +27,19 @@ const recommendedClassModelResponseSchema = z.object({
   finalDate: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  // Activity drafts attached to this model. Kept in the schema so Zod
+  // preserves the field during validation — used to derive
+  // activityDraftsCount for the send-modal "Permitir refazer?" gate.
+  activityDrafts: z
+    .array(
+      z.object({
+        activityDraftId: z.string().uuid(),
+        sequence: z.number(),
+        title: z.string().nullable().optional(),
+      })
+    )
+    .optional()
+    .default([]),
 });
 
 /**

--- a/src/hooks/useRecommendedClassModels.ts
+++ b/src/hooks/useRecommendedClassModels.ts
@@ -92,6 +92,7 @@ export const transformRecommendedClassModelToTableItem = (
     savedAt: dayjs(model.createdAt).format('DD/MM/YYYY'),
     subject: subjectName,
     subjectId: model.subjectId,
+    activityDraftsCount: model.activityDrafts?.length ?? 0,
   };
 };
 

--- a/src/hooks/useRecommendedClassModels.ts
+++ b/src/hooks/useRecommendedClassModels.ts
@@ -33,7 +33,7 @@ const recommendedClassModelResponseSchema = z.object({
   activityDrafts: z
     .array(
       z.object({
-        activityDraftId: z.string().uuid(),
+        activityDraftId: z.uuid(),
         sequence: z.number(),
         title: z.string().nullable().optional(),
       })

--- a/src/hooks/useRecommendedLessonsPage.test.ts
+++ b/src/hooks/useRecommendedLessonsPage.test.ts
@@ -681,6 +681,7 @@ describe('useRecommendedLessonsPage', () => {
       students: [{ studentId: 'student-1', userInstitutionId: 'inst-1' }],
       startDate: '2024-06-01T08:00:00',
       finalDate: '2024-06-15T23:59:00',
+      canRetry: false,
     });
     expect(result.current.modalProps.isOpen).toBe(false);
   });

--- a/src/hooks/useRecommendedLessonsPage.ts
+++ b/src/hooks/useRecommendedLessonsPage.ts
@@ -173,6 +173,9 @@ export interface UseRecommendedLessonsPageReturn {
     onCategoriesChange: (categories: CategoryConfig[]) => void;
     isLoading: boolean;
     modalTitle: string | undefined;
+    /** Whether the selected model has activity drafts attached, which
+     *  controls the visibility of the "Permitir refazer?" field. */
+    hasAttachedActivities: boolean;
   };
   /** Navigate function for custom tab handlers */
   navigate: (path: string, options?: { state?: unknown }) => void;
@@ -582,7 +585,7 @@ export const createUseRecommendedLessonsPage = (
         const params = buildQueryParams({
           ...filters,
           type: RecommendedClassDraftType.MODELO,
-        } as Record<string, unknown>);
+        });
         const response = await api.get<RecommendedClassModelsApiResponse>(
           endpoints.recommendedClassDrafts,
           { params }
@@ -624,7 +627,7 @@ export const createUseRecommendedLessonsPage = (
         const params = buildQueryParams({
           ...filters,
           type: RecommendedClassDraftType.RASCUNHO,
-        } as Record<string, unknown>);
+        });
         const response = await api.get<RecommendedClassModelsApiResponse>(
           endpoints.recommendedClassDrafts,
           { params }
@@ -742,6 +745,7 @@ export const createUseRecommendedLessonsPage = (
             students: formData.students,
             startDate: `${formData.startDate}T${formData.startTime}:00`,
             finalDate: `${formData.finalDate}T${formData.finalTime}:00`,
+            canRetry: formData.canRetry ?? false,
           });
 
           setSendModalOpen(false);
@@ -804,6 +808,7 @@ export const createUseRecommendedLessonsPage = (
         onCategoriesChange: handleCategoriesChange,
         isLoading: sendModalLoading,
         modalTitle: selectedModel?.title,
+        hasAttachedActivities: (selectedModel?.activityDraftsCount ?? 0) > 0,
       },
       navigate,
     };

--- a/src/types/recommendedLessons.ts
+++ b/src/types/recommendedLessons.ts
@@ -513,6 +513,14 @@ export interface RecommendedClassModelResponse {
   finalDate: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Activity drafts attached to this model (returned by
+   *  GET /recommended-class/drafts). Used to derive whether the model has
+   *  any activities for the "Permitir refazer?" field on the send modal. */
+  activityDrafts?: Array<{
+    activityDraftId: string;
+    sequence: number;
+    title?: string | null;
+  }>;
 }
 
 /**
@@ -527,6 +535,8 @@ export interface RecommendedClassModelTableItem extends Record<
   savedAt: string;
   subject: string;
   subjectId: string | null;
+  /** Number of activity drafts attached to this model. */
+  activityDraftsCount?: number;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retry option to the lesson sending modal that allows instructors to control whether students can retry attached activities when present.

* **Tests**
  * Extended test coverage for the retry option UI and submission payload validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->