### PR TITLE
AE-2705 - fix(buildSendActivityPayload): mirror useSendActivity isDigital logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ActivityCreate/ActivityCreate.utils.test.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.test.ts
@@ -7,13 +7,15 @@ import {
   convertQuestionToPreview,
   getTypeFromUrl,
   getTypeFromUrlString,
+  buildSendActivityPayload,
   type KnowledgeArea,
 } from './ActivityCreate.utils';
 import { loadCategoriesData, formatTime } from '@/utils/categoryDataUtils';
 import { ActivityType } from './ActivityCreate.types';
 import { QUESTION_TYPE } from '../Quiz/useQuizStore';
+import { ActivityMode, ActivitySubtype } from '../SendActivityModal/types';
 import type { BaseApiClient } from '../../types/api';
-import type { ActivityFiltersData } from '../..';
+import type { ActivityFiltersData, SendActivityFormData } from '../..';
 import type {
   BackendFiltersFormat,
   School,
@@ -835,5 +837,41 @@ describe('ActivityCreate.utils', () => {
       expect(getTypeFromUrlString('rascunho')).toBe(ActivityType.RASCUNHO);
       expect(getTypeFromUrlString('modelo')).toBe(ActivityType.MODELO);
     });
+  });
+
+  describe('buildSendActivityPayload', () => {
+    const baseFormData: SendActivityFormData = {
+      title: 'Atividade',
+      subtype: ActivitySubtype.TAREFA,
+      notification: '',
+      students: [],
+      startDate: '2026-01-01',
+      startTime: '08:00',
+      finalDate: '2026-01-02',
+      finalTime: '18:00',
+      canRetry: false,
+    };
+
+    it.each([
+      [ActivitySubtype.TAREFA, undefined, true],
+      [ActivitySubtype.TRABALHO, undefined, true],
+      [ActivitySubtype.PROVA, ActivityMode.ONLINE, true],
+      [ActivitySubtype.PROVA, ActivityMode.PRESENCIAL, false],
+      [ActivitySubtype.PROVA, undefined, true],
+    ])(
+      'should set isDigital correctly for subtype=%s mode=%s (expected=%s)',
+      (subtype, mode, expectedIsDigital) => {
+        const payload = buildSendActivityPayload(
+          { ...baseFormData, subtype, mode },
+          'subject-1',
+          ['q-1'],
+          '2026-01-01T08:00:00.000Z',
+          '2026-01-02T18:00:00.000Z',
+          'ATIVIDADE'
+        );
+
+        expect(payload.isDigital).toBe(expectedIsDigital);
+      }
+    );
   });
 });

--- a/src/components/ActivityCreate/ActivityCreate.utils.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.ts
@@ -5,7 +5,7 @@ import type {
   SendActivityFormData,
 } from '../..';
 import type { Lesson } from '../../types/lessons';
-import { ActivityMode } from '../SendActivityModal/types';
+import { ActivityMode, ActivitySubtype } from '../SendActivityModal/types';
 import { QUESTION_TYPE } from '../Quiz/useQuizStore';
 import type {
   BackendFiltersFormat,
@@ -412,9 +412,9 @@ export function buildSendActivityPayload(
     finalDate: finalDateTime,
     canRetry: formData.canRetry,
     isDigital:
-      formData.mode === undefined
-        ? undefined
-        : formData.mode === ActivityMode.ONLINE,
+      formData.subtype === ActivitySubtype.PROVA
+        ? formData.mode !== ActivityMode.PRESENCIAL
+        : true,
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced how the system determines activity digital status by evaluating both activity type and operational mode for more accurate classification across different activity configurations.

* **Tests**
  * Added comprehensive test coverage validating digital classification across all activity type and mode combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->