### PR TITLE
fix(deps): pin html-react-parser to 6.1.2 to fix white screen in Vite…

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.21",
     "dompurify": "^3.4.7",
-    "html-react-parser": "^6.1.3",
+    "html-react-parser": "6.1.2",
     "katex": "^0.17.0",
     "phosphor-react": "^1.4.1",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,7 +3747,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-jsdoc: "npm:^63.0.1"
     eslint-plugin-prettier: "npm:^5.5.6"
-    html-react-parser: "npm:^6.1.3"
+    html-react-parser: "npm:6.1.2"
     husky: "npm:^9.1.7"
     identity-obj-proxy: "npm:^3.0.0"
     jest: "npm:^30.4.2"
@@ -6562,13 +6562,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-dom-parser@npm:8.0.0":
-  version: 8.0.0
-  resolution: "html-dom-parser@npm:8.0.0"
+"html-dom-parser@npm:7.1.0":
+  version: 7.1.0
+  resolution: "html-dom-parser@npm:7.1.0"
   dependencies:
     domhandler: "npm:6.0.1"
     htmlparser2: "npm:12.0.0"
-  checksum: 10c0/8458df97521270b0d9d0c5a604462189b1f58c6da58810dfaae7d1903a15f25da01ed224de5ecf243dad36e91436d32dd45e6e207fcc4bcd35a3bb28d3268881
+  checksum: 10c0/e73b0c2e8bbe809ff877bf2483f6547f4797ee55c1c6d0f486d54ce7310e799c36986328f11dde1ce99608939a06efdf1d02c45a0abd0ec40b405b230c3dffdf
   languageName: node
   linkType: hard
 
@@ -6604,12 +6604,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-react-parser@npm:^6.1.3":
-  version: 6.1.3
-  resolution: "html-react-parser@npm:6.1.3"
+"html-react-parser@npm:6.1.2":
+  version: 6.1.2
+  resolution: "html-react-parser@npm:6.1.2"
   dependencies:
     domhandler: "npm:6.0.1"
-    html-dom-parser: "npm:8.0.0"
+    html-dom-parser: "npm:7.1.0"
     react-property: "npm:2.0.2"
     style-to-js: "npm:2.0.0"
   peerDependencies:
@@ -6618,7 +6618,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/2b2520a6e836bb9c6b3c561f808714c7fc2393bfc093dc72cdd0b62a4d7009c9be63a685b8b967080a4cd1cd0774198b752f49133a309f5d5ba78cd390d83a6c
+  checksum: 10c0/af016a9286c6454c355da9167586baac1489253c38863b6714aeeceb9ebf9e4b9f23e1d0b6217fadddc7fde3cdbd4b0f270a6d5388f8fae30a3cc09cbc8f6256
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problema

Consumidores Vite da lib (frontend-professor, backoffice, etc.) ficavam com tela branca no boot ao subir para versões ≥ 1.4.43, com o erro em runtime:

    Uncaught TypeError: require_constants is not a function

O stack apontava inteiramente para dentro do bundle da analytica-frontend-lib otimizado pelo Vite — não para o código do app.

## Causa raiz

A lib declarava `html-react-parser: ^6.1.3`. A versão 6.1.3 fixa exatamente `html-dom-parser@8.0.0` (rewrite recente), cujo build nomeia variáveis internas como `require_constants`:

    // html-dom-parser/lib/client/utilities.js (8.0.0)
    const require_constants = require("./constants.js");

Esse nome colide com o helper de interop CJS do esbuild (`require_<basename>`). Ao otimizar/bundlar, o esbuild gera `var require_constants = require_constants()` (auto-referência → undefined), quebrando em runtime. Não é cache do Vite nem código do app — é incompatibilidade da dependência transitiva com o esbuild.

- html-react-parser@6.1.2 → html-dom-parser@7.1.0 ✅ (sem o nome colidente)
- html-react-parser@6.1.3 → html-dom-parser@8.0.0 ❌

A tentativa anterior (v1.4.47, repontar exports.import → index.mjs) não resolveu, pois o index.mjs importa o html-react-parser como dependência externa — quem bundla o html-dom-parser quebrado é o Vite do consumidor.

## Solução

Pin de `html-react-parser` em `6.1.2` (exato — `^`/`~` ainda pegariam 6.1.3), forçando a resolução do `html-dom-parser@7.1.0`, compatível com o esbuild.

## Validação

- Resolução: html-react-parser 6.1.2 → html-dom-parser 7.1.0
- dist/index.mjs recém-buildado: sem a colisão require_constants
- yarn typecheck: limpo
- yarn tsup (build): sucesso
- yarn jest: 352 suites / 9382 testes passando

## Impacto / próximos passos

- Consumidores devem subir para esta versão e remover qualquer resolutions temporário de html-react-parser (usado como ponte enquanto o fix não saía). - Caso tenha usado este artifício
- Acompanhar upstream: quando html-react-parser/html-dom-parser corrigirem a colisão com o esbuild, dá para voltar ao range normal.
