### PR TITLE
AE-2704 - fix(useActivityDraftModelPage): label send button by activity category

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.38",
+  "version": "1.4.39",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/ExamPageLayout/examDraftsModelsTableConfig.test.tsx
+++ b/src/components/ExamPageLayout/examDraftsModelsTableConfig.test.tsx
@@ -147,6 +147,23 @@ describe('examDraftsModelsTableConfig', () => {
       ).toBeInTheDocument();
     });
 
+    it('should render send button with a custom label when provided', () => {
+      const columns = createExamDraftsModelsTableColumns(
+        mockCallbacks,
+        'Enviar atividade'
+      );
+      const actionsColumn = columns.find((col) => col.key === 'actions');
+
+      render(<>{actionsColumn?.render?.(undefined, mockRow, 0)}</>);
+
+      expect(
+        screen.getByRole('button', { name: /enviar atividade/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /enviar prova/i })
+      ).not.toBeInTheDocument();
+    });
+
     it('should render delete button', () => {
       const columns = createExamDraftsModelsTableColumns(mockCallbacks);
       const actionsColumn = columns.find((col) => col.key === 'actions');

--- a/src/components/ExamPageLayout/examDraftsModelsTableConfig.tsx
+++ b/src/components/ExamPageLayout/examDraftsModelsTableConfig.tsx
@@ -21,13 +21,16 @@ export interface ExamTableCallbacks {
 }
 
 /**
- * Factory function to create column configuration for exam drafts and models tables
+ * Factory function to create column configuration for drafts and models tables
+ * (used by both exam and activity pages).
  * Returns columns with action buttons that use the provided callbacks
  * @param callbacks - Object containing onSend, onDelete, and onEdit handlers
+ * @param sendLabel - Label for the send button (e.g. "Enviar prova" / "Enviar atividade")
  * @returns Column configuration array for TableProvider
  */
 export const createExamDraftsModelsTableColumns = (
-  callbacks: ExamTableCallbacks
+  callbacks: ExamTableCallbacks,
+  sendLabel = 'Enviar prova'
 ): ColumnConfig<ActivityModelTableItem>[] => [
   {
     key: 'title',
@@ -75,7 +78,7 @@ export const createExamDraftsModelsTableColumns = (
             callbacks.onSend(row);
           }}
         >
-          Enviar prova
+          {sendLabel}
         </Button>
         <IconButton
           icon={<Trash size={20} />}

--- a/src/hooks/useActivityDraftModelPage.ts
+++ b/src/hooks/useActivityDraftModelPage.ts
@@ -78,7 +78,7 @@ export interface UseActivityDraftModelPageReturn {
  * @returns Shared state and callbacks for the page
  */
 export const useActivityDraftModelPage = ({
-  activityCategory: _activityCategory,
+  activityCategory,
   fetchFn,
   deleteFn,
   userData,
@@ -171,16 +171,23 @@ export const useActivityDraftModelPage = ({
   }, [itemToDeleteId, deleteFn, fetchFn, currentParams, errorLogLabel]);
 
   /**
-   * Create table columns with action callbacks
+   * Create table columns with action callbacks.
+   * The send button label follows the category: "Enviar prova" for exams,
+   * "Enviar atividade" for activities.
    */
+  const sendLabel =
+    activityCategory === 'PROVA' ? 'Enviar prova' : 'Enviar atividade';
   const tableColumns = useMemo(
     () =>
-      createExamDraftsModelsTableColumns({
-        onSend: handleSend,
-        onDelete: handleDelete,
-        onEdit: handleEdit,
-      }),
-    [handleSend, handleDelete, handleEdit]
+      createExamDraftsModelsTableColumns(
+        {
+          onSend: handleSend,
+          onDelete: handleDelete,
+          onEdit: handleEdit,
+        },
+        sendLabel
+      ),
+    [handleSend, handleDelete, handleEdit, sendLabel]
   );
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual send button labels that adapt based on activity type (displays "Enviar prova" for exams and "Enviar atividade" for activities).

* **Tests**
  * Added test coverage for custom send button label functionality.

* **Chores**
  * Bumped version to 1.4.39.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/analytica-ensino/analytica-frontend-lib/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->