### PR TITLE
AE-2637: fix map stroke color

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -585,7 +585,7 @@ describe('ChoroplethMap animations', () => {
     };
     const initialStyle = initialStyleFn(mockFeature);
     expect(initialStyle.fillOpacity).toBe(0);
-    expect(initialStyle.strokeColor).toBe('#abd9e9');
+    expect(initialStyle.strokeColor).toBe('#9ca3af');
     expect(initialStyle.strokeWeight).toBe(0.3);
   });
 
@@ -682,7 +682,7 @@ describe('ChoroplethMap animations', () => {
     expect(mockOverrideStyle).toHaveBeenCalledWith(
       mockFeatureObj,
       expect.objectContaining({
-        strokeColor: '#abd9e9',
+        strokeColor: '#9ca3af',
       })
     );
   });
@@ -873,7 +873,7 @@ describe('ChoroplethMap NRE boundary layer', () => {
     await waitFor(() => {
       expect(mockNreSetStyle).toHaveBeenCalledWith({
         fillOpacity: 0,
-        strokeColor: '#2c7bb6',
+        strokeColor: '#4b5563',
         strokeWeight: 1.5,
         clickable: false,
       });

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -374,8 +374,8 @@ const ChoroplethMap = ({
   useEffect(() => {
     if (!map || !stableData.length) return;
 
-    const strokeCityColor = getCssVar('--color-map-stroke-city', '#abd9e9');
-    const strokeNreColor = getCssVar('--color-map-stroke-nre', '#2c7bb6');
+    const strokeCityColor = getCssVar('--color-map-stroke-city', '#9ca3af');
+    const strokeNreColor = getCssVar('--color-map-stroke-nre', '#4b5563');
 
     // Clear existing data
     map.data.forEach((feature) => {

--- a/src/themes/analytica/dark.css
+++ b/src/themes/analytica/dark.css
@@ -194,8 +194,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/analytica/light.css
+++ b/src/themes/analytica/light.css
@@ -192,8 +192,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);

--- a/src/themes/base/dark.css
+++ b/src/themes/base/dark.css
@@ -193,8 +193,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/paraiba/dark.css
+++ b/src/themes/paraiba/dark.css
@@ -193,8 +193,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/paraiba/light.css
+++ b/src/themes/paraiba/light.css
@@ -187,8 +187,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);

--- a/src/themes/parana/dark.css
+++ b/src/themes/parana/dark.css
@@ -193,8 +193,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);

--- a/src/themes/parana/light.css
+++ b/src/themes/parana/light.css
@@ -187,8 +187,8 @@
     --color-map-above-avg: #abd9e9;
     --color-map-below-avg: #fdae61;
     --color-map-attention: #d7191c;
-    --color-map-stroke-city: #abd9e9;
-    --color-map-stroke-nre: #2c7bb6;
+    --color-map-stroke-city: #9ca3af;
+    --color-map-stroke-nre: #4b5563;
 
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -192,8 +192,8 @@
   --color-map-above-avg: #abd9e9;
   --color-map-below-avg: #fdae61;
   --color-map-attention: #d7191c;
-  --color-map-stroke-city: #abd9e9;
-  --color-map-stroke-nre: #2c7bb6;
+  --color-map-stroke-city: #9ca3af;
+  --color-map-stroke-nre: #4b5563;
 
   /* Hard Shadow Colors */
   --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated map visualization colors: city boundary strokes and NRE region borders now use gray tones instead of blue across all application themes for improved visual clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->