### PR TITLE
AE 2738 fix

### DIFF
--- a/src/components/Quiz/Quiz.test.tsx
+++ b/src/components/Quiz/Quiz.test.tsx
@@ -2141,7 +2141,9 @@ describe('Quiz', () => {
 
         render(<QuizQuestionList />);
 
-        expect(screen.getByText('Questão 01 (ENEM - 2023)')).toBeInTheDocument();
+        expect(
+          screen.getByText('Questão 01 (ENEM - 2023)')
+        ).toBeInTheDocument();
       });
 
       it('should NOT display examBoard/examYear when quiz type is ATIVIDADE', () => {
@@ -2167,7 +2169,9 @@ describe('Quiz', () => {
         render(<QuizQuestionList />);
 
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (ENEM - 2023)')
+        ).not.toBeInTheDocument();
       });
 
       it('should NOT display examBoard/examYear when quiz type is QUESTIONARIO', () => {
@@ -2193,7 +2197,9 @@ describe('Quiz', () => {
         render(<QuizQuestionList />);
 
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (UNICAMP - 2022)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (UNICAMP - 2022)')
+        ).not.toBeInTheDocument();
       });
 
       it('should NOT display examBoard/examYear when quiz type is AULA_RECOMENDADA', () => {
@@ -2219,7 +2225,9 @@ describe('Quiz', () => {
         render(<QuizQuestionList />);
 
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (FUVEST - 2021)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (FUVEST - 2021)')
+        ).not.toBeInTheDocument();
       });
 
       it('should NOT display exam info when quiz is undefined', () => {
@@ -2245,7 +2253,9 @@ describe('Quiz', () => {
         render(<QuizQuestionList />);
 
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (ENEM - 2023)')
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/Quiz/Quiz.test.tsx
+++ b/src/components/Quiz/Quiz.test.tsx
@@ -1498,6 +1498,142 @@ describe('Quiz', () => {
       // Should use the first topic name
       expect(screen.getByTestId('subtitle')).toHaveTextContent('Mathematics');
     });
+
+    describe('Exam Info Display (examBoard/examYear)', () => {
+      it('should display examBoard and examYear when quiz type is SIMULADO', () => {
+        const mockQuestion = {
+          id: 'question-1',
+          statement: 'Test question',
+          examBoard: 'ENEM',
+          examYear: '2023',
+          knowledgeMatrix: [{ topic: { name: 'Math' } }],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getCurrentQuestion: () => mockQuestion,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.SIMULADO },
+          currentQuestionIndex: 0,
+        });
+
+        render(<QuizHeader />);
+
+        expect(screen.getByTestId('title')).toHaveTextContent(
+          'Questão 01 (ENEM - 2023)'
+        );
+      });
+
+      it('should display only examBoard when examYear is null and quiz type is SIMULADO', () => {
+        const mockQuestion = {
+          id: 'question-1',
+          statement: 'Test question',
+          examBoard: 'FUVEST',
+          examYear: null,
+          knowledgeMatrix: [{ topic: { name: 'Math' } }],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getCurrentQuestion: () => mockQuestion,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.SIMULADO },
+          currentQuestionIndex: 0,
+        });
+
+        render(<QuizHeader />);
+
+        expect(screen.getByTestId('title')).toHaveTextContent(
+          'Questão 01 (FUVEST)'
+        );
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is ATIVIDADE', () => {
+        const mockQuestion = {
+          id: 'question-1',
+          statement: 'Test question',
+          examBoard: 'ENEM',
+          examYear: '2023',
+          knowledgeMatrix: [{ topic: { name: 'Math' } }],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getCurrentQuestion: () => mockQuestion,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.ATIVIDADE },
+          currentQuestionIndex: 0,
+        });
+
+        render(<QuizHeader />);
+
+        expect(screen.getByTestId('title')).toHaveTextContent('Questão 01');
+        expect(screen.getByTestId('title')).not.toHaveTextContent('ENEM');
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is QUESTIONARIO', () => {
+        const mockQuestion = {
+          id: 'question-1',
+          statement: 'Test question',
+          examBoard: 'UNICAMP',
+          examYear: '2022',
+          knowledgeMatrix: [{ topic: { name: 'Math' } }],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getCurrentQuestion: () => mockQuestion,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.QUESTIONARIO },
+          currentQuestionIndex: 0,
+        });
+
+        render(<QuizHeader />);
+
+        expect(screen.getByTestId('title')).toHaveTextContent('Questão 01');
+        expect(screen.getByTestId('title')).not.toHaveTextContent('UNICAMP');
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is AULA_RECOMENDADA', () => {
+        const mockQuestion = {
+          id: 'question-1',
+          statement: 'Test question',
+          examBoard: 'ENEM',
+          examYear: '2021',
+          knowledgeMatrix: [{ topic: { name: 'Math' } }],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getCurrentQuestion: () => mockQuestion,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.AULA_RECOMENDADA },
+          currentQuestionIndex: 0,
+        });
+
+        render(<QuizHeader />);
+
+        expect(screen.getByTestId('title')).toHaveTextContent('Questão 01');
+        expect(screen.getByTestId('title')).not.toHaveTextContent('ENEM');
+      });
+
+      it('should NOT display exam info when quiz is undefined', () => {
+        const mockQuestion = {
+          id: 'question-1',
+          statement: 'Test question',
+          examBoard: 'ENEM',
+          examYear: '2023',
+          knowledgeMatrix: [{ topic: { name: 'Math' } }],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getCurrentQuestion: () => mockQuestion,
+          getQuestionIndex: () => 1,
+          quiz: undefined,
+          currentQuestionIndex: 0,
+        });
+
+        render(<QuizHeader />);
+
+        expect(screen.getByTestId('title')).toHaveTextContent('Questão 01');
+        expect(screen.getByTestId('title')).not.toHaveTextContent('ENEM');
+      });
+    });
   });
 
   describe('QuizContent Component', () => {
@@ -1980,6 +2116,137 @@ describe('Quiz', () => {
       );
       expect(subjectName).toBeInTheDocument();
       expect(subjectName).toHaveTextContent('Matemática');
+    });
+
+    describe('Exam Info Display (examBoard/examYear)', () => {
+      it('should display examBoard and examYear when quiz type is SIMULADO', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              examBoard: 'ENEM',
+              examYear: '2023',
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          goToQuestion: jest.fn(),
+          getQuestionStatusFromUserAnswers: () => 'answered',
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.SIMULADO },
+        });
+
+        render(<QuizQuestionList />);
+
+        expect(screen.getByText('Questão 01 (ENEM - 2023)')).toBeInTheDocument();
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is ATIVIDADE', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              examBoard: 'ENEM',
+              examYear: '2023',
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          goToQuestion: jest.fn(),
+          getQuestionStatusFromUserAnswers: () => 'answered',
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.ATIVIDADE },
+        });
+
+        render(<QuizQuestionList />);
+
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is QUESTIONARIO', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              examBoard: 'UNICAMP',
+              examYear: '2022',
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          goToQuestion: jest.fn(),
+          getQuestionStatusFromUserAnswers: () => 'answered',
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.QUESTIONARIO },
+        });
+
+        render(<QuizQuestionList />);
+
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (UNICAMP - 2022)')).not.toBeInTheDocument();
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is AULA_RECOMENDADA', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              examBoard: 'FUVEST',
+              examYear: '2021',
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          goToQuestion: jest.fn(),
+          getQuestionStatusFromUserAnswers: () => 'answered',
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.AULA_RECOMENDADA },
+        });
+
+        render(<QuizQuestionList />);
+
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (FUVEST - 2021)')).not.toBeInTheDocument();
+      });
+
+      it('should NOT display exam info when quiz is undefined', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              examBoard: 'ENEM',
+              examYear: '2023',
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          goToQuestion: jest.fn(),
+          getQuestionStatusFromUserAnswers: () => 'answered',
+          getQuestionIndex: () => 1,
+          quiz: undefined,
+        });
+
+        render(<QuizQuestionList />);
+
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/src/components/Quiz/Quiz.tsx
+++ b/src/components/Quiz/Quiz.tsx
@@ -238,7 +238,7 @@ const QuizTitle = forwardRef<
 });
 
 const QuizHeader = () => {
-  const { getCurrentQuestion, getQuestionIndex } = useQuizStore();
+  const { getCurrentQuestion, getQuestionIndex, quiz } = useQuizStore();
   const currentQuestion = getCurrentQuestion();
   let currentId =
     currentQuestion && 'questionId' in currentQuestion
@@ -250,10 +250,11 @@ const QuizHeader = () => {
     ? `Questão ${questionIndex.toString().padStart(2, '0')}`
     : 'Questão';
 
-  const examInfo = formatExamInfo(
-    currentQuestion?.examBoard,
-    currentQuestion?.examYear
-  );
+  // Only show exam info (banca/year) for SIMULADO type
+  const shouldShowExamInfo = quiz?.type === QUIZ_TYPE.SIMULADO;
+  const examInfo = shouldShowExamInfo
+    ? formatExamInfo(currentQuestion?.examBoard, currentQuestion?.examYear)
+    : '';
 
   const title = examInfo ? `${questionNumber} ${examInfo}` : questionNumber;
 
@@ -311,7 +312,11 @@ const QuizQuestionList = ({
     goToQuestion,
     getQuestionStatusFromUserAnswers,
     getQuestionIndex,
+    quiz,
   } = useQuizStore();
+
+  // Only show exam info (banca/year) for SIMULADO type
+  const shouldShowExamInfo = quiz?.type === QUIZ_TYPE.SIMULADO;
 
   const groupedQuestions = getQuestionsGroupedBySubject();
   const getQuestionStatus = (questionId: string) => {
@@ -375,10 +380,9 @@ const QuizQuestionList = ({
               {questions.map((question) => {
                 const status = getQuestionStatus(question.id);
                 const questionNumber = getQuestionIndex(question.id);
-                const examInfo = formatExamInfo(
-                  question.examBoard,
-                  question.examYear
-                );
+                const examInfo = shouldShowExamInfo
+                  ? formatExamInfo(question.examBoard, question.examYear)
+                  : '';
                 const questionTitle = `Questão ${questionNumber.toString().padStart(2, '0')}`;
                 const header = examInfo
                   ? `${questionTitle} ${examInfo}`

--- a/src/components/Quiz/QuizResult.test.tsx
+++ b/src/components/Quiz/QuizResult.test.tsx
@@ -2951,5 +2951,191 @@ describe('Quiz', () => {
         expect(screen.getByText('Matemática')).toBeInTheDocument();
       });
     });
+
+    describe('Exam Info Display (examBoard/examYear)', () => {
+      it('should display examBoard and examYear when quiz type is SIMULADO', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              answerStatus: ANSWER_STATUS.RESPOSTA_CORRETA,
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+              examBoard: 'ENEM',
+              examYear: '2023',
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.SIMULADO },
+        } as MockQuizStore);
+
+        render(
+          <QuizListResultByMateria
+            subject="subject-1"
+            onQuestionClick={jest.fn()}
+          />
+        );
+
+        // Should show exam info in the header
+        expect(screen.getByText('Questão 01 (ENEM - 2023)')).toBeInTheDocument();
+      });
+
+      it('should display only examBoard when examYear is null and quiz type is SIMULADO', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              answerStatus: ANSWER_STATUS.RESPOSTA_CORRETA,
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+              examBoard: 'FUVEST',
+              examYear: null,
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.SIMULADO },
+        } as MockQuizStore);
+
+        render(
+          <QuizListResultByMateria
+            subject="subject-1"
+            onQuestionClick={jest.fn()}
+          />
+        );
+
+        // Should show only examBoard
+        expect(screen.getByText('Questão 01 (FUVEST)')).toBeInTheDocument();
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is ATIVIDADE', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              answerStatus: ANSWER_STATUS.RESPOSTA_CORRETA,
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+              examBoard: 'ENEM',
+              examYear: '2023',
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.ATIVIDADE },
+        } as MockQuizStore);
+
+        render(
+          <QuizListResultByMateria
+            subject="subject-1"
+            onQuestionClick={jest.fn()}
+          />
+        );
+
+        // Should NOT show exam info, only question number
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is QUESTIONARIO', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              answerStatus: ANSWER_STATUS.RESPOSTA_CORRETA,
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+              examBoard: 'UNICAMP',
+              examYear: '2022',
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.QUESTIONARIO },
+        } as MockQuizStore);
+
+        render(
+          <QuizListResultByMateria
+            subject="subject-1"
+            onQuestionClick={jest.fn()}
+          />
+        );
+
+        // Should NOT show exam info, only question number
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (UNICAMP - 2022)')).not.toBeInTheDocument();
+      });
+
+      it('should NOT display examBoard/examYear when quiz type is AULA_RECOMENDADA', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              answerStatus: ANSWER_STATUS.RESPOSTA_CORRETA,
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+              examBoard: 'ENEM',
+              examYear: '2021',
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          getQuestionIndex: () => 1,
+          quiz: { type: QUIZ_TYPE.AULA_RECOMENDADA },
+        } as MockQuizStore);
+
+        render(
+          <QuizListResultByMateria
+            subject="subject-1"
+            onQuestionClick={jest.fn()}
+          />
+        );
+
+        // Should NOT show exam info, only question number
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (ENEM - 2021)')).not.toBeInTheDocument();
+      });
+
+      it('should NOT display exam info when quiz is undefined', () => {
+        const mockGroupedQuestions = {
+          'subject-1': [
+            {
+              id: 'question-1',
+              answerStatus: ANSWER_STATUS.RESPOSTA_CORRETA,
+              knowledgeMatrix: [{ subject: { name: 'Matemática' } }],
+              examBoard: 'ENEM',
+              examYear: '2023',
+            },
+          ],
+        };
+
+        mockUseQuizStore.mockReturnValue({
+          getQuestionsGroupedBySubject: () => mockGroupedQuestions,
+          getQuestionIndex: () => 1,
+          quiz: undefined,
+        } as MockQuizStore);
+
+        render(
+          <QuizListResultByMateria
+            subject="subject-1"
+            onQuestionClick={jest.fn()}
+          />
+        );
+
+        // Should NOT show exam info when quiz is undefined
+        expect(screen.getByText('Questão 01')).toBeInTheDocument();
+        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/Quiz/QuizResult.test.tsx
+++ b/src/components/Quiz/QuizResult.test.tsx
@@ -2980,7 +2980,9 @@ describe('Quiz', () => {
         );
 
         // Should show exam info in the header
-        expect(screen.getByText('Questão 01 (ENEM - 2023)')).toBeInTheDocument();
+        expect(
+          screen.getByText('Questão 01 (ENEM - 2023)')
+        ).toBeInTheDocument();
       });
 
       it('should display only examBoard when examYear is null and quiz type is SIMULADO', () => {
@@ -3041,7 +3043,9 @@ describe('Quiz', () => {
 
         // Should NOT show exam info, only question number
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (ENEM - 2023)')
+        ).not.toBeInTheDocument();
       });
 
       it('should NOT display examBoard/examYear when quiz type is QUESTIONARIO', () => {
@@ -3072,7 +3076,9 @@ describe('Quiz', () => {
 
         // Should NOT show exam info, only question number
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (UNICAMP - 2022)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (UNICAMP - 2022)')
+        ).not.toBeInTheDocument();
       });
 
       it('should NOT display examBoard/examYear when quiz type is AULA_RECOMENDADA', () => {
@@ -3103,7 +3109,9 @@ describe('Quiz', () => {
 
         // Should NOT show exam info, only question number
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (ENEM - 2021)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (ENEM - 2021)')
+        ).not.toBeInTheDocument();
       });
 
       it('should NOT display exam info when quiz is undefined', () => {
@@ -3134,7 +3142,9 @@ describe('Quiz', () => {
 
         // Should NOT show exam info when quiz is undefined
         expect(screen.getByText('Questão 01')).toBeInTheDocument();
-        expect(screen.queryByText('Questão 01 (ENEM - 2023)')).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Questão 01 (ENEM - 2023)')
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/Quiz/QuizResult.tsx
+++ b/src/components/Quiz/QuizResult.tsx
@@ -465,8 +465,12 @@ const QuizListResultByMateria = ({
   ) => void;
   subjectName?: string;
 }) => {
-  const { getQuestionsGroupedBySubject, getQuestionIndex } = useQuizStore();
+  const { getQuestionsGroupedBySubject, getQuestionIndex, quiz } =
+    useQuizStore();
   const groupedQuestions = getQuestionsGroupedBySubject();
+
+  // Only show exam info (banca/year) for SIMULADO type
+  const shouldShowExamInfo = quiz?.type === QUIZ_TYPE.SIMULADO;
 
   const answeredQuestions = groupedQuestions[subject] || [];
   const formattedQuestions =
@@ -495,11 +499,13 @@ const QuizListResultByMateria = ({
               'questionId' in question ? question.questionId : question.id;
             const questionIndex = getQuestionIndex(questionId);
 
-            // examBoard and examYear only exist in Question type
+            // examBoard and examYear only exist in Question type - only show for SIMULADO
             const examBoard =
               'examBoard' in question ? question.examBoard : null;
             const examYear = 'examYear' in question ? question.examYear : null;
-            const examInfo = formatExamInfo(examBoard, examYear);
+            const examInfo = shouldShowExamInfo
+              ? formatExamInfo(examBoard, examYear)
+              : '';
             const questionTitle = `Questão ${questionIndex.toString().padStart(2, '0')}`;
             const header = examInfo
               ? `${questionTitle} ${examInfo}`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Exam information display has been refined to appear exclusively in simulated exam quizzes. Other quiz formats now display without exam board and year metadata, providing clearer interfaces and improved user experience across different quiz types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->