### PR TITLE
AE-2668 - feat(ChoroplethMap): add countLabel prop to customize tooltip label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -3,7 +3,11 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ChoroplethMap from './ChoroplethMap';
-import type { RegionData, MapBounds } from './ChoroplethMap.types';
+import type {
+  RegionData,
+  MapBounds,
+  ChoroplethMapProps,
+} from './ChoroplethMap.types';
 
 // Mock useTheme - return light mode by default
 jest.mock('../../hooks/useTheme', () => ({
@@ -625,7 +629,15 @@ describe('ChoroplethMap animations', () => {
     expect(finalStyle.fillOpacity).toBe(0.8);
   });
 
-  it('triggers hover animation with overrideStyle on mouseover', async () => {
+  /**
+   * Render the map and fire a `mouseover` on a single region, leaving the
+   * hover tooltip visible.
+   * @param props - Extra props forwarded to ChoroplethMap (e.g. countLabel)
+   * @returns The mocked Data.Feature that received the hover
+   */
+  const renderAndHoverRegion = async (
+    props: Partial<ChoroplethMapProps> = {}
+  ): Promise<{ feature: unknown }> => {
     let mouseoverHandler: ((event: unknown) => void) | null = null;
     mockAddListener.mockImplementation((event, handler) => {
       if (event === 'mouseover') {
@@ -660,7 +672,7 @@ describe('ChoroplethMap animations', () => {
       },
     ];
 
-    render(<ChoroplethMap data={mockRegion} apiKey={mockApiKey} />);
+    render(<ChoroplethMap data={mockRegion} apiKey={mockApiKey} {...props} />);
 
     await waitFor(() => {
       expect(mouseoverHandler).not.toBeNull();
@@ -673,6 +685,12 @@ describe('ChoroplethMap animations', () => {
       });
     });
 
+    return { feature: mockFeatureObj };
+  };
+
+  it('triggers hover animation with overrideStyle on mouseover', async () => {
+    const { feature } = await renderAndHoverRegion();
+
     // Flush hover animation to completion (time >= HOVER_DURATION 200ms)
     act(() => {
       flushRAF(300);
@@ -680,11 +698,25 @@ describe('ChoroplethMap animations', () => {
 
     // After animation, overrideStyle should have been called with target values
     expect(mockOverrideStyle).toHaveBeenCalledWith(
-      mockFeatureObj,
+      feature,
       expect.objectContaining({
         strokeColor: '#9ca3af',
       })
     );
+  });
+
+  it('shows the default "Acessos" count label in the region tooltip', async () => {
+    await renderAndHoverRegion();
+
+    expect(screen.getByText(/Acessos: 200/)).toBeInTheDocument();
+  });
+
+  it('shows a custom countLabel in the region tooltip', async () => {
+    await renderAndHoverRegion({ countLabel: 'Atividades realizadas' });
+
+    expect(
+      screen.getByText(/Atividades realizadas: 200/)
+    ).toBeInTheDocument();
   });
 
   it('zooms to NRE region on click', async () => {

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -265,6 +265,7 @@ const ChoroplethMap = ({
   data,
   apiKey,
   title = 'Performance por região',
+  countLabel = 'Acessos',
   loading = false,
   bounds,
   onRegionClick,
@@ -754,7 +755,7 @@ const ChoroplethMap = ({
               {hoveredRegion.name}
             </Text>
             <Text size="xs" color="text-text-700">
-              Acessos: {hoveredRegion.accessCount.toLocaleString('pt-BR')}
+              {countLabel}: {hoveredRegion.accessCount.toLocaleString('pt-BR')}
             </Text>
           </div>
         )}

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -50,6 +50,8 @@ export interface ChoroplethMapProps {
   apiKey: string;
   /** Optional title for the map section */
   title?: string;
+  /** Label shown before the count value in the region tooltip (default: 'Acessos') */
+  countLabel?: string;
   /** Loading state indicator */
   loading?: boolean;
   /** Map bounds for initial view */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The ChoroplethMap component now supports a customizable tooltip count label. Previously hardcoded as "Acessos", the label can now be configured via an optional parameter while maintaining existing default behavior.

* **Tests**
  * Updated test coverage to verify the new tooltip label customization feature and confirm proper rendering with custom and default labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->