### PR TITLE
AE-2744 - feat: FileDropzone improvement

### DIFF
--- a/src/components/FileDropzone/FileDropzone.stories.tsx
+++ b/src/components/FileDropzone/FileDropzone.stories.tsx
@@ -16,6 +16,7 @@ const FileDropzoneWithState = ({
   initialFileUrl,
   disabled,
   required,
+  changeButtonText,
 }: {
   fileType: FileType;
   accept: string;
@@ -26,6 +27,7 @@ const FileDropzoneWithState = ({
   initialFileUrl?: string;
   disabled?: boolean;
   required?: boolean;
+  changeButtonText?: string;
 }) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [fileUrl, setFileUrl] = useState<string | null>(initialFileUrl || null);
@@ -71,6 +73,7 @@ const FileDropzoneWithState = ({
       onTypeError={handleTypeError}
       disabled={disabled}
       required={required}
+      changeButtonText={changeButtonText}
     />
   );
 };
@@ -206,7 +209,8 @@ export const SubtitleUpload: Story = () => (
 );
 
 /**
- * Com arquivo pré-carregado (URL)
+ * Com imagem pré-carregada (URL): preview + chip com nome,
+ * botão de deletar (X) e botão "Trocar".
  */
 export const WithExistingFile: Story = () => (
   <div className="p-4 max-w-md">
@@ -216,6 +220,22 @@ export const WithExistingFile: Story = () => (
       label="Capa da aula"
       initialFileUrl="https://picsum.photos/400/300"
       showPreview={true}
+    />
+  </div>
+);
+
+/**
+ * Imagem pré-carregada com label customizado do botão de troca.
+ */
+export const ImagePreviewCustomReplaceLabel: Story = () => (
+  <div className="p-4 max-w-md">
+    <FileDropzoneWithState
+      fileType="image"
+      accept="image/*"
+      label="Logo login"
+      initialFileUrl="https://picsum.photos/400/300"
+      showPreview={true}
+      changeButtonText="Substituir imagem"
     />
   </div>
 );

--- a/src/components/FileDropzone/FileDropzone.test.tsx
+++ b/src/components/FileDropzone/FileDropzone.test.tsx
@@ -1,6 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import FileDropzone from './FileDropzone';
 
+// Mock URL.createObjectURL/revokeObjectURL for image preview from a selectedFile
+(
+  globalThis.URL as unknown as {
+    createObjectURL: jest.Mock;
+    revokeObjectURL: jest.Mock;
+  }
+).createObjectURL = jest.fn(() => 'blob:mock-url');
+(
+  globalThis.URL as unknown as {
+    createObjectURL: jest.Mock;
+    revokeObjectURL: jest.Mock;
+  }
+).revokeObjectURL = jest.fn();
+
 describe('FileDropzone', () => {
   const defaultProps = {
     accept: 'image/*',
@@ -555,6 +569,90 @@ describe('FileDropzone', () => {
 
       const img = screen.getByRole('img');
       expect(img.className).toContain('max-h-64');
+    });
+  });
+
+  describe('Image preview actions', () => {
+    const imageProps = {
+      accept: 'image/*',
+      fileType: 'image' as const,
+      fileUrl: 'https://example.com/image.jpg',
+      showPreview: true,
+    };
+
+    it('should render the replace button (Trocar) in image preview', () => {
+      render(<FileDropzone {...imageProps} />);
+
+      expect(
+        screen.getByRole('button', { name: 'Trocar' })
+      ).toBeInTheDocument();
+    });
+
+    it('should render a custom replace button label', () => {
+      render(<FileDropzone {...imageProps} changeButtonText="Substituir" />);
+
+      expect(
+        screen.getByRole('button', { name: 'Substituir' })
+      ).toBeInTheDocument();
+    });
+
+    it('should not render the replace button when disabled', () => {
+      render(<FileDropzone {...imageProps} disabled />);
+
+      expect(
+        screen.queryByRole('button', { name: 'Trocar' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('should open the file picker when the replace button is clicked', () => {
+      render(<FileDropzone {...imageProps} />);
+
+      const input = document.querySelector(
+        'input[type="file"]'
+      ) as HTMLInputElement;
+      const clickSpy = jest.spyOn(input, 'click');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Trocar' }));
+
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it('should show remove button in image preview when onRemoveFile is provided', () => {
+      render(<FileDropzone {...imageProps} onRemoveFile={jest.fn()} />);
+
+      expect(screen.getByLabelText('Remover arquivo')).toBeInTheDocument();
+    });
+
+    it('should call onRemoveFile when remove button is clicked in image preview', () => {
+      const handleRemoveFile = jest.fn();
+      render(<FileDropzone {...imageProps} onRemoveFile={handleRemoveFile} />);
+
+      fireEvent.click(screen.getByLabelText('Remover arquivo'));
+
+      expect(handleRemoveFile).toHaveBeenCalled();
+    });
+
+    it('should not render remove button in image preview without onRemoveFile', () => {
+      render(<FileDropzone {...imageProps} />);
+
+      expect(
+        screen.queryByLabelText('Remover arquivo')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should display "Arquivo carregado" in the chip when only fileUrl is provided', () => {
+      render(<FileDropzone {...imageProps} />);
+
+      expect(screen.getByText('Arquivo carregado')).toBeInTheDocument();
+    });
+
+    it('should display the selected file name in the image preview chip', () => {
+      const file = new File(['test'], 'logo.png', { type: 'image/png' });
+      render(
+        <FileDropzone accept="image/*" fileType="image" selectedFile={file} />
+      );
+
+      expect(screen.getByText('logo.png')).toBeInTheDocument();
     });
   });
 

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -8,9 +8,12 @@ import {
   FileAudio,
   FilePdf,
   ClosedCaptioning,
+  Paperclip,
+  PencilSimple,
   X,
 } from 'phosphor-react';
 import Text from '../Text/Text';
+import Button from '../Button/Button';
 import { cn } from '../../utils/utils';
 
 export type FileType = 'image' | 'video' | 'audio' | 'pdf' | 'subtitle';
@@ -40,6 +43,8 @@ export interface FileDropzoneProps {
   placeholder?: string;
   /** Text shown when hovering over an existing file */
   changeText?: string;
+  /** Label of the replace button shown in the image preview state (default: "Trocar") */
+  changeButtonText?: string;
   /** Disabled state */
   disabled?: boolean;
   /** Required field indicator */
@@ -134,6 +139,7 @@ export default function FileDropzone({
   actionText = 'Clique aqui',
   placeholder,
   changeText,
+  changeButtonText = 'Trocar',
   disabled = false,
   required = false,
   className,
@@ -271,6 +277,16 @@ export default function FileDropzone({
     }
   };
 
+  const handleChangeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!disabled) {
+      fileInputRef.current?.click();
+    }
+  };
+
+  const fileName = selectedFile?.name || (fileUrl ? 'Arquivo carregado' : '');
+
   const getBorderClasses = () => {
     if (hasError) {
       return disabled
@@ -291,36 +307,65 @@ export default function FileDropzone({
     disabled && 'cursor-not-allowed opacity-50'
   );
 
+  // Image preview state (Figma): solid card with preview + file chip + actions
+  const isImagePreview =
+    fileType === 'image' && showPreview && Boolean(displayUrl);
+
+  const imageCardClasses = cn(
+    'flex flex-col items-center justify-center gap-3 p-6 rounded-lg bg-background-100',
+    hasError && 'border-2 border-indicator-error',
+    disabled && 'opacity-50'
+  );
+
   const getAriaDescribedBy = (): string | undefined => {
     if (errorMessage) return `${inputId}-error`;
     if (helperText) return `${inputId}-helper`;
     return undefined;
   };
 
-  const renderFilePreview = () => {
-    // For images with showPreview enabled
-    if (fileType === 'image' && showPreview && displayUrl) {
-      return (
-        <div className="flex flex-col items-center gap-2">
-          <img
-            src={displayUrl}
-            alt="Preview do arquivo"
-            className={cn(
-              'max-w-full rounded-lg object-cover',
-              previewMaxHeight
-            )}
-          />
-          <Text size="xs" className="text-text-500">
-            {defaultChangeText}
-          </Text>
-        </div>
-      );
-    }
+  // Image preview state (Figma): preview + file chip (with remove) + replace button
+  const renderImagePreview = () => (
+    <>
+      <img
+        src={displayUrl ?? undefined}
+        alt="Preview do arquivo"
+        className={cn('max-w-full rounded-lg object-contain', previewMaxHeight)}
+      />
 
+      <div className="flex items-center gap-2 rounded-full border border-border-200 bg-background px-3 py-1.5">
+        <Paperclip size={16} className="text-text-600" />
+        <Text size="sm" className="text-text-700 max-w-[200px] truncate">
+          {fileName}
+        </Text>
+        {onRemoveFile && !disabled && (
+          <button
+            type="button"
+            onClick={handleRemove}
+            className="p-0.5 rounded-full hover:bg-error-100 transition-colors"
+            aria-label="Remover arquivo"
+          >
+            <X size={14} className="text-indicator-error" />
+          </button>
+        )}
+      </div>
+
+      {!disabled && (
+        <Button
+          variant="outline"
+          action="primary"
+          size="small"
+          iconLeft={<PencilSimple size={16} />}
+          onClick={handleChangeClick}
+        >
+          {changeButtonText}
+        </Button>
+      )}
+    </>
+  );
+
+  const renderFilePreview = () => {
     // For non-image files or images without preview - show file info with check
     if (hasFile) {
-      const fileName =
-        selectedFile?.name || (fileUrl ? 'Arquivo carregado' : '');
       return (
         <div className="flex flex-col items-center gap-3">
           <div className="flex items-center justify-center w-12 h-12 rounded-full bg-success-100">
@@ -372,27 +417,40 @@ export default function FileDropzone({
         </label>
       )}
 
-      <label
-        className={dropzoneClasses}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-      >
-        <input
-          ref={fileInputRef}
-          id={inputId}
-          type="file"
-          accept={accept}
-          onChange={handleFileChange}
-          className="hidden"
-          disabled={disabled}
-          aria-invalid={hasError}
-          aria-describedby={getAriaDescribedBy()}
-        />
+      <input
+        ref={fileInputRef}
+        id={inputId}
+        type="file"
+        accept={accept}
+        onChange={handleFileChange}
+        className="hidden"
+        disabled={disabled}
+        aria-invalid={hasError}
+        aria-describedby={getAriaDescribedBy()}
+      />
 
-        {renderFilePreview()}
-      </label>
+      {isImagePreview ? (
+        <div
+          className={imageCardClasses}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+        >
+          {renderImagePreview()}
+        </div>
+      ) : (
+        <label
+          htmlFor={inputId}
+          className={dropzoneClasses}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+        >
+          {renderFilePreview()}
+        </label>
+      )}
 
       <div className="mt-1">
         {helperText && !errorMessage && (

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -338,14 +338,15 @@ export default function FileDropzone({
           {fileName}
         </Text>
         {onRemoveFile && !disabled && (
-          <button
+          <Button
+            variant="raw"
             type="button"
             onClick={handleRemove}
             className="p-0.5 rounded-full hover:bg-error-100 transition-colors"
             aria-label="Remover arquivo"
           >
             <X size={14} className="text-indicator-error" />
-          </button>
+          </Button>
         )}
       </div>
 
@@ -377,14 +378,15 @@ export default function FileDropzone({
               {fileName}
             </Text>
             {onRemoveFile && !disabled && (
-              <button
+              <Button
+                variant="raw"
                 type="button"
                 onClick={handleRemove}
                 className="p-1 rounded-full hover:bg-error-100 transition-colors"
                 aria-label="Remover arquivo"
               >
                 <X size={14} className="text-indicator-error" />
-              </button>
+              </Button>
             )}
           </div>
           <Text size="xs" className="text-text-500">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable "replace" button label for image previews and a dedicated image-preview layout showing the image, filename chip, replace action, and optional remove action.
  * Storybook example demonstrating the custom replace-label preview.

* **Tests**
  * Added tests covering image preview UI, replace-button behavior (opens file picker), disabled state, and remove-file interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->