### PR TITLE
AE-2742 - fix: render KaTeX directly instead of react-katex

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,6 @@
     "./dist/index.css"
   ],
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    },
     "./styles.css": "./dist/styles.css"
   },
   "scripts": {
@@ -142,13 +137,12 @@
     "dayjs": "^1.11.21",
     "dompurify": "^3.4.7",
     "html-react-parser": "6.1.2",
-    "katex": "^0.17.0",
+    "katex": "^0.16.0",
     "phosphor-react": "^1.4.1",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-katex": "^3.1.0",
     "react-markdown": "^10.1.0",
     "react-to-print": "^3.3.0",
     "rehype-katex": "^7.0.0",
@@ -192,7 +186,6 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
-    "@types/react-katex": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
     "autoprefixer": "^10.5.0",

--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.test.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.test.tsx
@@ -9,14 +9,21 @@ import {
   stripHtml,
 } from './utils';
 
-// Mock react-katex to avoid actual LaTeX rendering in tests
-jest.mock('react-katex', () => ({
-  InlineMath: ({ math }: { math: string }) => (
-    <span data-testid="inline-math">{math}</span>
-  ),
-  BlockMath: ({ math }: { math: string }) => (
-    <div data-testid="block-math">{math}</div>
-  ),
+// Mock KatexMath (which calls katex directly) to avoid actual LaTeX rendering
+// in tests and keep deterministic test ids for inline vs block math.
+jest.mock('./KatexMath', () => ({
+  KatexMath: ({
+    math,
+    displayMode,
+  }: {
+    math: string;
+    displayMode?: boolean;
+  }) =>
+    displayMode ? (
+      <div data-testid="block-math">{math}</div>
+    ) : (
+      <span data-testid="inline-math">{math}</span>
+    ),
 }));
 
 describe('HtmlMathRenderer', () => {

--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, forwardRef, memo, ReactNode, Ref } from 'react';
 import 'katex/dist/katex.min.css';
-import { InlineMath, BlockMath } from 'react-katex';
+import { KatexMath } from './KatexMath';
 import { cn } from '../../utils/utils';
 import MarkdownMathRenderer from '../MarkdownMathRenderer/MarkdownMathRenderer';
 import {
@@ -125,17 +125,17 @@ const HtmlMathRenderer = forwardRef<HTMLElement, HtmlMathRendererProps>(
             const key = getPartKey(part, index);
             if (part.type === 'math' && part.latex) {
               return (
-                <InlineMath
+                <KatexMath
                   key={key}
                   math={part.latex}
                   renderError={() => errorRenderer(part.latex!)}
                 />
               );
             } else if (part.type === 'block-math' && part.latex) {
-              // When inline mode, use InlineMath to avoid block-level elements inside span
+              // When inline mode, render inline to avoid block-level elements inside span
               if (inline) {
                 return (
-                  <InlineMath
+                  <KatexMath
                     key={key}
                     math={part.latex}
                     renderError={() => errorRenderer(part.latex!)}
@@ -144,8 +144,9 @@ const HtmlMathRenderer = forwardRef<HTMLElement, HtmlMathRendererProps>(
               }
               return (
                 <div key={key} className="my-2.5 text-center">
-                  <BlockMath
+                  <KatexMath
                     math={part.latex}
+                    displayMode
                     renderError={() => errorRenderer(part.latex!)}
                   />
                 </div>

--- a/src/components/HtmlMathRenderer/KatexMath.test.tsx
+++ b/src/components/HtmlMathRenderer/KatexMath.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { KatexMath } from './KatexMath';
+
+// Uses the real `katex` package (renderToString is pure and runs under jsdom).
+
+describe('KatexMath', () => {
+  it('renders inline math as a <span> with KaTeX output', () => {
+    const { container } = render(<KatexMath math="\frac{1}{2}" />);
+    const el = screen.getByTestId('react-katex');
+    expect(el.tagName).toBe('SPAN');
+    expect(container.querySelector('.katex')).toBeInTheDocument();
+    // \frac must actually render as a fraction (the bug was \frac failing)
+    expect(container.querySelector('.mfrac')).toBeInTheDocument();
+  });
+
+  it('renders display math as a <div>', () => {
+    render(<KatexMath math="x^2" displayMode />);
+    expect(screen.getByTestId('react-katex').tagName).toBe('DIV');
+  });
+
+  it('renders backslash commands (\\cdot, \\left/\\right) without error', () => {
+    const onError = jest.fn(() => <span data-testid="err" />);
+    const { container } = render(
+      <KatexMath
+        math="\left(\frac{1}{2}\right) \cdot u"
+        renderError={onError}
+      />
+    );
+    expect(onError).not.toHaveBeenCalled();
+    expect(container.querySelector('.katex')).toBeInTheDocument();
+  });
+
+  it('calls renderError when LaTeX is invalid', () => {
+    const onError = jest.fn(() => <span data-testid="err">erro</span>);
+    render(<KatexMath math={'\\frac{'} renderError={onError} />);
+    expect(onError).toHaveBeenCalled();
+    expect(screen.getByTestId('err')).toBeInTheDocument();
+  });
+
+  it('renders nothing when LaTeX is invalid and no renderError is given', () => {
+    const { container } = render(<KatexMath math={'\\frac{'} />);
+    expect(
+      container.querySelector('[data-testid="react-katex"]')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HtmlMathRenderer/KatexMath.tsx
+++ b/src/components/HtmlMathRenderer/KatexMath.tsx
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react';
+import katex from 'katex';
+
+export interface KatexMathProps {
+  /** LaTeX source to render */
+  math: string;
+  /** Render as centered display math (block) instead of inline */
+  displayMode?: boolean;
+  /** Called with the thrown error when KaTeX fails to parse `math` */
+  renderError?: (error: unknown) => ReactNode;
+}
+
+/**
+ * Renders a single LaTeX expression with KaTeX, calling `katex.renderToString`
+ * directly instead of going through `react-katex`.
+ *
+ * Why not `react-katex`: when bundlers (Vite/esbuild dev optimizer, Rollup)
+ * bundle `react-katex` they inline their OWN copy of KaTeX whose function
+ * registry ends up broken — symbols render but `\`-commands (`\frac`, `\cdot`,
+ * `\left`, ...) fail with a parse error. Importing `katex` directly here uses
+ * the shared, correctly-bundled KaTeX (the same one `rehype-katex` uses), so
+ * every command renders. See HtmlMathRenderer for the surrounding pipeline.
+ */
+export const KatexMath = ({
+  math,
+  displayMode = false,
+  renderError,
+}: KatexMathProps) => {
+  let html: string | null = null;
+  let error: unknown = null;
+
+  try {
+    html = katex.renderToString(math, {
+      displayMode,
+      throwOnError: true,
+    });
+  } catch (caught) {
+    error = caught;
+  }
+
+  if (error !== null) {
+    return <>{renderError ? renderError(error) : null}</>;
+  }
+
+  const Tag = displayMode ? 'div' : 'span';
+  return (
+    <Tag
+      data-testid="react-katex"
+      // KaTeX output is sanitized markup it generates itself from the parsed
+      // LaTeX; there is no untrusted HTML passthrough here.
+      dangerouslySetInnerHTML={{ __html: html as string }}
+    />
+  );
+};
+
+export default KatexMath;

--- a/src/components/HtmlMathRenderer/KatexMath.tsx
+++ b/src/components/HtmlMathRenderer/KatexMath.tsx
@@ -26,20 +26,14 @@ export const KatexMath = ({
   displayMode = false,
   renderError,
 }: KatexMathProps) => {
-  let html: string | null = null;
-  let error: unknown = null;
-
+  let html: string;
   try {
     html = katex.renderToString(math, {
       displayMode,
       throwOnError: true,
     });
-  } catch (caught) {
-    error = caught;
-  }
-
-  if (error !== null) {
-    return <>{renderError ? renderError(error) : null}</>;
+  } catch (error_) {
+    return <>{renderError ? renderError(error_) : null}</>;
   }
 
   const Tag = displayMode ? 'div' : 'span';
@@ -48,7 +42,7 @@ export const KatexMath = ({
       data-testid="react-katex"
       // KaTeX output is sanitized markup it generates itself from the parsed
       // LaTeX; there is no untrusted HTML passthrough here.
-      dangerouslySetInnerHTML={{ __html: html as string }}
+      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 };

--- a/src/components/LatexRenderer/LatexRenderer.tsx
+++ b/src/components/LatexRenderer/LatexRenderer.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, ReactNode } from 'react';
 import 'katex/dist/katex.min.css';
-import { InlineMath, BlockMath } from 'react-katex';
+import { KatexMath } from '../HtmlMathRenderer/KatexMath';
 import DOMPurify from 'dompurify';
 import parse, {
   DOMNode,
@@ -80,7 +80,7 @@ const createMathReplacer = (
 
       if (mathPart.type === 'inline') {
         return (
-          <InlineMath
+          <KatexMath
             key={`math-${mathId}`}
             math={mathPart.latex}
             renderError={() => errorRenderer(mathPart.latex)}
@@ -89,8 +89,9 @@ const createMathReplacer = (
       } else {
         return (
           <div key={`math-${mathId}`} className="my-2.5 text-center">
-            <BlockMath
+            <KatexMath
               math={mathPart.latex}
+              displayMode
               renderError={() => errorRenderer(mathPart.latex)}
             />
           </div>

--- a/src/components/MarkdownMathRenderer/MarkdownMathRenderer.test.tsx
+++ b/src/components/MarkdownMathRenderer/MarkdownMathRenderer.test.tsx
@@ -7,15 +7,21 @@ import HtmlMathRenderer from '../HtmlMathRenderer/HtmlMathRenderer';
 import { isLikelyMarkdown } from '../HtmlMathRenderer/utils';
 
 // react-markdown / remark / rehype ship ESM and are stubbed via jest
-// moduleNameMapper. react-katex is mocked here for the HTML-path branches that
-// HtmlMathRenderer may exercise.
-jest.mock('react-katex', () => ({
-  InlineMath: ({ math }: { math: string }) => (
-    <span data-testid="inline-math">{math}</span>
-  ),
-  BlockMath: ({ math }: { math: string }) => (
-    <div data-testid="block-math">{math}</div>
-  ),
+// moduleNameMapper. KatexMath (used by HtmlMathRenderer) is mocked here for the
+// HTML-path branches that the delegation tests may exercise.
+jest.mock('../HtmlMathRenderer/KatexMath', () => ({
+  KatexMath: ({
+    math,
+    displayMode,
+  }: {
+    math: string;
+    displayMode?: boolean;
+  }) =>
+    displayMode ? (
+      <div data-testid="block-math">{math}</div>
+    ) : (
+      <span data-testid="inline-math">{math}</span>
+    ),
 }));
 
 describe('isLikelyMarkdown', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,24 +3234,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-katex@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@types/react-katex@npm:3.0.4"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/919d5752eb5ea8e5eb72dde1cb2f2b3e0b0d7e74e463eb95a8da4a3a12478223b92e78c0b1bece53ce9e5404aa1a0ac63955ef1a4e00829080ad41808ee82538
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*":
-  version: 19.2.14
-  resolution: "@types/react@npm:19.2.14"
-  dependencies:
-    csstype: "npm:^3.2.2"
-  checksum: 10c0/7d25bf41b57719452d86d2ac0570b659210402707313a36ee612666bf11275a1c69824f8c3ee1fdca077ccfe15452f6da8f1224529b917050eb2d861e52b59b7
-  languageName: node
-  linkType: hard
-
 "@types/react@npm:^19.2.15":
   version: 19.2.15
   resolution: "@types/react@npm:19.2.15"
@@ -3736,7 +3718,6 @@ __metadata:
     "@types/qrcode": "npm:^1.5.6"
     "@types/react": "npm:^19.2.15"
     "@types/react-dom": "npm:^19.2.3"
-    "@types/react-katex": "npm:^3.0.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.60.0"
     "@typescript-eslint/parser": "npm:^8.60.0"
     autoprefixer: "npm:^10.5.0"
@@ -3754,7 +3735,7 @@ __metadata:
     jest-environment-jsdom: "npm:^30.4.1"
     jest-sonar-reporter: "npm:^2.0.0"
     jsdom: "npm:^29.1.1"
-    katex: "npm:^0.17.0"
+    katex: "npm:^0.16.0"
     phosphor-react: "npm:^1.4.1"
     polished: "npm:^4.3.1"
     postcss: "npm:^8.5.15"
@@ -3764,7 +3745,6 @@ __metadata:
     react: "npm:^19.2.6"
     react-dom: "npm:^19.2.6"
     react-hook-form: "npm:^7.77.0"
-    react-katex: "npm:^3.1.0"
     react-markdown: "npm:^10.1.0"
     react-router-dom: "npm:^7.16.0"
     react-to-print: "npm:^3.3.0"
@@ -7831,17 +7811,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"katex@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "katex@npm:0.17.0"
-  dependencies:
-    commander: "npm:^8.3.0"
-  bin:
-    katex: cli.js
-  checksum: 10c0/e80ad159961341799940740ceeaf9501338f9f04a91089f35e08ee25a13aeeff1cb0771a1ae5394f0b5eb98cc5c8e6ef2569c29ae60a1554c4844bcd079a2e21
-  languageName: node
-  linkType: hard
-
 "kdbush@npm:^4.0.2":
   version: 4.0.2
   resolution: "kdbush@npm:4.0.2"
@@ -10143,18 +10112,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
-  languageName: node
-  linkType: hard
-
-"react-katex@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "react-katex@npm:3.1.0"
-  dependencies:
-    katex: "npm:^0.16.0"
-  peerDependencies:
-    prop-types: ^15.8.1
-    react: ">=15.3.2 <20"
-  checksum: 10c0/a61eb2c19a2dc384ad5864a27af66f40c504643f984150f4e270373df88293c2586779b53b2ee7ee4e75076f3c5284b36f425bbc1021d164ccb2997d11d8678f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal mathematics rendering system with optimized dependencies.
  * All LaTeX rendering and mathematical expression display functionality remains fully supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->