### PR TITLE
AE-2784: render unmanaged regions in gray on map

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -276,20 +276,15 @@ describe('ChoroplethMap', () => {
     });
   });
 
-  it('bumps zoom by 0.8 after fitBounds completes', async () => {
+  it('frames the provided bounds with padding and without a zoom bump', async () => {
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} bounds={mockBounds} />);
 
     await waitFor(() => {
-      expect(mockGoogle.maps.event.addListenerOnce).toHaveBeenCalledWith(
-        expect.anything(),
-        'idle',
-        expect.any(Function)
-      );
+      expect(mockFitBounds).toHaveBeenCalledWith(expect.anything(), 20);
     });
 
-    await waitFor(() => {
-      expect(mockSetZoom).toHaveBeenCalledWith(7.8);
-    });
+    // Zooming past the fitted bounds would crop the edges of the state
+    expect(mockSetZoom).not.toHaveBeenCalled();
   });
 
   it('adds GeoJSON data to map when data is provided', async () => {
@@ -1576,6 +1571,85 @@ describe('ChoroplethMap isManagedRegion', () => {
     // visible managed feature left, fitBounds must not run
     expect(unmanagedLatLng).not.toHaveBeenCalled();
     expect(mockFitBounds).not.toHaveBeenCalled();
+  });
+
+  it('does not refit bounds on mount when all legend classes are active', async () => {
+    const managedFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return true;
+        if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionName') return 'NRE Gerido';
+        return null;
+      },
+      getGeometry: () => ({ forEachLatLng: jest.fn() }),
+    };
+    mockForEach.mockImplementation((cb) => {
+      cb(managedFeature);
+    });
+
+    render(<ChoroplethMap data={[managedRegion]} apiKey={mockApiKey} />);
+
+    await waitFor(() => {
+      expect(mockSetStyle).toHaveBeenCalled();
+    });
+
+    // Without a legend filter the initial framing comes from the bounds
+    // prop, so the visibility effect must not zoom into managed regions
+    expect(mockFitBounds).not.toHaveBeenCalled();
+  });
+
+  it('refits bounds to visible managed features when a legend class is toggled off', async () => {
+    const highValueLatLng = jest.fn();
+    const lowValueLatLng = jest.fn();
+
+    const highValueFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return true;
+        if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionName') return 'NRE Destaque';
+        return null;
+      },
+      getGeometry: () => ({ forEachLatLng: highValueLatLng }),
+    };
+    const lowValueFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return true;
+        if (prop === 'regionValue') return 0.1;
+        if (prop === 'regionName') return 'NRE Atenção';
+        return null;
+      },
+      getGeometry: () => ({ forEachLatLng: lowValueLatLng }),
+    };
+    mockForEach.mockImplementation((cb) => {
+      cb(highValueFeature);
+      cb(lowValueFeature);
+    });
+
+    render(
+      <ChoroplethMap
+        data={[managedRegion, unmanagedRegion]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetStyle).toHaveBeenCalled();
+    });
+
+    mockFitBounds.mockClear();
+    lowValueLatLng.mockClear();
+
+    // Toggle off "Destaque": the low-value managed feature stays visible
+    // and the map refits to it
+    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    act(() => {
+      destaqueBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(lowValueLatLng).toHaveBeenCalled();
+      expect(mockFitBounds).toHaveBeenCalledWith(expect.anything(), 20);
+    });
   });
 
   it('re-adds GeoJSON data when only isManagedRegion changes', async () => {

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -59,11 +59,13 @@ const mockRevertStyle = jest.fn();
 
 const mockGetZoom = jest.fn().mockReturnValue(7);
 const mockSetZoom = jest.fn();
+const mockGetBounds = jest.fn();
 
 const mockMap = {
   fitBounds: mockFitBounds,
   getZoom: mockGetZoom,
   setZoom: mockSetZoom,
+  getBounds: mockGetBounds,
   data: {
     setStyle: mockSetStyle,
     addGeoJson: mockAddGeoJson,
@@ -276,7 +278,32 @@ describe('ChoroplethMap', () => {
     });
   });
 
-  it('frames the provided bounds with padding and without a zoom bump', async () => {
+  it('grows the fractional zoom by the remaining slack after fitBounds', async () => {
+    // Viewport spans are exactly twice the target bounds spans
+    // (lat 8 vs 4, lng 14 vs 7) → slack of 1 zoom level minus safety margin
+    mockGetBounds.mockReturnValue({
+      getNorthEast: () => ({ lat: () => -21, lng: () => -44.5 }),
+      getSouthWest: () => ({ lat: () => -29, lng: () => -58.5 }),
+    });
+
+    render(<ChoroplethMap data={[]} apiKey={mockApiKey} bounds={mockBounds} />);
+
+    await waitFor(() => {
+      expect(mockFitBounds).toHaveBeenCalledWith(expect.anything(), 20);
+    });
+
+    await waitFor(() => {
+      expect(mockSetZoom).toHaveBeenCalledWith(7.95);
+    });
+  });
+
+  it('does not zoom past the fitted bounds when there is no slack', async () => {
+    // Viewport spans match the target bounds spans exactly: no room to grow
+    mockGetBounds.mockReturnValue({
+      getNorthEast: () => ({ lat: () => -23, lng: () => -48 }),
+      getSouthWest: () => ({ lat: () => -27, lng: () => -55 }),
+    });
+
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} bounds={mockBounds} />);
 
     await waitFor(() => {

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -1225,3 +1225,393 @@ describe('ChoroplethMap legend interaction', () => {
     });
   });
 });
+
+describe('ChoroplethMap isManagedRegion', () => {
+  const mockApiKey = 'test-api-key';
+
+  /**
+   * Build a minimal GeoJSON polygon feature for region fixtures
+   * @returns GeoJSON feature with an empty polygon geometry
+   */
+  const makeGeoJson = (): RegionData['geoJson'] => ({
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'Polygon', coordinates: [[]] },
+  });
+
+  const managedRegion: RegionData = {
+    id: 'managed-1',
+    name: 'NRE Gerido',
+    value: 0.9,
+    accessCount: 350,
+    geoJson: makeGeoJson(),
+  };
+
+  const explicitManagedRegion: RegionData = {
+    id: 'managed-2',
+    name: 'NRE Gerido Explicito',
+    value: 0.6,
+    accessCount: 120,
+    isManagedRegion: true,
+    geoJson: makeGeoJson(),
+  };
+
+  const unmanagedRegion: RegionData = {
+    id: 'unmanaged-1',
+    name: 'NRE Fora do Escopo',
+    value: 0.2,
+    accessCount: 40,
+    isManagedRegion: false,
+    geoJson: makeGeoJson(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockForEach.mockReset();
+    rafCallbacks = new Map();
+    mockAddGeoJson.mockReturnValue([{ setProperty: jest.fn() }]);
+  });
+
+  /**
+   * Render the map with the given data and fire a `mouseover` on one region
+   * @param data - Region data passed to the component
+   * @param hovered - Region whose feature receives the mouseover event
+   */
+  const renderAndHover = async (data: RegionData[], hovered: RegionData) => {
+    let mouseoverHandler: ((event: unknown) => void) | null = null;
+    mockAddListener.mockImplementation((event, handler) => {
+      if (event === 'mouseover') {
+        mouseoverHandler = handler;
+      }
+      return {};
+    });
+
+    const featureObj = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionId') return hovered.id;
+        if (prop === 'regionName') return hovered.name;
+        if (prop === 'regionValue') return hovered.value;
+        if (prop === 'regionIsManaged')
+          return hovered.isManagedRegion !== false;
+        return null;
+      },
+      getGeometry: () => ({ forEachLatLng: jest.fn() }),
+    };
+    mockForEach.mockImplementation((cb) => cb(featureObj));
+
+    render(<ChoroplethMap data={data} apiKey={mockApiKey} />);
+
+    await waitFor(() => {
+      expect(mouseoverHandler).not.toBeNull();
+    });
+
+    act(() => {
+      (mouseoverHandler as unknown as (event: unknown) => void)({
+        feature: featureObj,
+        domEvent: { clientX: 100, clientY: 200 },
+      });
+    });
+  };
+
+  it('styles unmanaged regions with the unmanaged fill color and default cursor', async () => {
+    render(
+      <ChoroplethMap
+        data={[managedRegion, unmanagedRegion]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetStyle).toHaveBeenCalled();
+    });
+
+    // First setStyle call is the fade-in start (opacity 0)
+    const styleFn = mockSetStyle.mock.calls[0][0];
+
+    const unmanagedFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return false;
+        if (prop === 'regionValue') return 0.2;
+        return null;
+      },
+    };
+    expect(styleFn(unmanagedFeature)).toEqual({
+      fillColor: '#e0e0e0',
+      fillOpacity: 0,
+      strokeColor: '#ffffff',
+      strokeWeight: 0.3,
+      cursor: 'default',
+    });
+
+    const managedFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return true;
+        if (prop === 'regionValue') return 0.9;
+        return null;
+      },
+    };
+    expect(styleFn(managedFeature)).toEqual({
+      fillColor: '#2c7bb6',
+      fillOpacity: 0,
+      strokeColor: '#ffffff',
+      strokeWeight: 0.3,
+      cursor: 'pointer',
+    });
+  });
+
+  it('keeps the unmanaged style at target opacity after fade-in completes', async () => {
+    render(<ChoroplethMap data={[unmanagedRegion]} apiKey={mockApiKey} />);
+
+    await waitFor(() => {
+      expect(mockSetStyle).toHaveBeenCalled();
+    });
+
+    act(() => {
+      flushRAF(500);
+    });
+
+    const styleFn = mockSetStyle.mock.calls.at(-1)![0];
+    const unmanagedFeature = {
+      getProperty: (prop: string) =>
+        prop === 'regionIsManaged' ? false : null,
+    };
+    expect(styleFn(unmanagedFeature)).toEqual({
+      fillColor: '#e0e0e0',
+      fillOpacity: 0.8,
+      strokeColor: '#ffffff',
+      strokeWeight: 0.3,
+      cursor: 'default',
+    });
+  });
+
+  it('sets regionIsManaged property according to each region flag', async () => {
+    const createdFeatures: Array<{ setProperty: jest.Mock }> = [];
+    mockAddGeoJson.mockImplementation(() => {
+      const feature = { setProperty: jest.fn() };
+      createdFeatures.push(feature);
+      return [feature];
+    });
+
+    render(
+      <ChoroplethMap
+        data={[explicitManagedRegion, managedRegion, unmanagedRegion]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(3);
+    });
+
+    // Explicit true
+    expect(createdFeatures[0].setProperty).toHaveBeenCalledWith(
+      'regionIsManaged',
+      true
+    );
+    // Undefined is treated as managed
+    expect(createdFeatures[1].setProperty).toHaveBeenCalledWith(
+      'regionIsManaged',
+      true
+    );
+    // Explicit false
+    expect(createdFeatures[2].setProperty).toHaveBeenCalledWith(
+      'regionIsManaged',
+      false
+    );
+  });
+
+  it('shows a name-only tooltip when hovering an unmanaged region', async () => {
+    await renderAndHover([managedRegion, unmanagedRegion], unmanagedRegion);
+
+    expect(screen.getByText('NRE Fora do Escopo')).toBeInTheDocument();
+    expect(screen.queryByText(/Acessos:/)).not.toBeInTheDocument();
+  });
+
+  it('shows name and access count when hovering a managed region', async () => {
+    await renderAndHover([managedRegion, unmanagedRegion], managedRegion);
+
+    expect(screen.getByText('NRE Gerido')).toBeInTheDocument();
+    expect(screen.getByText(/Acessos: 350/)).toBeInTheDocument();
+  });
+
+  /**
+   * Render the map and fire a click on the feature of the given region
+   * @param data - Region data passed to the component
+   * @param clicked - Region whose feature receives the click event
+   * @param onRegionClick - Click callback forwarded to the component
+   */
+  const renderAndClick = async (
+    data: RegionData[],
+    clicked: RegionData,
+    onRegionClick: jest.Mock
+  ) => {
+    let clickHandler: ((event: unknown) => void) | null = null;
+    mockAddListener.mockImplementation((event, handler) => {
+      if (event === 'click') {
+        clickHandler = handler;
+      }
+      return {};
+    });
+
+    const mockForEachLatLng = jest.fn();
+    mockForEach.mockImplementation((cb) => {
+      cb({
+        getProperty: (prop: string) => {
+          if (prop === 'regionName') return clicked.name;
+          return null;
+        },
+        getGeometry: () => ({ forEachLatLng: mockForEachLatLng }),
+      });
+    });
+
+    render(
+      <ChoroplethMap
+        data={data}
+        apiKey={mockApiKey}
+        onRegionClick={onRegionClick}
+      />
+    );
+
+    await waitFor(() => {
+      expect(clickHandler).not.toBeNull();
+    });
+
+    act(() => {
+      (clickHandler as unknown as (event: unknown) => void)({
+        feature: {
+          getProperty: (prop: string) => {
+            if (prop === 'regionId') return clicked.id;
+            if (prop === 'regionName') return clicked.name;
+            return null;
+          },
+        },
+      });
+    });
+  };
+
+  it('does not call onRegionClick for an unmanaged region but still zooms to it', async () => {
+    const onRegionClick = jest.fn();
+
+    await renderAndClick(
+      [managedRegion, unmanagedRegion],
+      unmanagedRegion,
+      onRegionClick
+    );
+
+    expect(onRegionClick).not.toHaveBeenCalled();
+    // NRE zoom still happens for unmanaged regions
+    expect(mockFitBounds).toHaveBeenCalledWith(expect.any(Object), 20);
+  });
+
+  it('calls onRegionClick for a managed region', async () => {
+    const onRegionClick = jest.fn();
+
+    await renderAndClick(
+      [managedRegion, unmanagedRegion],
+      managedRegion,
+      onRegionClick
+    );
+
+    expect(onRegionClick).toHaveBeenCalledWith(managedRegion);
+  });
+
+  it('keeps unmanaged features visible and out of fit bounds when a legend class is toggled off', async () => {
+    const managedLatLng = jest.fn();
+    const unmanagedLatLng = jest.fn();
+
+    const managedFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return true;
+        if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionName') return 'NRE Gerido';
+        return null;
+      },
+      getGeometry: () => ({ forEachLatLng: managedLatLng }),
+    };
+    const unmanagedFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionIsManaged') return false;
+        if (prop === 'regionValue') return 0.2;
+        if (prop === 'regionName') return 'NRE Fora do Escopo';
+        return null;
+      },
+      getGeometry: () => ({ forEachLatLng: unmanagedLatLng }),
+    };
+    mockForEach.mockImplementation((cb) => {
+      cb(managedFeature);
+      cb(unmanagedFeature);
+    });
+
+    render(
+      <ChoroplethMap
+        data={[managedRegion, unmanagedRegion]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetStyle).toHaveBeenCalled();
+    });
+
+    mockOverrideStyle.mockClear();
+    mockFitBounds.mockClear();
+    unmanagedLatLng.mockClear();
+
+    // Toggle off "Destaque" — the managed feature (value 0.9) belongs to it
+    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    act(() => {
+      destaqueBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(mockOverrideStyle).toHaveBeenCalledWith(managedFeature, {
+        visible: false,
+      });
+      expect(mockOverrideStyle).toHaveBeenCalledWith(unmanagedFeature, {
+        visible: true,
+      });
+    });
+
+    // Unmanaged geometry never extends the visible bounds, and with no
+    // visible managed feature left, fitBounds must not run
+    expect(unmanagedLatLng).not.toHaveBeenCalled();
+    expect(mockFitBounds).not.toHaveBeenCalled();
+  });
+
+  it('re-adds GeoJSON data when only isManagedRegion changes', async () => {
+    const { rerender } = render(
+      <ChoroplethMap
+        data={[managedRegion, unmanagedRegion]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(2);
+    });
+
+    // Same signature (new array, same values): data is NOT re-added
+    rerender(
+      <ChoroplethMap
+        data={[{ ...managedRegion }, { ...unmanagedRegion }]}
+        apiKey={mockApiKey}
+      />
+    );
+    expect(mockAddGeoJson).toHaveBeenCalledTimes(2);
+
+    // Only the isManagedRegion flag changes: signature differs, data re-added
+    rerender(
+      <ChoroplethMap
+        data={[
+          { ...managedRegion, isManagedRegion: false },
+          { ...unmanagedRegion },
+        ]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -139,17 +139,32 @@ const computeNREBoundaries = (
 
 /**
  * Create style function for Data Layer features
+ *
+ * Regions flagged as not managed by the logged user ignore the color
+ * classes and are rendered with the unmanaged gray fill.
+ *
  * @param opacity - Current fill opacity
  * @param colorClasses - Array of color class configurations
  * @param strokeCityColor - Stroke color for city borders
+ * @param unmanagedFillColor - Fill color for regions outside the user scope
  * @returns Style function for map.data.setStyle
  */
 const createStyleFunction = (
   opacity: number,
   colorClasses: ColorClass[],
-  strokeCityColor: string
+  strokeCityColor: string,
+  unmanagedFillColor: string
 ) => {
   return (feature: google.maps.Data.Feature) => {
+    if (feature.getProperty('regionIsManaged') === false) {
+      return {
+        fillColor: unmanagedFillColor,
+        fillOpacity: opacity,
+        strokeColor: strokeCityColor,
+        strokeWeight: 0.3,
+        cursor: 'default',
+      };
+    }
     const value = feature.getProperty('regionValue') as number;
     const colorClass = getColorClass(value ?? 0, colorClasses);
     return {
@@ -292,7 +307,12 @@ const ChoroplethMap = ({
   const dataSignature = useMemo(
     () =>
       data
-        .map((d) => `${d.id}:${d.value}:${d.name}:${d.accessCount}`)
+        .map(
+          (d) =>
+            `${d.id}:${d.value}:${d.name}:${d.accessCount}:${
+              d.isManagedRegion === false ? 0 : 1
+            }`
+        )
         .join('|'),
     [data]
   );
@@ -376,6 +396,10 @@ const ChoroplethMap = ({
     if (!map || !stableData.length) return;
 
     const strokeCityColor = getCssVar('--color-map-stroke-city', '#ffffff');
+    const unmanagedFillColor = getCssVar(
+      '--color-map-unmanaged-region',
+      '#e0e0e0'
+    );
     const strokeNreColor = getCssVar('--color-map-stroke-nre', '#ffffff');
 
     // Clear existing data
@@ -400,6 +424,7 @@ const ChoroplethMap = ({
             f.setProperty('regionName', region.name);
             f.setProperty('regionValue', region.value);
             f.setProperty('regionAccessCount', region.accessCount);
+            f.setProperty('regionIsManaged', region.isManagedRegion !== false);
           });
         }
       } catch (error) {
@@ -422,7 +447,9 @@ const ChoroplethMap = ({
     });
 
     // Start with opacity 0 for fade-in animation
-    map.data.setStyle(createStyleFunction(0, colorClasses, strokeCityColor));
+    map.data.setStyle(
+      createStyleFunction(0, colorClasses, strokeCityColor, unmanagedFillColor)
+    );
 
     // Add NRE boundary overlay
     const nreLayer = new google.maps.Data();
@@ -446,7 +473,12 @@ const ChoroplethMap = ({
       const currentOpacity = progress * TARGET_OPACITY;
 
       map.data.setStyle(
-        createStyleFunction(currentOpacity, colorClasses, strokeCityColor)
+        createStyleFunction(
+          currentOpacity,
+          colorClasses,
+          strokeCityColor,
+          unmanagedFillColor
+        )
       );
 
       if (progress < 1) {
@@ -616,7 +648,7 @@ const ChoroplethMap = ({
         const regionId = event.feature.getProperty('regionId') as string;
         const regionName = event.feature.getProperty('regionName') as string;
         const region = stableData.find((r) => r.id === regionId);
-        if (region) {
+        if (region && region.isManagedRegion !== false) {
           onRegionClickRef.current?.(region);
         }
 
@@ -655,6 +687,13 @@ const ChoroplethMap = ({
     let hasVisibleFeatures = false;
 
     map.data.forEach((feature: google.maps.Data.Feature) => {
+      // Unmanaged regions don't belong to any legend class: always visible,
+      // and they never drive the fit-bounds of the visible selection.
+      if (feature.getProperty('regionIsManaged') === false) {
+        map.data.overrideStyle(feature, { visible: true });
+        return;
+      }
+
       const value = feature.getProperty('regionValue') as number;
       const colorClass = getColorClass(value ?? 0, colorClasses);
       const classIndex = colorClasses.indexOf(colorClass);
@@ -763,9 +802,12 @@ const ChoroplethMap = ({
             <Text size="sm" weight="semibold">
               {hoveredRegion.name}
             </Text>
-            <Text size="xs" color="text-text-700">
-              {countLabel}: {hoveredRegion.accessCount.toLocaleString('pt-BR')}
-            </Text>
+            {hoveredRegion.isManagedRegion !== false && (
+              <Text size="xs" color="text-text-700">
+                {countLabel}:{' '}
+                {hoveredRegion.accessCount.toLocaleString('pt-BR')}
+              </Text>
+            )}
           </div>
         )}
       </div>

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -356,17 +356,40 @@ const ChoroplethMap = ({
     (mapInstance: google.maps.Map) => {
       setMap(mapInstance);
 
-      // Fit bounds if provided, then bump zoom to fill the container
+      // Fit bounds if provided so the whole region is framed on load.
+      // fitBounds snaps the zoom down to the next level that fits, often
+      // leaving the region small in the container. After the fit settles,
+      // grow the (fractional) zoom by exactly how much slack is left, so the
+      // region fills the container without cropping its edges.
       if (bounds) {
         const googleBounds = new google.maps.LatLngBounds(
           { lat: bounds.south, lng: bounds.west },
           { lat: bounds.north, lng: bounds.east }
         );
-        mapInstance.fitBounds(googleBounds, 0);
+        mapInstance.fitBounds(googleBounds, 20);
         google.maps.event.addListenerOnce(mapInstance, 'idle', () => {
-          const currentZoom = mapInstance.getZoom();
-          if (currentZoom) {
-            mapInstance.setZoom(currentZoom + 0.8);
+          const view = mapInstance.getBounds();
+          const zoom = mapInstance.getZoom();
+          if (!view || zoom == null) return;
+
+          const viewSpanLat =
+            view.getNorthEast().lat() - view.getSouthWest().lat();
+          const viewSpanLng =
+            view.getNorthEast().lng() - view.getSouthWest().lng();
+          const targetSpanLat = bounds.north - bounds.south;
+          const targetSpanLng = bounds.east - bounds.west;
+          if (targetSpanLat <= 0 || targetSpanLng <= 0) return;
+
+          // Largest extra zoom that keeps both spans inside the viewport,
+          // with a small safety margin for Mercator distortion
+          const extraZoom =
+            Math.min(
+              Math.log2(viewSpanLat / targetSpanLat),
+              Math.log2(viewSpanLng / targetSpanLng)
+            ) - 0.05;
+
+          if (extraZoom > 0) {
+            mapInstance.setZoom(zoom + Math.min(extraZoom, 1));
           }
         });
       }
@@ -678,11 +701,16 @@ const ChoroplethMap = ({
 
   /**
    * Apply visibility filter based on active legend classes
-   * and adjust map bounds to fit visible features
+   * and adjust map bounds to fit visible features.
+   *
+   * Bounds are only refit while a legend filter is active: with every class
+   * enabled the initial framing comes from the `bounds` prop (whole state),
+   * which keeps unmanaged regions in view for region-scoped managers.
    */
   useEffect(() => {
     if (!map || !stableData.length) return;
 
+    const isFiltering = activeClasses.size < colorClasses.length;
     const visibleBounds = new google.maps.LatLngBounds();
     let hasVisibleFeatures = false;
 
@@ -709,7 +737,7 @@ const ChoroplethMap = ({
       }
     });
 
-    if (hasVisibleFeatures && !visibleBounds.isEmpty()) {
+    if (isFiltering && hasVisibleFeatures && !visibleBounds.isEmpty()) {
       map.fitBounds(visibleBounds, 20);
     }
   }, [map, stableData, activeClasses, colorClasses]);

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -16,6 +16,12 @@ export interface RegionData {
   accessCount: number;
   /** GeoJSON feature for the region polygon */
   geoJson: Feature<MultiPolygon | Polygon>;
+  /**
+   * Whether the region is managed by the logged user. When false, the region
+   * is rendered with the unmanaged gray fill, shows a name-only tooltip and
+   * does not trigger onRegionClick. Undefined is treated as true.
+   */
+  isManagedRegion?: boolean;
 }
 
 /**

--- a/src/hooks/useMapData.test.ts
+++ b/src/hooks/useMapData.test.ts
@@ -107,9 +107,52 @@ describe('useMapData', () => {
       expect(result.current.data[0].name).toBe('NRE Curitiba');
       expect(result.current.data[0].value).toBe(85);
       expect(result.current.data[0].accessCount).toBe(1200);
+      expect(result.current.data[0].isManagedRegion).toBe(true);
       expect(result.current.bounds).toEqual(mockBounds);
       expect(result.current.geoJSON).toBe(geoJSON);
       expect(result.current.error).toBeNull();
+    });
+
+    it('should map isManagedRegion from feature properties, defaulting to true', async () => {
+      const geoJSON: FeatureCollection<Polygon | MultiPolygon> = {
+        type: 'FeatureCollection',
+        features: [
+          createMockFeature({
+            GEOCODIGO: '4113700',
+            NOME: 'Londrina',
+            NRE: 'Londrina',
+            value: 0,
+            totalAccess: 0,
+            isManagedRegion: false,
+          }),
+          createMockFeature({
+            GEOCODIGO: '4115200',
+            NOME: 'Maringá',
+            NRE: 'Maringá',
+            value: 0.4,
+            totalAccess: 300,
+          }),
+        ],
+      };
+
+      mockFetchMapData.mockResolvedValueOnce({
+        message: 'Success',
+        data: {
+          state: 'PR',
+          regions: [],
+          bounds: mockBounds,
+          geoJSON,
+        },
+      });
+
+      const { result } = renderHook(() => useMapData(defaultFilters));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data[0].isManagedRegion).toBe(false);
+      expect(result.current.data[1].isManagedRegion).toBe(true);
     });
 
     it('should use NOME when NRE is missing', async () => {
@@ -252,6 +295,49 @@ describe('useMapData', () => {
       expect(result.current.data[0].code).toBe('NRE-01');
       expect(result.current.data[0].value).toBe(72);
       expect(result.current.data[0].accessCount).toBe(500);
+      expect(result.current.data[0].isManagedRegion).toBe(true);
+    });
+
+    it('should map isManagedRegion from regions, defaulting to true', async () => {
+      const mockFeature = createMockFeature({}) as Feature<
+        MultiPolygon | Polygon
+      >;
+
+      mockFetchMapData.mockResolvedValueOnce({
+        message: 'Success',
+        data: {
+          state: 'PR',
+          regions: [
+            {
+              schoolGroupId: 'sg-unmanaged',
+              schoolGroupName: 'NRE Londrina',
+              schoolGroupCode: 'NRE-02',
+              totalAccess: 0,
+              value: 0,
+              geoJson: mockFeature,
+              isManagedRegion: false,
+            },
+            {
+              schoolGroupId: 'sg-legacy',
+              schoolGroupName: 'NRE Maringá',
+              schoolGroupCode: 'NRE-03',
+              totalAccess: 80,
+              value: 0.2,
+              geoJson: mockFeature,
+            },
+          ],
+          bounds: mockBounds,
+        },
+      });
+
+      const { result } = renderHook(() => useMapData(defaultFilters));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data[0].isManagedRegion).toBe(false);
+      expect(result.current.data[1].isManagedRegion).toBe(true);
     });
 
     it('should filter out regions with null geoJson', async () => {

--- a/src/hooks/useMapData.ts
+++ b/src/hooks/useMapData.ts
@@ -43,6 +43,7 @@ function transformGeoJSONFeatures(
     value: feature.properties?.value ?? 0,
     accessCount: feature.properties?.totalAccess ?? 0,
     geoJson: feature,
+    isManagedRegion: feature.properties?.isManagedRegion !== false,
   }));
 }
 
@@ -65,6 +66,7 @@ function transformRegionData(
     value: region.value,
     accessCount: region.totalAccess,
     geoJson: region.geoJson,
+    isManagedRegion: region.isManagedRegion !== false,
   };
 }
 

--- a/src/themes/analytica/dark.css
+++ b/src/themes/analytica/dark.css
@@ -197,6 +197,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #3f3f46;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(255, 255, 255, 0.1);

--- a/src/themes/analytica/light.css
+++ b/src/themes/analytica/light.css
@@ -195,6 +195,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #e0e0e0;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(38, 38, 38, 0.2);

--- a/src/themes/base/dark.css
+++ b/src/themes/base/dark.css
@@ -196,6 +196,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #3f3f46;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(255, 255, 255, 0.1);

--- a/src/themes/paraiba/dark.css
+++ b/src/themes/paraiba/dark.css
@@ -196,6 +196,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #3f3f46;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(255, 255, 255, 0.1);

--- a/src/themes/paraiba/light.css
+++ b/src/themes/paraiba/light.css
@@ -190,6 +190,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #e0e0e0;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(38, 38, 38, 0.2);

--- a/src/themes/parana/dark.css
+++ b/src/themes/parana/dark.css
@@ -196,6 +196,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #3f3f46;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(255, 255, 255, 0.1);

--- a/src/themes/parana/light.css
+++ b/src/themes/parana/light.css
@@ -190,6 +190,7 @@
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 
+    --color-map-unmanaged-region: #e0e0e0;
     /* Hard Shadow Colors */
     --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);
     --shadow-hard-shadow-2: 0px 3px 10px rgba(38, 38, 38, 0.2);

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -195,6 +195,7 @@
   --color-map-stroke-city: #ffffff;
   --color-map-stroke-nre: #ffffff;
 
+  --color-map-unmanaged-region: #e0e0e0;
   /* Hard Shadow Colors */
   --shadow-hard-shadow-1: -2px 2px 8px rgba(38, 38, 38, 0.2);
   --shadow-hard-shadow-2: 0px 3px 10px rgba(38, 38, 38, 0.2);

--- a/src/types/mapData.ts
+++ b/src/types/mapData.ts
@@ -39,6 +39,8 @@ export interface MapDataRegion {
   totalAccess: number;
   value: number;
   geoJson: Feature<MultiPolygon | Polygon> | null;
+  /** False when the region is outside the logged manager's scope */
+  isManagedRegion?: boolean;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regions can be marked as unmanaged: they show a gray style, limited tooltip (name only), and won’t open region details when clicked.

* **Improvements**
  * Map fitting/zoom behavior refined for more accurate bounds handling.
  * Legend toggles now hide managed regions from visibility/fit calculations while keeping unmanaged regions visible.

* **Theme**
  * Theme tokens added to control unmanaged-region color across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->