### PR TITLE
AE-2614: fix retry option when sending activities from recommended lessons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
@@ -1130,6 +1130,9 @@ const RecommendedLessonCreate = ({
             }))
           : undefined;
 
+        const hasAttachedActivities =
+          !!activityDraftIds && activityDraftIds.length > 0;
+
         const lessonPayload: RecommendedLessonCreatePayload = {
           title:
             formData.title || recommendedLesson?.title || 'Aula Recomendada',
@@ -1144,8 +1147,11 @@ const RecommendedLessonCreate = ({
           targetStudentIds: formData.students.map((s) => s.userInstitutionId),
           // Send notification as separate field (backend expects "notification")
           ...(formData.notification && { notification: formData.notification }),
-          // Forward retry flag — only meaningful when activityDraftIds is set.
-          canRetry: formData.canRetry ?? false,
+          // Forward retry flag only when activities are actually attached
+          // — backend ignores it otherwise and it would just be noise.
+          ...(hasAttachedActivities && {
+            canRetry: formData.canRetry ?? false,
+          }),
         };
 
         // POST: Create recommended lesson

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.tsx
@@ -1144,6 +1144,8 @@ const RecommendedLessonCreate = ({
           targetStudentIds: formData.students.map((s) => s.userInstitutionId),
           // Send notification as separate field (backend expects "notification")
           ...(formData.notification && { notification: formData.notification }),
+          // Forward retry flag — only meaningful when activityDraftIds is set.
+          canRetry: formData.canRetry ?? false,
         };
 
         // POST: Create recommended lesson
@@ -1416,6 +1418,9 @@ const RecommendedLessonCreate = ({
         categories={categories}
         onCategoriesChange={handleCategoriesChange}
         isLoading={isSendingLesson}
+        hasAttachedActivities={
+          (recommendedLesson?.activityDraftIds?.length ?? 0) > 0
+        }
         onError={(error) => {
           console.error('Error sending lesson:', error);
           const errorMessage =

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.types.ts
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.types.ts
@@ -108,6 +108,9 @@ export interface RecommendedLessonCreatePayload {
   activityDraftIds?: RecommendedLessonActivityDraft[];
   startDate: string;
   finalDate: string;
+  /** Whether attached activities can be retried by the student.
+   *  Only meaningful when activityDraftIds is non-empty. */
+  canRetry?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry control option for recommended lessons with attached activities.

* **Chores**
  * Updated package version to 1.4.16.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->