### PR TITLE
AE-2705 - fix(useSendActivity): correctly derive isDigital from subtype and mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.33",
+  "version": "1.4.34",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/hooks/useSendActivity.test.ts
+++ b/src/hooks/useSendActivity.test.ts
@@ -7,7 +7,10 @@ import type {
   ActivityModelItem,
 } from '../types/sendActivity';
 import type { BaseApiClient } from '../types/api';
-import { ActivitySubtype } from '../components/SendActivityModal/types';
+import {
+  ActivityMode,
+  ActivitySubtype,
+} from '../components/SendActivityModal/types';
 import type { SendActivityFormData } from '../components/SendActivityModal/types';
 
 /**
@@ -421,6 +424,7 @@ describe('useSendActivity', () => {
         subjectId: 'subject-1',
         questionIds: ['q1', 'q2', 'q3'],
         subtype: ActivitySubtype.TAREFA,
+        isDigital: true,
         notification: 'true',
         startDate: expectedISODateTime('2025-01-15', '08:00'),
         finalDate: expectedISODateTime('2025-01-20', '23:59'),
@@ -438,6 +442,37 @@ describe('useSendActivity', () => {
       );
       expect(result.current.isOpen).toBe(false);
     });
+
+    it.each([
+      [ActivitySubtype.TAREFA, undefined, true],
+      [ActivitySubtype.TRABALHO, undefined, true],
+      [ActivitySubtype.PROVA, ActivityMode.ONLINE, true],
+      [ActivitySubtype.PROVA, ActivityMode.PRESENCIAL, false],
+      [ActivitySubtype.PROVA, undefined, true],
+    ])(
+      'should send isDigital correctly for subtype=%s mode=%s (expected=%s)',
+      async (subtype, mode, expectedIsDigital) => {
+        const config = createMockConfig();
+        const { result } = renderHook(() => useSendActivity(config));
+
+        await act(async () => {
+          result.current.openModal(mockModel);
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            ...mockFormData,
+            subtype,
+            mode,
+          });
+        });
+
+        expect(config.api.post).toHaveBeenCalledWith(
+          '/activities',
+          expect.objectContaining({ isDigital: expectedIsDigital })
+        );
+      }
+    );
 
     it('should handle error when fetchQuestionIds returns null', async () => {
       const defaultMockApi = createMockApiClient();

--- a/src/hooks/useSendActivity.ts
+++ b/src/hooks/useSendActivity.ts
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import type { CategoryConfig } from '../components/CheckBoxGroup/CheckBoxGroup';
 import {
   ActivityMode,
+  ActivitySubtype,
   type SendActivityFormData,
   type SendActivityModalInitialData,
 } from '../components/SendActivityModal/types';
@@ -229,9 +230,9 @@ export function useSendActivity(
             questionIds,
             subtype: data.subtype,
             isDigital:
-              data.mode === undefined
-                ? undefined
-                : data.mode === ActivityMode.ONLINE,
+              data.subtype === ActivitySubtype.PROVA
+                ? data.mode !== ActivityMode.PRESENCIAL
+                : true,
             notification: data.notification,
             startDate: toISODateTime(data.startDate, data.startTime),
             finalDate: toISODateTime(data.finalDate, data.finalTime),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.4.34

* **Tests**
  * Enhanced test coverage for activity submission behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->