### PR TITLE
AE-2742 - fix: LaTeX rendering

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,8 @@ const config = {
     // transform node_modules ESM without heavy config).
     '^react-markdown$': '<rootDir>/src/testing/mockReactMarkdown.tsx',
     '^remark-gfm$': '<rootDir>/src/testing/mockRemarkGfm.ts',
+    '^remark-math$': '<rootDir>/src/testing/mockRemarkMath.ts',
+    '^rehype-katex$': '<rootDir>/src/testing/mockRehypeKatex.ts',
   },
   // Coverage configuration
   collectCoverage: true,

--- a/package.json
+++ b/package.json
@@ -151,7 +151,9 @@
     "react-katex": "^3.1.0",
     "react-markdown": "^10.1.0",
     "react-to-print": "^3.3.0",
+    "rehype-katex": "^7.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "tailwind-merge": "^3.6.0",
     "xlsx": "^0.18.5",
     "zustand": "^5.0.14"

--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
@@ -62,6 +62,13 @@ const HtmlMathRenderer = forwardRef<HTMLElement, HtmlMathRendererProps>(
     // collapse line breaks, so route that content to the Markdown renderer.
     // Inline usage stays on the HTML path to keep phrasing-content validity
     // (Markdown emits block elements: <p>, <ul>, <h4>, ...).
+    //
+    // Note: `renderMathError` is intentionally not forwarded here. The Markdown
+    // path renders math via rehype-katex, which already degrades gracefully on
+    // invalid LaTeX (KaTeX's built-in red error output) rather than throwing.
+    // `renderMathError` is an HTML-path-only customization and is currently
+    // unused by any consumer; honoring it on the Markdown path would require a
+    // bespoke rehype plugin for no practical gain.
     if (!inline && content && isLikelyMarkdown(content)) {
       return (
         <MarkdownMathRenderer

--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
@@ -2,7 +2,12 @@ import { CSSProperties, forwardRef, memo, ReactNode, Ref } from 'react';
 import 'katex/dist/katex.min.css';
 import { InlineMath, BlockMath } from 'react-katex';
 import { cn } from '../../utils/utils';
-import { processHtmlWithMath, sanitizeHtmlForDisplay } from './utils';
+import MarkdownMathRenderer from '../MarkdownMathRenderer/MarkdownMathRenderer';
+import {
+  isLikelyMarkdown,
+  processHtmlWithMath,
+  sanitizeHtmlForDisplay,
+} from './utils';
 
 export interface HtmlMathRendererProps {
   /** HTML content to render, may contain LaTeX math expressions */
@@ -52,6 +57,23 @@ const HtmlMathRenderer = forwardRef<HTMLElement, HtmlMathRendererProps>(
     },
     ref
   ) => {
+    // AI-generated questions/resolutions arrive as Markdown + LaTeX. The HTML
+    // pipeline below would render their `**`/`####`/`*` tokens literally and
+    // collapse line breaks, so route that content to the Markdown renderer.
+    // Inline usage stays on the HTML path to keep phrasing-content validity
+    // (Markdown emits block elements: <p>, <ul>, <h4>, ...).
+    if (!inline && content && isLikelyMarkdown(content)) {
+      return (
+        <MarkdownMathRenderer
+          ref={ref as Ref<HTMLDivElement>}
+          content={content}
+          className={className}
+          style={style}
+          testId={testId}
+        />
+      );
+    }
+
     const defaultErrorRenderer = (latex: string) => (
       <span className="text-error-600 text-sm">Math Error: {latex}</span>
     );

--- a/src/components/HtmlMathRenderer/index.ts
+++ b/src/components/HtmlMathRenderer/index.ts
@@ -6,5 +6,7 @@ export {
   cleanLatex,
   containsMath,
   stripHtml,
+  looksLikeLatex,
+  isLikelyMarkdown,
   type MathPart,
 } from './utils';

--- a/src/components/HtmlMathRenderer/utils.ts
+++ b/src/components/HtmlMathRenderer/utils.ts
@@ -60,6 +60,62 @@ export const looksLikeLatex = (str: string): boolean => {
 };
 
 /**
+ * HTML element names the backoffice RichEditor emits. Kept as a Set (instead
+ * of a long regex alternation) so the tag-detection regex below stays simple
+ * and cheap to reason about.
+ */
+const HTML_TAG_NAMES = new Set([
+  'p',
+  'div',
+  'span',
+  'br',
+  'b',
+  'strong',
+  'i',
+  'em',
+  'u',
+  's',
+  'ul',
+  'ol',
+  'li',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'a',
+  'img',
+  'table',
+  'thead',
+  'tbody',
+  'tfoot',
+  'tr',
+  'td',
+  'th',
+  'blockquote',
+  'pre',
+  'code',
+  'sub',
+  'sup',
+  'font',
+  'latex',
+]);
+
+/**
+ * True when `content` contains a real HTML element tag (open or close) whose
+ * name is one the editor produces. A single generic regex captures any
+ * `<tag`/`</tag` candidate; membership is then checked against the Set, which
+ * keeps the regex trivial and avoids a giant alternation.
+ */
+const containsHtmlTag = (content: string): boolean => {
+  for (const match of content.matchAll(/<\/?([a-z][a-z0-9]*)/gi)) {
+    if (HTML_TAG_NAMES.has(match[1].toLowerCase())) return true;
+  }
+  return false;
+};
+
+/**
  * Heuristic that decides whether `content` is Markdown (as opposed to the
  * HTML the backoffice RichEditor produces). AI-generated questions and
  * resolutions arrive as Markdown + LaTeX (`**bold**`, `#### heading`,
@@ -71,24 +127,28 @@ export const looksLikeLatex = (str: string): boolean => {
  *   `HtmlMathRenderer` handle it exactly as before (math-formula spans,
  *   currency heuristic, katex-error recovery, sanitization).
  * - Otherwise we return `true` only when an unmistakable Markdown marker is
- *   present (ATX heading, bold, bullet/ordered list, or a paragraph break),
- *   which is what breaks today: Markdown rendered as HTML shows the raw
+ *   present (ATX heading, bold, bullet/ordered list, GFM table, or a paragraph
+ *   break), which is what breaks today: Markdown rendered as HTML shows the raw
  *   `**`/`####`/`*` tokens and collapses line breaks.
+ *
+ * Regex note: line-anchored signals use the `m` flag with `^` and restrict
+ * horizontal whitespace to `[ \t]` (never `\s`, which also matches `\n`). This
+ * keeps each quantifier on a single line and avoids the super-linear
+ * backtracking that `(?:^|\n)\s*…\s+` can trigger across newlines.
  */
 export const isLikelyMarkdown = (content: string): boolean => {
   if (!content) return false;
 
   // Presence of real HTML element tags => treat as HTML (RichEditor output).
-  const HTML_TAG_PATTERN =
-    /<\/?(?:p|div|span|br|b|strong|i|em|u|s|ul|ol|li|h[1-6]|a|img|table|thead|tbody|tfoot|tr|td|th|blockquote|pre|code|sub|sup|font|latex)\b/i;
-  if (HTML_TAG_PATTERN.test(content)) return false;
+  if (containsHtmlTag(content)) return false;
 
   const MARKDOWN_SIGNALS = [
-    /(?:^|\n)#{1,6}\s+\S/, // ATX heading (#, ##, ... ######)
+    /^#{1,6}[ \t]+\S/m, // ATX heading (#, ##, ... ######)
     /\*\*[^*\n]+\*\*/, // bold
     /__[^_\n]+__/, // bold (underscore)
-    /(?:^|\n)\s*[-*+]\s+\S/, // bullet list
-    /(?:^|\n)\s*\d+\.\s+\S/, // ordered list
+    /^[ \t]*[-*+][ \t]+\S/m, // bullet list
+    /^[ \t]*\d+\.[ \t]+\S/m, // ordered list
+    /\|[ \t]*:?-+:?[ \t]*\|/, // GFM table delimiter row (|---|---|)
     /\n\n/, // paragraph break (only reached when no HTML tag is present)
   ];
   return MARKDOWN_SIGNALS.some((pattern) => pattern.test(content));

--- a/src/components/HtmlMathRenderer/utils.ts
+++ b/src/components/HtmlMathRenderer/utils.ts
@@ -52,11 +52,46 @@ export const cleanLatex = (str: string): string => {
  *   even a lone `abc` \u2014 does not. This keeps normal spaced equations
  *   rendering while still rejecting currency-`$` prose.
  */
-const looksLikeLatex = (str: string): boolean => {
+export const looksLikeLatex = (str: string): boolean => {
   if (/[\\^_{}]/.test(str)) return true;
   const words = str.match(/[a-zA-Z]{3,}/g);
   if (words && words.length >= 2) return false;
   return true;
+};
+
+/**
+ * Heuristic that decides whether `content` is Markdown (as opposed to the
+ * HTML the backoffice RichEditor produces). AI-generated questions and
+ * resolutions arrive as Markdown + LaTeX (`**bold**`, `#### heading`,
+ * `* lists`, `$...$`, `$$...$$`), whereas the editor stores HTML (`<p>`,
+ * `<b>`, `<span class="math-formula" data-latex="...">`). The two sources are
+ * cleanly separable, so we bias toward the proven HTML path:
+ *
+ * - If any real HTML element tag is present we return `false` and let
+ *   `HtmlMathRenderer` handle it exactly as before (math-formula spans,
+ *   currency heuristic, katex-error recovery, sanitization).
+ * - Otherwise we return `true` only when an unmistakable Markdown marker is
+ *   present (ATX heading, bold, bullet/ordered list, or a paragraph break),
+ *   which is what breaks today: Markdown rendered as HTML shows the raw
+ *   `**`/`####`/`*` tokens and collapses line breaks.
+ */
+export const isLikelyMarkdown = (content: string): boolean => {
+  if (!content) return false;
+
+  // Presence of real HTML element tags => treat as HTML (RichEditor output).
+  const HTML_TAG_PATTERN =
+    /<\/?(?:p|div|span|br|b|strong|i|em|u|s|ul|ol|li|h[1-6]|a|img|table|thead|tbody|tfoot|tr|td|th|blockquote|pre|code|sub|sup|font|latex)\b/i;
+  if (HTML_TAG_PATTERN.test(content)) return false;
+
+  const MARKDOWN_SIGNALS = [
+    /(?:^|\n)#{1,6}\s+\S/, // ATX heading (#, ##, ... ######)
+    /\*\*[^*\n]+\*\*/, // bold
+    /__[^_\n]+__/, // bold (underscore)
+    /(?:^|\n)\s*[-*+]\s+\S/, // bullet list
+    /(?:^|\n)\s*\d+\.\s+\S/, // ordered list
+    /\n\n/, // paragraph break (only reached when no HTML tag is present)
+  ];
+  return MARKDOWN_SIGNALS.some((pattern) => pattern.test(content));
 };
 
 /**

--- a/src/components/MarkdownMathRenderer/MarkdownMathRenderer.test.tsx
+++ b/src/components/MarkdownMathRenderer/MarkdownMathRenderer.test.tsx
@@ -51,6 +51,13 @@ describe('isLikelyMarkdown', () => {
     // multiplication asterisks must not be treated as bold
     expect(isLikelyMarkdown('Calcule 3 * 4 * 5 com cuidado.')).toBe(false);
   });
+
+  it('detects GFM tables via the delimiter row', () => {
+    expect(isLikelyMarkdown('| A | B |\n|---|---|\n| 1 | 2 |')).toBe(true);
+    expect(isLikelyMarkdown('| x | y |\n| :-- | --: |\n| 1 | 2 |')).toBe(true);
+    // a stray pipe in prose is not a table
+    expect(isLikelyMarkdown('use a | b para separar valores')).toBe(false);
+  });
 });
 
 describe('protectCurrencyInlineMath', () => {
@@ -146,5 +153,19 @@ describe('HtmlMathRenderer delegation', () => {
     // On the inline HTML path the markdown tokens stay literal (no <strong>).
     expect(container.querySelector('strong')).toBeNull();
     expect(container.textContent).toContain('**destaque**');
+  });
+});
+
+describe('MarkdownMathRenderer code protection', () => {
+  it('does not escape currency $ inside inline code spans', () => {
+    // The `$ ... $` inside the code span looks like prose-currency and would
+    // be escaped by protectCurrencyInlineMath if not shielded. withProtectedCode
+    // must keep the code content verbatim.
+    const { container } = render(
+      <MarkdownMathRenderer content="`valor R$ 15,00 pelo custo fixo R$ 42,00`" />
+    );
+    const code = container.querySelector('code');
+    expect(code?.textContent).toBe('valor R$ 15,00 pelo custo fixo R$ 42,00');
+    expect(container.textContent).not.toContain('\\$');
   });
 });

--- a/src/components/MarkdownMathRenderer/MarkdownMathRenderer.test.tsx
+++ b/src/components/MarkdownMathRenderer/MarkdownMathRenderer.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import MarkdownMathRenderer, {
+  protectCurrencyInlineMath,
+  reflowDisplayMath,
+} from './MarkdownMathRenderer';
+import HtmlMathRenderer from '../HtmlMathRenderer/HtmlMathRenderer';
+import { isLikelyMarkdown } from '../HtmlMathRenderer/utils';
+
+// react-markdown / remark / rehype ship ESM and are stubbed via jest
+// moduleNameMapper. react-katex is mocked here for the HTML-path branches that
+// HtmlMathRenderer may exercise.
+jest.mock('react-katex', () => ({
+  InlineMath: ({ math }: { math: string }) => (
+    <span data-testid="inline-math">{math}</span>
+  ),
+  BlockMath: ({ math }: { math: string }) => (
+    <div data-testid="block-math">{math}</div>
+  ),
+}));
+
+describe('isLikelyMarkdown', () => {
+  it('returns false for empty content', () => {
+    expect(isLikelyMarkdown('')).toBe(false);
+  });
+
+  it('treats content with HTML tags as NOT markdown (HTML path)', () => {
+    expect(isLikelyMarkdown('<p>Olá <b>mundo</b></p>')).toBe(false);
+    expect(
+      isLikelyMarkdown('<span class="math-formula" data-latex="x^2">x^2</span>')
+    ).toBe(false);
+    expect(isLikelyMarkdown('Texto com <br/> quebra')).toBe(false);
+    expect(isLikelyMarkdown('Use <latex>x^2</latex> aqui')).toBe(false);
+    expect(isLikelyMarkdown('<sub>2</sub>O')).toBe(false);
+  });
+
+  it('detects markdown headings, bold, lists and paragraph breaks', () => {
+    expect(isLikelyMarkdown('#### Conclusão\n\ntexto')).toBe(true);
+    expect(isLikelyMarkdown('A afirmativa é **Verdadeira**.')).toBe(true);
+    expect(isLikelyMarkdown('texto __forte__ aqui')).toBe(true);
+    expect(isLikelyMarkdown('* item um\n* item dois')).toBe(true);
+    expect(isLikelyMarkdown('- item\n- outro')).toBe(true);
+    expect(isLikelyMarkdown('1. primeiro\n2. segundo')).toBe(true);
+    expect(isLikelyMarkdown('Parágrafo um.\n\nParágrafo dois.')).toBe(true);
+  });
+
+  it('does not flag plain prose or single-line math as markdown', () => {
+    expect(isLikelyMarkdown('Uma frase simples sem marcação.')).toBe(false);
+    expect(isLikelyMarkdown('A fórmula é $\\frac{1}{2} u$ apenas.')).toBe(
+      false
+    );
+    // multiplication asterisks must not be treated as bold
+    expect(isLikelyMarkdown('Calcule 3 * 4 * 5 com cuidado.')).toBe(false);
+  });
+});
+
+describe('protectCurrencyInlineMath', () => {
+  it('escapes currency $ spans so they are not parsed as math', () => {
+    const out = protectCurrencyInlineMath(
+      'O preço é R$ 15,00 reais e o livro custa R$ 42,00 no total.'
+    );
+    expect(out).toBe(
+      'O preço é R\\$ 15,00 reais e o livro custa R\\$ 42,00 no total.'
+    );
+  });
+
+  it('keeps real inline math untouched', () => {
+    const input = 'A fórmula $x^2 + 1$ é importante.';
+    expect(protectCurrencyInlineMath(input)).toBe(input);
+  });
+
+  it('does not touch display math ($$...$$)', () => {
+    const input = 'Equação: $$a = b$$ pronta.';
+    expect(protectCurrencyInlineMath(input)).toBe(input);
+  });
+});
+
+describe('reflowDisplayMath', () => {
+  it('reflows single-line $$...$$ into block (display) form', () => {
+    expect(reflowDisplayMath('Veja $$a = b$$ agora')).toBe(
+      'Veja \n\n$$\na = b\n$$\n\n agora'
+    );
+  });
+
+  it('leaves inline single-$ math untouched', () => {
+    const input = 'inline $x^2$ aqui';
+    expect(reflowDisplayMath(input)).toBe(input);
+  });
+});
+
+describe('MarkdownMathRenderer (component)', () => {
+  it('renders markdown bold via react-markdown', () => {
+    render(<MarkdownMathRenderer content="A afirmativa é **Verdadeira**." />);
+    expect(screen.getByText('Verdadeira')).toBeInTheDocument();
+    expect(screen.getByText('Verdadeira').tagName).toBe('STRONG');
+  });
+
+  it('renders bullet lists', () => {
+    const { container } = render(
+      <MarkdownMathRenderer content={'* item um\n* item dois'} />
+    );
+    expect(container.querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('applies testId, className and style', () => {
+    const { container } = render(
+      <MarkdownMathRenderer
+        content="**oi**"
+        testId="md"
+        className="custom-class"
+        style={{ color: 'red' }}
+      />
+    );
+    const root = screen.getByTestId('md');
+    expect(root).toBeInTheDocument();
+    expect(root.className).toContain('custom-class');
+    expect(container.querySelector('[data-testid="md"]')).toHaveStyle({
+      color: 'rgb(255, 0, 0)',
+    });
+  });
+
+  it('returns gracefully for empty content', () => {
+    const { container } = render(<MarkdownMathRenderer content="" />);
+    expect(container).toBeInTheDocument();
+  });
+});
+
+describe('HtmlMathRenderer delegation', () => {
+  it('delegates markdown content to the markdown renderer', () => {
+    render(
+      <HtmlMathRenderer content={'#### Título\n\nA resposta é **certa**.'} />
+    );
+    expect(screen.getByText('certa').tagName).toBe('STRONG');
+  });
+
+  it('keeps HTML content on the HTML path (bold stays via tags)', () => {
+    const { container } = render(
+      <HtmlMathRenderer content="<p>Olá <b>mundo</b></p>" />
+    );
+    expect(container.querySelector('b')?.textContent).toBe('mundo');
+  });
+
+  it('does NOT route inline usage to markdown (phrasing-content safe)', () => {
+    const { container } = render(
+      <HtmlMathRenderer content="valor **destaque**" inline />
+    );
+    // On the inline HTML path the markdown tokens stay literal (no <strong>).
+    expect(container.querySelector('strong')).toBeNull();
+    expect(container.textContent).toContain('**destaque**');
+  });
+});

--- a/src/components/MarkdownMathRenderer/MarkdownMathRenderer.tsx
+++ b/src/components/MarkdownMathRenderer/MarkdownMathRenderer.tsx
@@ -1,0 +1,134 @@
+import { CSSProperties, forwardRef, memo, Ref } from 'react';
+import 'katex/dist/katex.min.css';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import { cn } from '../../utils/utils';
+import { looksLikeLatex } from '../HtmlMathRenderer/utils';
+
+export interface MarkdownMathRendererProps {
+  /** Markdown content, may contain LaTeX math expressions ($...$ / $$...$$) */
+  content: string;
+  /** Additional CSS class names */
+  className?: string;
+  /** Inline styles */
+  style?: CSSProperties;
+  /** Test ID for testing */
+  testId?: string;
+}
+
+/**
+ * Strips zero-width / invisible characters that occasionally leak into
+ * AI-generated content and break KaTeX parsing.
+ */
+const stripInvisibleChars = (str: string): string =>
+  str.replaceAll(/[\u200B-\u200D\uFEFF]/g, '');
+
+/**
+ * Escapes the `$` of inline `$...$` spans that do NOT look like real math, so
+ * `remark-math` leaves them as literal text. Without this, currency prose like
+ * "R$ 15,00 ... R$ 42,00" gets paired up and rendered as gibberish math.
+ *
+ * Reuses the exact `looksLikeLatex` heuristic the HTML renderer applies to
+ * single-`$` spans, so both renderers agree on what is math vs currency.
+ * Display math (`$$...$$`) is intentionally left untouched (handled below).
+ */
+export const protectCurrencyInlineMath = (markdown: string): string =>
+  markdown.replaceAll(
+    /(?<!\\)\$(?!\$)([^\n$]+?)(?<!\\)\$(?!\$)/g,
+    (match, inner: string) =>
+      looksLikeLatex(inner) ? match : match.replaceAll('$', String.raw`\$`)
+  );
+
+/**
+ * `remark-math` only renders a `$$...$$` block as centered display math when
+ * the delimiters sit on their own lines ("math flow"). AI content usually puts
+ * the whole equation on a single line (`$$x = y$$`), which would otherwise be
+ * rendered inline. Reflow single-line `$$...$$` into block form so equations
+ * stay centered, matching how the HTML renderer treats `$$`.
+ */
+export const reflowDisplayMath = (markdown: string): string =>
+  markdown.replaceAll(
+    /(?<!\$)\$\$(?!\$)([^\n]+?)\$\$(?!\$)/g,
+    (_match, inner: string) => `\n\n$$\n${inner.trim()}\n$$\n\n`
+  );
+
+const preprocessMarkdown = (content: string): string =>
+  reflowDisplayMath(protectCurrencyInlineMath(stripInvisibleChars(content)));
+
+/**
+ * MarkdownMathRenderer - Renders Markdown content with embedded LaTeX math.
+ *
+ * Used for AI-generated questions and resolutions, which arrive as Markdown
+ * (`**bold**`, `#### headings`, `* lists`, paragraphs) mixed with LaTeX
+ * (`$...$` inline, `$$...$$` display). Built on `react-markdown` with
+ * `remark-gfm` (tables/lists), `remark-math` + `rehype-katex` (math).
+ *
+ * SECURITY: raw HTML is intentionally NOT enabled (no `rehype-raw`). This
+ * renderer only receives content classified as Markdown (no HTML tags) by
+ * `isLikelyMarkdown`; HTML content keeps flowing through `HtmlMathRenderer`,
+ * which sanitizes it. Adding raw-HTML support here would reintroduce an XSS
+ * vector and requires a dedicated sanitization pipeline + security review.
+ */
+const MarkdownMathRenderer = forwardRef<
+  HTMLDivElement,
+  MarkdownMathRendererProps
+>(({ content, className, style, testId }, ref) => {
+  const sharedClassName = cn(
+    'leading-relaxed',
+    // Paragraph spacing
+    '[&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0',
+    // Headings
+    '[&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-3 [&_h1]:mb-2',
+    '[&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2',
+    '[&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-2.5 [&_h3]:mb-1.5',
+    '[&_h4]:text-base [&_h4]:font-semibold [&_h4]:mt-2.5 [&_h4]:mb-1.5',
+    '[&_h5]:font-semibold [&_h6]:font-semibold',
+    // Lists
+    '[&_ul]:list-disc [&_ul]:pl-5 [&_ul]:my-2',
+    '[&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:my-2',
+    '[&_li]:my-1 [&_li>ul]:my-1 [&_li>ol]:my-1',
+    // Text formatting
+    '[&_b]:font-bold [&_strong]:font-bold',
+    '[&_i]:italic [&_em]:italic',
+    '[&_u]:underline',
+    '[&_blockquote]:border-l-4 [&_blockquote]:border-border-200 [&_blockquote]:pl-3 [&_blockquote]:text-text-700',
+    '[&_code]:rounded [&_code]:bg-background-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-sm',
+    // Hide the KaTeX MathML accessibility layer visually (still readable to
+    // screen readers). Tailwind preflight overrides KaTeX's default clip
+    // rule, so without this the MathML layer duplicates every formula as
+    // raw text next to the visual render.
+    '[&_.katex-mathml]:sr-only',
+    // Display math spacing
+    '[&_.katex-display]:my-2.5',
+    // Tables (GFM)
+    '[&_table]:border-collapse [&_table]:w-full [&_table]:my-2.5 [&_table]:table-auto',
+    '[&_table_td]:border [&_table_td]:border-border-200 [&_table_td]:p-2 [&_table_td]:min-w-[50px] [&_table_td]:align-top',
+    '[&_table_th]:border [&_table_th]:border-border-200 [&_table_th]:p-2 [&_table_th]:min-w-[50px] [&_table_th]:align-top [&_table_th]:bg-background-50 [&_table_th]:font-semibold',
+    // Images and links
+    '[&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2',
+    '[&_a]:text-primary-500 [&_a]:underline [&_a:hover]:text-primary-600',
+    className
+  );
+
+  return (
+    <div
+      ref={ref as Ref<HTMLDivElement>}
+      className={sharedClassName}
+      style={style}
+      data-testid={testId}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+      >
+        {preprocessMarkdown(content)}
+      </ReactMarkdown>
+    </div>
+  );
+});
+
+MarkdownMathRenderer.displayName = 'MarkdownMathRenderer';
+
+export default memo(MarkdownMathRenderer);

--- a/src/components/MarkdownMathRenderer/MarkdownMathRenderer.tsx
+++ b/src/components/MarkdownMathRenderer/MarkdownMathRenderer.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, forwardRef, memo, Ref } from 'react';
+import { CSSProperties, forwardRef, memo } from 'react';
 import 'katex/dist/katex.min.css';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -54,8 +54,39 @@ export const reflowDisplayMath = (markdown: string): string =>
     (_match, inner: string) => `\n\n$$\n${inner.trim()}\n$$\n\n`
   );
 
+/**
+ * Runs `transform` over the markdown while shielding fenced code blocks and
+ * inline code spans: each is stashed behind a placeholder, the transform runs
+ * on the rest, then the originals are restored before the markdown reaches
+ * react-markdown. Without this, the currency / display-math passes would
+ * rewrite literal `$`/`$$` that authors put inside code samples (e.g. a fenced
+ * block containing `price = $value`). The placeholder is purely transient (it
+ * never reaches the markdown parser) and contains no `$`, so the passes ignore
+ * it.
+ */
+const withProtectedCode = (
+  markdown: string,
+  transform: (input: string) => string
+): string => {
+  const stash: string[] = [];
+  const tokenized = markdown.replaceAll(
+    /```[\s\S]*?```|`[^`\n]*`/g,
+    (segment) => {
+      const token = `__CODE_SEG_${stash.length}__`;
+      stash.push(segment);
+      return token;
+    }
+  );
+  return transform(tokenized).replaceAll(
+    /__CODE_SEG_(\d+)__/g,
+    (_match, index: string) => stash[Number(index)]
+  );
+};
+
 const preprocessMarkdown = (content: string): string =>
-  reflowDisplayMath(protectCurrencyInlineMath(stripInvisibleChars(content)));
+  withProtectedCode(stripInvisibleChars(content), (safe) =>
+    reflowDisplayMath(protectCurrencyInlineMath(safe))
+  );
 
 /**
  * MarkdownMathRenderer - Renders Markdown content with embedded LaTeX math.
@@ -114,7 +145,7 @@ const MarkdownMathRenderer = forwardRef<
 
   return (
     <div
-      ref={ref as Ref<HTMLDivElement>}
+      ref={ref}
       className={sharedClassName}
       style={style}
       data-testid={testId}

--- a/src/components/MarkdownMathRenderer/index.ts
+++ b/src/components/MarkdownMathRenderer/index.ts
@@ -1,0 +1,6 @@
+export { default as MarkdownMathRenderer } from './MarkdownMathRenderer';
+export type { MarkdownMathRendererProps } from './MarkdownMathRenderer';
+export {
+  protectCurrencyInlineMath,
+  reflowDisplayMath,
+} from './MarkdownMathRenderer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,11 +22,19 @@ export {
   cleanLatex,
   containsMath,
   stripHtml,
+  looksLikeLatex,
+  isLikelyMarkdown,
 } from './components/HtmlMathRenderer';
 export type {
   HtmlMathRendererProps,
   MathPart,
 } from './components/HtmlMathRenderer';
+export {
+  MarkdownMathRenderer,
+  protectCurrencyInlineMath,
+  reflowDisplayMath,
+} from './components/MarkdownMathRenderer';
+export type { MarkdownMathRendererProps } from './components/MarkdownMathRenderer';
 export { default as IconButton } from './components/IconButton/IconButton';
 export { Tooltip } from './components/Tooltip/Tooltip';
 export type { TooltipProps } from './components/Tooltip/Tooltip';

--- a/src/testing/mockRehypeKatex.ts
+++ b/src/testing/mockRehypeKatex.ts
@@ -1,0 +1,7 @@
+/**
+ * Test double for `rehype-katex`. The real plugin is ESM-only; our mocked
+ * `react-markdown` ignores the plugins array, so the no-op default is
+ * sufficient to satisfy the import.
+ */
+const rehypeKatexMock = () => undefined;
+export default rehypeKatexMock;

--- a/src/testing/mockRemarkMath.ts
+++ b/src/testing/mockRemarkMath.ts
@@ -1,0 +1,7 @@
+/**
+ * Test double for `remark-math`. The real plugin is ESM-only; our mocked
+ * `react-markdown` ignores the plugins array, so the no-op default is
+ * sufficient to satisfy the import.
+ */
+const remarkMathMock = () => undefined;
+export default remarkMathMock;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,7 +3170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/katex@npm:^0.16.8":
+"@types/katex@npm:^0.16.0, @types/katex@npm:^0.16.8":
   version: 0.16.8
   resolution: "@types/katex@npm:0.16.8"
   checksum: 10c0/0661609353f4f5e62bd2dc78da99e842761c6474b19f2268b195bbe9dbf20e6f766a31155d79eec2e7c3eff4e7eba4b30f4f519e9c6a11c75bb45e257a2ddb69
@@ -3768,7 +3768,9 @@ __metadata:
     react-markdown: "npm:^10.1.0"
     react-router-dom: "npm:^7.16.0"
     react-to-print: "npm:^3.3.0"
+    rehype-katex: "npm:^7.0.0"
     remark-gfm: "npm:^4.0.1"
+    remark-math: "npm:^6.0.0"
     sonarqube-scanner: "npm:^4.3.6"
     tailwind-merge: "npm:^3.6.0"
     tailwindcss: "npm:^4.3.0"
@@ -6368,6 +6370,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-from-dom@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "hast-util-from-dom@npm:5.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hastscript: "npm:^9.0.0"
+    web-namespaces: "npm:^2.0.0"
+  checksum: 10c0/9a90381e048107a093a3da758bb17b67aaf5322e222f02497f841c4990abf94aa177d38d5b9bf61ad07b3601d0409f34f5b556d89578cc189230c6b994d2af77
+  languageName: node
+  linkType: hard
+
+"hast-util-from-html-isomorphic@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "hast-util-from-html-isomorphic@npm:2.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hast-util-from-dom: "npm:^5.0.0"
+    hast-util-from-html: "npm:^2.0.0"
+    unist-util-remove-position: "npm:^5.0.0"
+  checksum: 10c0/fc68d9245e794483a802d5c85a9f6c25959e00db78cc796411efc965134f3206f9cc9fa38134572ea781ad74663e801f1f83202007b208e27a770855566a62b6
+  languageName: node
+  linkType: hard
+
+"hast-util-from-html@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "hast-util-from-html@npm:2.0.3"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    devlop: "npm:^1.1.0"
+    hast-util-from-parse5: "npm:^8.0.0"
+    parse5: "npm:^7.0.0"
+    vfile: "npm:^6.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/993ef707c1a12474c8d4094fc9706a72826c660a7e308ea54c50ad893353d32e139b7cbc67510c2e82feac572b320e3b05aeb13d0f9c6302d61261f337b46764
+  languageName: node
+  linkType: hard
+
 "hast-util-from-parse5@npm:^8.0.0":
   version: 8.0.3
   resolution: "hast-util-from-parse5@npm:8.0.3"
@@ -6390,6 +6429,15 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/6e2c0e22ca893c6ebb60f8390e184c4deb041c36d09796756f02cd121c1789c0f5c862ed06caea8f1a80ea8c0ef6a7854dd57946c2eebb76488727bd4a1c952e
+  languageName: node
+  linkType: hard
+
+"hast-util-is-element@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-is-element@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10c0/f5361e4c9859c587ca8eb0d8343492f3077ccaa0f58a44cd09f35d5038f94d65152288dcd0c19336ef2c9491ec4d4e45fde2176b05293437021570aa0bc3613b
   languageName: node
   linkType: hard
 
@@ -6514,6 +6562,18 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10c0/b5fa1912a6ba6131affae52a0f4394406c4c0d23c2b0307f1d69988f1030c7bb830289303e67c5ad8f674f5f23a454c1dcd492c39e45a22c1f46d3c9bce5bd0c
+  languageName: node
+  linkType: hard
+
+"hast-util-to-text@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "hast-util-to-text@npm:4.0.2"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    hast-util-is-element: "npm:^3.0.0"
+    unist-util-find-after: "npm:^5.0.0"
+  checksum: 10c0/93ecc10e68fe5391c6e634140eb330942e71dea2724c8e0c647c73ed74a8ec930a4b77043b5081284808c96f73f2bee64ee416038ece75a63a467e8d14f09946
   languageName: node
   linkType: hard
 
@@ -8292,6 +8352,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-math@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mdast-util-math@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.1.0"
+    unist-util-remove-position: "npm:^5.0.0"
+  checksum: 10c0/d4e839e38719f26872ed78aac18339805a892f1b56585a9cb8668f34e221b4f0660b9dfe49ec96dbbe79fd1b63b648608a64046d8286bcd2f9d576e80b48a0a1
+  languageName: node
+  linkType: hard
+
 "mdast-util-mdx-expression@npm:^2.0.0":
   version: 2.0.1
   resolution: "mdast-util-mdx-expression@npm:2.0.1"
@@ -8380,7 +8455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-to-markdown@npm:^2.0.0":
+"mdast-util-to-markdown@npm:^2.0.0, mdast-util-to-markdown@npm:^2.1.0":
   version: 2.1.2
   resolution: "mdast-util-to-markdown@npm:2.1.2"
   dependencies:
@@ -8548,6 +8623,21 @@ __metadata:
     micromark-util-combine-extensions: "npm:^2.0.0"
     micromark-util-types: "npm:^2.0.0"
   checksum: 10c0/970e28df6ebdd7c7249f52a0dda56e0566fbfa9ae56c8eeeb2445d77b6b89d44096880cd57a1c01e7821b1f4e31009109fbaca4e89731bff7b83b8519690e5d9
+  languageName: node
+  linkType: hard
+
+"micromark-extension-math@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "micromark-extension-math@npm:3.1.0"
+  dependencies:
+    "@types/katex": "npm:^0.16.0"
+    devlop: "npm:^1.0.0"
+    katex: "npm:^0.16.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/56e6f2185a4613f9d47e7e98cf8605851c990957d9229c942b005e286c8087b61dc9149448d38b2f8be6d42cc6a64aad7e1f2778ddd86fbbb1a2f48a3ca1872f
   languageName: node
   linkType: hard
 
@@ -10227,6 +10317,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rehype-katex@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "rehype-katex@npm:7.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/katex": "npm:^0.16.0"
+    hast-util-from-html-isomorphic: "npm:^2.0.0"
+    hast-util-to-text: "npm:^4.0.0"
+    katex: "npm:^0.16.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/73c770319536128b75055d904d06951789d00a0552c11724c0dac2e244dcb21041630552d118a11cc42233fdcd1bfee525e78a0020fde635bd916cceb281dfb1
+  languageName: node
+  linkType: hard
+
 "rehype-raw@npm:^7.0.0":
   version: 7.0.0
   resolution: "rehype-raw@npm:7.0.0"
@@ -10260,6 +10365,18 @@ __metadata:
     remark-stringify: "npm:^11.0.0"
     unified: "npm:^11.0.0"
   checksum: 10c0/427ecc6af3e76222662061a5f670a3e4e33ec5fffe2cabf04034da6a3f9a1bda1fc023e838a636385ba314e66e2bebbf017ca61ebea357eb0f5200fe0625a4b7
+  languageName: node
+  linkType: hard
+
+"remark-math@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "remark-math@npm:6.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-math: "npm:^3.0.0"
+    micromark-extension-math: "npm:^3.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/859613c4db194bb6b3c9c063661dc52b8ceda9c5cf3256b42f73d93eb8f38a6d634eb5f976fe094425f6f1035aaf329eb49ada314feb3b2b1073326b6d3aaa02
   languageName: node
   linkType: hard
 
@@ -11569,6 +11686,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-find-after@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-find-after@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/a7cea473c4384df8de867c456b797ff1221b20f822e1af673ff5812ed505358b36f47f3b084ac14c3622cb879ed833b71b288e8aa71025352a2aab4c2925a6eb
+  languageName: node
+  linkType: hard
+
 "unist-util-is@npm:^6.0.0":
   version: 6.0.1
   resolution: "unist-util-is@npm:6.0.1"
@@ -11593,6 +11720,16 @@ __metadata:
   dependencies:
     "@types/unist": "npm:^3.0.0"
   checksum: 10c0/dde3b31e314c98f12b4dc6402f9722b2bf35e96a4f2d463233dd90d7cde2d4928074a7a11eff0a5eb1f4e200f27fc1557e0a64a7e8e4da6558542f251b1b7400
+  languageName: node
+  linkType: hard
+
+"unist-util-remove-position@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-remove-position@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-visit: "npm:^5.0.0"
+  checksum: 10c0/e8c76da4399446b3da2d1c84a97c607b37d03d1d92561e14838cbe4fdcb485bfc06c06cfadbb808ccb72105a80643976d0660d1fe222ca372203075be9d71105
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MarkdownMathRenderer component for rendering Markdown content with embedded LaTeX math equations.
  * Enhanced HtmlMathRenderer with intelligent content detection to automatically route between HTML and Markdown rendering modes.

* **Tests**
  * Added comprehensive test suite validating math rendering across inline and block display formats.

* **Chores**
  * Added dependencies for LaTeX math rendering support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->