### PR TITLE
AE-2637: change map color scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -585,7 +585,7 @@ describe('ChoroplethMap animations', () => {
     };
     const initialStyle = initialStyleFn(mockFeature);
     expect(initialStyle.fillOpacity).toBe(0);
-    expect(initialStyle.strokeColor).toBe('#64B5F6');
+    expect(initialStyle.strokeColor).toBe('#abd9e9');
     expect(initialStyle.strokeWeight).toBe(0.3);
   });
 
@@ -682,7 +682,7 @@ describe('ChoroplethMap animations', () => {
     expect(mockOverrideStyle).toHaveBeenCalledWith(
       mockFeatureObj,
       expect.objectContaining({
-        strokeColor: '#64B5F6',
+        strokeColor: '#abd9e9',
       })
     );
   });
@@ -873,7 +873,7 @@ describe('ChoroplethMap NRE boundary layer', () => {
     await waitFor(() => {
       expect(mockNreSetStyle).toHaveBeenCalledWith({
         fillOpacity: 0,
-        strokeColor: '#1565C0',
+        strokeColor: '#2c7bb6',
         strokeWeight: 1.5,
         clickable: false,
       });

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -55,29 +55,29 @@ const getColorClasses = (): ColorClass[] => [
   {
     min: 0.75,
     max: 1.01,
-    fillColor: getCssVar('--color-map-highlight', '#1C61B2'),
-    strokeColor: getCssVar('--color-map-highlight', '#1C61B2'),
+    fillColor: getCssVar('--color-map-highlight', '#2c7bb6'),
+    strokeColor: getCssVar('--color-map-highlight', '#2c7bb6'),
     label: 'Destaque',
   },
   {
     min: 0.5,
     max: 0.75,
-    fillColor: getCssVar('--color-map-above-avg', '#2883D7'),
-    strokeColor: getCssVar('--color-map-above-avg', '#2883D7'),
+    fillColor: getCssVar('--color-map-above-avg', '#abd9e9'),
+    strokeColor: getCssVar('--color-map-above-avg', '#abd9e9'),
     label: 'Acima da média',
   },
   {
     min: 0.25,
     max: 0.5,
-    fillColor: getCssVar('--color-map-below-avg', '#91C7F1'),
-    strokeColor: getCssVar('--color-map-below-avg', '#91C7F1'),
+    fillColor: getCssVar('--color-map-below-avg', '#fdae61'),
+    strokeColor: getCssVar('--color-map-below-avg', '#fdae61'),
     label: 'Abaixo da média',
   },
   {
     min: 0,
     max: 0.25,
-    fillColor: getCssVar('--color-map-attention', '#E3F1FB'),
-    strokeColor: getCssVar('--color-map-highlight', '#1C61B2'),
+    fillColor: getCssVar('--color-map-attention', '#d7191c'),
+    strokeColor: getCssVar('--color-map-attention', '#d7191c'),
     label: 'Ponto de atenção',
   },
 ];
@@ -374,8 +374,8 @@ const ChoroplethMap = ({
   useEffect(() => {
     if (!map || !stableData.length) return;
 
-    const strokeCityColor = getCssVar('--color-map-stroke-city', '#64B5F6');
-    const strokeNreColor = getCssVar('--color-map-stroke-nre', '#1565C0');
+    const strokeCityColor = getCssVar('--color-map-stroke-city', '#abd9e9');
+    const strokeNreColor = getCssVar('--color-map-stroke-nre', '#2c7bb6');
 
     // Clear existing data
     map.data.forEach((feature) => {

--- a/src/themes/analytica/dark.css
+++ b/src/themes/analytica/dark.css
@@ -189,13 +189,13 @@
     --color-question-type-image: #EAB308;
     --color-question-type-matching: #C084FC;
 
-    /* Map Choropleth Colors — escala verde Analytica (dark) */
-    --color-map-highlight: #004c0e;
-    --color-map-above-avg: #00ad20;
-    --color-map-below-avg: #abf2b8;
-    --color-map-attention: #022208;
-    --color-map-stroke-city: #5af677;
-    --color-map-stroke-nre: #006b14;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/analytica/light.css
+++ b/src/themes/analytica/light.css
@@ -187,13 +187,13 @@
     --color-question-type-image: #715904;
     --color-question-type-matching: #6a4ac2;
 
-    /* Map Choropleth Colors — escala verde Analytica */
-    --color-map-highlight: #006b14;
-    --color-map-above-avg: #008a19;
-    --color-map-below-avg: #abf2b8;
-    --color-map-attention: #eef6f0;
-    --color-map-stroke-city: #5af677;
-    --color-map-stroke-nre: #004c0e;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);

--- a/src/themes/base/dark.css
+++ b/src/themes/base/dark.css
@@ -188,13 +188,13 @@
     --color-question-type-image: #EAB308;
     --color-question-type-matching: #C084FC;
 
-    /* Map Choropleth Colors */
-    --color-map-highlight: #1C61B2;
-    --color-map-above-avg: #2883D7;
-    --color-map-below-avg: #91C7F1;
-    --color-map-attention: #E3F1FB;
-    --color-map-stroke-city: #64B5F6;
-    --color-map-stroke-nre: #1565C0;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/paraiba/dark.css
+++ b/src/themes/paraiba/dark.css
@@ -188,13 +188,13 @@
     --color-question-type-image: #EAB308;
     --color-question-type-matching: #C084FC;
 
-    /* Map Choropleth Colors — escala vermelha Paraíba */
-    --color-map-highlight: #6e0818;
-    --color-map-above-avg: #c8102e;
-    --color-map-below-avg: #f2909a;
-    --color-map-attention: #3a030c;
-    --color-map-stroke-city: #e8606d;
-    --color-map-stroke-nre: #8a0a1e;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/paraiba/light.css
+++ b/src/themes/paraiba/light.css
@@ -182,13 +182,13 @@
     --color-question-type-image: #715904;
     --color-question-type-matching: #660CB0;
 
-    /* Map Choropleth Colors — escala vermelha para a Paraíba */
-    --color-map-highlight: #6e0818;
-    --color-map-above-avg: #c8102e;
-    --color-map-below-avg: #f2909a;
-    --color-map-attention: #fdeaec;
-    --color-map-stroke-city: #e8606d;
-    --color-map-stroke-nre: #8a0a1e;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);

--- a/src/themes/parana/dark.css
+++ b/src/themes/parana/dark.css
@@ -188,13 +188,13 @@
     --color-question-type-image: #EAB308;
     --color-question-type-matching: #C084FC;
 
-    /* Map Choropleth Colors — escala azul Paraná */
-    --color-map-highlight: #1C61B2;
-    --color-map-above-avg: #2883D7;
-    --color-map-below-avg: #91C7F1;
-    --color-map-attention: #E3F1FB;
-    --color-map-stroke-city: #64B5F6;
-    --color-map-stroke-nre: #1565C0;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/parana/light.css
+++ b/src/themes/parana/light.css
@@ -182,13 +182,13 @@
     --color-question-type-image: #715904;
     --color-question-type-matching: #660CB0;
 
-    /* Map Choropleth Colors */
-    --color-map-highlight: #1C61B2;
-    --color-map-above-avg: #2883D7;
-    --color-map-below-avg: #91C7F1;
-    --color-map-attention: #E3F1FB;
-    --color-map-stroke-city: #64B5F6;
-    --color-map-stroke-nre: #1565C0;
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #2c7bb6;
+    --color-map-above-avg: #abd9e9;
+    --color-map-below-avg: #fdae61;
+    --color-map-attention: #d7191c;
+    --color-map-stroke-city: #abd9e9;
+    --color-map-stroke-nre: #2c7bb6;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -187,13 +187,13 @@
   --color-question-type-image: #715904;
   --color-question-type-matching: #660CB0;
 
-  /* Map Choropleth Colors */
-  --color-map-highlight: #1C61B2;
-  --color-map-above-avg: #2883D7;
-  --color-map-below-avg: #91C7F1;
-  --color-map-attention: #E3F1FB;
-  --color-map-stroke-city: #64B5F6;
-  --color-map-stroke-nre: #1565C0;
+  /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+  --color-map-highlight: #2c7bb6;
+  --color-map-above-avg: #abd9e9;
+  --color-map-below-avg: #fdae61;
+  --color-map-attention: #d7191c;
+  --color-map-stroke-city: #abd9e9;
+  --color-map-stroke-nre: #2c7bb6;
 
   /* Hard Shadow Colors */
   --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned choropleth map color palette across all application themes. Maps now use a diverging red-to-blue scale, replacing previous theme-specific color schemes for improved data visualization clarity and visual consistency.

* **Chores**
  * Bumped package version to 1.4.21.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->