### PR TITLE
AE-2802 - feat: simulation feature flags

### DIFF
--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -2536,6 +2536,52 @@ describe('CardSimulado', () => {
     expect(card.className).toContain('custom-class');
     expect(card.className).toContain('another-class');
   });
+
+  describe('comingSoon / disabled states', () => {
+    it('should render the "Em breve" badge and hide the caret when comingSoon', () => {
+      render(
+        <CardSimulado {...baseProps} comingSoon data-testid="card-simulado" />
+      );
+
+      expect(screen.getByTestId('badge-em-breve')).toBeInTheDocument();
+      expect(screen.getByText('Em breve')).toBeInTheDocument();
+      expect(screen.queryByTestId('caret-icon')).not.toBeInTheDocument();
+    });
+
+    it('should apply disabled visuals and block pointer events when comingSoon', () => {
+      render(
+        <CardSimulado {...baseProps} comingSoon data-testid="card-simulado" />
+      );
+
+      const card = screen.getByTestId('card-simulado');
+      expect(card.className).toContain('opacity-60');
+      expect(card.className).toContain('pointer-events-none');
+      expect(card.className).not.toContain('cursor-pointer');
+      expect(card).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should apply disabled visuals without a badge when disabled', () => {
+      render(
+        <CardSimulado {...baseProps} disabled data-testid="card-simulado" />
+      );
+
+      const card = screen.getByTestId('card-simulado');
+      expect(card.className).toContain('opacity-60');
+      expect(card.className).toContain('pointer-events-none');
+      expect(screen.queryByTestId('badge-em-breve')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('caret-icon')).not.toBeInTheDocument();
+    });
+
+    it('should stay interactive (caret, no badge) by default', () => {
+      render(<CardSimulado {...baseProps} data-testid="card-simulado" />);
+
+      const card = screen.getByTestId('card-simulado');
+      expect(card.className).toContain('cursor-pointer');
+      expect(card.className).not.toContain('opacity-60');
+      expect(screen.getByTestId('caret-icon')).toBeInTheDocument();
+      expect(screen.queryByTestId('badge-em-breve')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('CardTest', () => {

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -2581,6 +2581,55 @@ describe('CardSimulado', () => {
       expect(screen.getByTestId('caret-icon')).toBeInTheDocument();
       expect(screen.queryByTestId('badge-em-breve')).not.toBeInTheDocument();
     });
+
+    it('does not activate onClick when comingSoon, even via keyboard', () => {
+      const handleClick = jest.fn();
+      render(
+        <CardSimulado
+          {...baseProps}
+          comingSoon
+          onClick={handleClick}
+          data-testid="card-simulado"
+        />
+      );
+
+      const card = screen.getByTestId('card-simulado');
+      // CardBase derives role="button"/keyboard activation from a present onClick.
+      expect(card).not.toHaveAttribute('role', 'button');
+      fireEvent.click(card);
+      fireEvent.keyDown(card, { key: 'Enter' });
+      fireEvent.keyDown(card, { key: ' ' });
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('does not activate onClick when disabled', () => {
+      const handleClick = jest.fn();
+      render(
+        <CardSimulado
+          {...baseProps}
+          disabled
+          onClick={handleClick}
+          data-testid="card-simulado"
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('card-simulado'));
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('activates onClick when interactive', () => {
+      const handleClick = jest.fn();
+      render(
+        <CardSimulado
+          {...baseProps}
+          onClick={handleClick}
+          data-testid="card-simulado"
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('card-simulado'));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1289,6 +1289,8 @@ const CardSimulado = forwardRef<HTMLDivElement, CardSimuladoProps>(
       comingSoon = false,
       disabled = false,
       className,
+      onClick,
+      onKeyDown,
       ...props
     },
     ref
@@ -1304,6 +1306,11 @@ const CardSimulado = forwardRef<HTMLDivElement, CardSimuladoProps>(
         minHeight="none"
         cursor={isInteractive ? 'pointer' : 'default'}
         aria-disabled={isInteractive ? undefined : true}
+        // Only forward handlers when interactive: CardBase derives tabIndex,
+        // role="button" and Enter/Space activation from the presence of onClick,
+        // so a disabled/coming-soon card must not receive them.
+        onClick={isInteractive ? onClick : undefined}
+        onKeyDown={isInteractive ? onKeyDown : undefined}
         className={cn(
           backgroundClass,
           isInteractive

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1263,6 +1263,13 @@ interface CardSimuladoProps extends HTMLAttributes<HTMLDivElement> {
   duration?: string;
   info: string;
   backgroundColor: 'enem' | 'prova' | 'simuladao' | 'vestibular';
+  /**
+   * Renders the card in a non-interactive "coming soon" state: greyed out,
+   * not clickable, with an "Em breve" badge next to the title.
+   */
+  comingSoon?: boolean;
+  /** Disables interaction (greyed out, not clickable) without a badge. */
+  disabled?: boolean;
 }
 
 const SIMULADO_BACKGROUND_CLASSES = {
@@ -1273,8 +1280,21 @@ const SIMULADO_BACKGROUND_CLASSES = {
 };
 
 const CardSimulado = forwardRef<HTMLDivElement, CardSimuladoProps>(
-  ({ title, duration, info, backgroundColor, className, ...props }, ref) => {
+  (
+    {
+      title,
+      duration,
+      info,
+      backgroundColor,
+      comingSoon = false,
+      disabled = false,
+      className,
+      ...props
+    },
+    ref
+  ) => {
     const backgroundClass = SIMULADO_BACKGROUND_CLASSES[backgroundColor];
+    const isInteractive = !comingSoon && !disabled;
 
     return (
       <CardBase
@@ -1282,18 +1302,43 @@ const CardSimulado = forwardRef<HTMLDivElement, CardSimuladoProps>(
         layout="horizontal"
         padding="medium"
         minHeight="none"
-        cursor="pointer"
+        cursor={isInteractive ? 'pointer' : 'default'}
+        aria-disabled={isInteractive ? undefined : true}
         className={cn(
-          `${backgroundClass} hover:shadow-soft-shadow-2 transition-shadow duration-200`,
+          backgroundClass,
+          isInteractive
+            ? 'hover:shadow-soft-shadow-2 transition-shadow duration-200'
+            : 'opacity-60 pointer-events-none',
           className
         )}
         {...props}
       >
         <div className="flex justify-between items-center w-full gap-4">
           <div className="flex flex-col gap-1 flex-1 min-w-0">
-            <Text size="lg" weight="bold" className="text-text-950 truncate">
-              {title}
-            </Text>
+            {comingSoon ? (
+              <div className="flex items-center gap-2 min-w-0">
+                <Text
+                  size="lg"
+                  weight="bold"
+                  className="text-text-950 truncate"
+                >
+                  {title}
+                </Text>
+                <Badge
+                  size="small"
+                  variant="solid"
+                  action="info"
+                  className="flex-shrink-0"
+                  data-testid="badge-em-breve"
+                >
+                  Em breve
+                </Badge>
+              </div>
+            ) : (
+              <Text size="lg" weight="bold" className="text-text-950 truncate">
+                {title}
+              </Text>
+            )}
 
             <div className="flex items-center gap-4 text-text-700">
               {duration && (
@@ -1309,11 +1354,13 @@ const CardSimulado = forwardRef<HTMLDivElement, CardSimuladoProps>(
             </div>
           </div>
 
-          <CaretRight
-            size={24}
-            className="text-text-800 flex-shrink-0"
-            data-testid="caret-icon"
-          />
+          {isInteractive && (
+            <CaretRight
+              size={24}
+              className="text-text-800 flex-shrink-0"
+              data-testid="caret-icon"
+            />
+          )}
         </div>
       </CardBase>
     );

--- a/src/components/ModuleProtectedRoute.test.tsx
+++ b/src/components/ModuleProtectedRoute.test.tsx
@@ -504,5 +504,20 @@ describe('ModuleProtectedRoute', () => {
 
       expect(container).toBeEmptyDOMElement();
     });
+
+    it('should fail closed (redirect) when neither module nor enabled is provided', () => {
+      mockUseModules.mockReturnValue({ ...baseReturn });
+
+      renderWithRouter(
+        // @ts-expect-error — the prop types require a gate; this verifies the
+        // defensive runtime fallback redirects rather than failing open.
+        <ModuleProtectedRoute>
+          <div>Ungated Content</div>
+        </ModuleProtectedRoute>
+      );
+
+      expect(screen.queryByText('Ungated Content')).not.toBeInTheDocument();
+      expect(screen.getByText('Painel Page')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/ModuleProtectedRoute.test.tsx
+++ b/src/components/ModuleProtectedRoute.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { ModuleProtectedRoute } from './ModuleProtectedRoute';
 import { useModules } from '../hooks/useModules';
+import { DEFAULT_SIMULATIONS } from '../store/modulesStore';
 
 // Mock the useModules hook
 jest.mock('../hooks/useModules', () => ({
@@ -42,6 +43,7 @@ describe('ModuleProtectedRoute', () => {
     exams: true,
     simulatedScoreTri: false,
     simulatedScoreAbsoluto: false,
+    simulations: DEFAULT_SIMULATIONS,
   };
 
   beforeEach(() => {
@@ -63,6 +65,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       const { container } = renderWithRouter(
@@ -91,6 +95,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -116,6 +122,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -141,6 +149,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -166,6 +176,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -193,6 +205,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -219,6 +233,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -245,6 +261,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -271,6 +289,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -299,6 +319,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -325,6 +347,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -352,6 +376,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       const ComplexChild = () => (
@@ -389,6 +415,8 @@ describe('ModuleProtectedRoute', () => {
         hasExams: true,
         hasSimulatedScoreTri: false,
         hasSimulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
+        hasSimulations: true,
       });
 
       renderWithRouter(
@@ -402,6 +430,79 @@ describe('ModuleProtectedRoute', () => {
       expect(screen.getByText('Child 1')).toBeInTheDocument();
       expect(screen.getByText('Child 2')).toBeInTheDocument();
       expect(screen.getByText('Child 3')).toBeInTheDocument();
+    });
+  });
+
+  describe('enabled prop (derived gates)', () => {
+    const baseReturn = {
+      modules: defaultModules,
+      loading: false,
+      hasSimulator: true,
+      hasEssay: true,
+      hasForum: true,
+      hasSupport: true,
+      hasSimulatedReports: true,
+      hasActivitiesReports: true,
+      hasLessonsReports: true,
+      hasExams: true,
+      hasSimulatedScoreTri: false,
+      hasSimulatedScoreAbsoluto: false,
+      simulations: DEFAULT_SIMULATIONS,
+      hasSimulations: true,
+    };
+
+    it('should render children when enabled is true', () => {
+      mockUseModules.mockReturnValue({ ...baseReturn });
+
+      renderWithRouter(
+        <ModuleProtectedRoute enabled={true}>
+          <div>Simulados Content</div>
+        </ModuleProtectedRoute>
+      );
+
+      expect(screen.getByText('Simulados Content')).toBeInTheDocument();
+    });
+
+    it('should redirect when enabled is false', () => {
+      mockUseModules.mockReturnValue({ ...baseReturn });
+
+      renderWithRouter(
+        <ModuleProtectedRoute enabled={false}>
+          <div>Simulados Content</div>
+        </ModuleProtectedRoute>
+      );
+
+      expect(screen.queryByText('Simulados Content')).not.toBeInTheDocument();
+      expect(screen.getByText('Painel Page')).toBeInTheDocument();
+    });
+
+    it('should prefer enabled over the module key when both are provided', () => {
+      mockUseModules.mockReturnValue({
+        ...baseReturn,
+        modules: { ...defaultModules, simulator: true },
+      });
+
+      renderWithRouter(
+        <ModuleProtectedRoute module="simulator" enabled={false}>
+          <div>Simulados Content</div>
+        </ModuleProtectedRoute>
+      );
+
+      // enabled=false wins even though simulator module is true
+      expect(screen.queryByText('Simulados Content')).not.toBeInTheDocument();
+      expect(screen.getByText('Painel Page')).toBeInTheDocument();
+    });
+
+    it('should render nothing while loading even when enabled is true', () => {
+      mockUseModules.mockReturnValue({ ...baseReturn, loading: true });
+
+      const { container } = renderWithRouter(
+        <ModuleProtectedRoute enabled={true}>
+          <div>Simulados Content</div>
+        </ModuleProtectedRoute>
+      );
+
+      expect(container).toBeEmptyDOMElement();
     });
   });
 });

--- a/src/components/ModuleProtectedRoute.tsx
+++ b/src/components/ModuleProtectedRoute.tsx
@@ -5,18 +5,26 @@ import type { ModulesConfig } from '../store/modulesStore';
 
 type ModuleKey = keyof ModulesConfig;
 
-export interface ModuleProtectedRouteProps {
-  /** Boolean module key from ModulesConfig (e.g. "simulator"). */
-  module?: ModuleKey;
-  /**
-   * Explicit enabled flag. When provided, takes precedence over `module` —
-   * use it for derived/nested gates such as the Simulados master toggle
-   * (`simulations.enabled`).
-   */
-  enabled?: boolean;
+/** Keys of ModulesConfig whose value is a boolean (i.e. gateable modules). */
+type BooleanModuleKey = {
+  [K in ModuleKey]: ModulesConfig[K] extends boolean ? K : never;
+}[ModuleKey];
+
+interface BaseModuleProtectedRouteProps {
   children: React.ReactNode;
   redirectTo?: string;
 }
+
+/**
+ * Gate on a boolean module key (`module`) OR on an explicit `enabled` flag
+ * (for derived/nested gates such as the Simulados master, `simulations.enabled`).
+ * At least one of the two is required, so a route can never be left ungated.
+ */
+export type ModuleProtectedRouteProps = BaseModuleProtectedRouteProps &
+  (
+    | { module: BooleanModuleKey; enabled?: boolean }
+    | { module?: BooleanModuleKey; enabled: boolean }
+  );
 
 /**
  * Route guard component that redirects if the specified module is disabled
@@ -49,8 +57,9 @@ export const ModuleProtectedRoute = ({
     return null;
   }
 
-  // `enabled` wins when provided; otherwise fall back to the boolean module key.
-  const isEnabled = enabled ?? (module ? Boolean(modules[module]) : true);
+  // `enabled` wins when provided; otherwise gate on the boolean module key.
+  // Fail closed when neither is supplied (the types prevent this, defensive).
+  const isEnabled = enabled ?? (module ? Boolean(modules[module]) : false);
 
   // If disabled, redirect
   if (!isEnabled) {

--- a/src/components/ModuleProtectedRoute.tsx
+++ b/src/components/ModuleProtectedRoute.tsx
@@ -6,7 +6,14 @@ import type { ModulesConfig } from '../store/modulesStore';
 type ModuleKey = keyof ModulesConfig;
 
 export interface ModuleProtectedRouteProps {
-  module: ModuleKey;
+  /** Boolean module key from ModulesConfig (e.g. "simulator"). */
+  module?: ModuleKey;
+  /**
+   * Explicit enabled flag. When provided, takes precedence over `module` —
+   * use it for derived/nested gates such as the Simulados master toggle
+   * (`simulations.enabled`).
+   */
+  enabled?: boolean;
   children: React.ReactNode;
   redirectTo?: string;
 }
@@ -21,9 +28,17 @@ export interface ModuleProtectedRouteProps {
  *     <SimuladorSisu />
  *   </ModuleProtectedRoute>
  * } />
+ *
+ * @example
+ * <Route path="simulados" element={
+ *   <ModuleProtectedRoute enabled={hasSimulations}>
+ *     <Simulados />
+ *   </ModuleProtectedRoute>
+ * } />
  */
 export const ModuleProtectedRoute = ({
   module,
+  enabled,
   children,
   redirectTo = '/painel',
 }: ModuleProtectedRouteProps) => {
@@ -34,8 +49,11 @@ export const ModuleProtectedRoute = ({
     return null;
   }
 
-  // If module is disabled, redirect
-  if (!modules[module]) {
+  // `enabled` wins when provided; otherwise fall back to the boolean module key.
+  const isEnabled = enabled ?? (module ? Boolean(modules[module]) : true);
+
+  // If disabled, redirect
+  if (!isEnabled) {
     return <Navigate to={redirectTo} replace />;
   }
 

--- a/src/hooks/useModules.test.ts
+++ b/src/hooks/useModules.test.ts
@@ -2,9 +2,17 @@ import { renderHook } from '@testing-library/react';
 import { useModules } from './useModules';
 import { useModulesStore } from '../store/modulesStore';
 
-// Mock the modulesStore
+// Mock the modulesStore (must also provide DEFAULT_SIMULATIONS, which useModules
+// imports as the defensive fallback for the nested `simulations` config).
 jest.mock('../store/modulesStore', () => ({
   useModulesStore: jest.fn(),
+  DEFAULT_SIMULATIONS: {
+    enabled: true,
+    enem: 'ENABLED',
+    prova: 'ENABLED',
+    simuladao: 'ENABLED',
+    vestibular: 'ENABLED',
+  },
 }));
 
 const mockUseModulesStore = useModulesStore as jest.MockedFunction<
@@ -209,6 +217,41 @@ describe('useModules', () => {
 
       expect(result.current.loading).toBe(false);
       expect(result.current.modules).toEqual(customModules);
+    });
+  });
+
+  describe('simulations config', () => {
+    const fullSimulations = {
+      enabled: false,
+      enem: 'ENABLED' as const,
+      prova: 'COMING_SOON' as const,
+      simuladao: 'HIDDEN' as const,
+      vestibular: 'ENABLED' as const,
+    };
+
+    it('should expose the simulations object and hasSimulations from the store', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: { ...defaultModules, simulations: fullSimulations },
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.simulations).toEqual(fullSimulations);
+      expect(result.current.hasSimulations).toBe(false);
+    });
+
+    it('should fall back to defaults when simulations is missing', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: defaultModules, // no `simulations` key
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasSimulations).toBe(true);
+      expect(result.current.simulations.enem).toBe('ENABLED');
+      expect(result.current.simulations.simuladao).toBe('ENABLED');
     });
   });
 });

--- a/src/hooks/useModules.ts
+++ b/src/hooks/useModules.ts
@@ -1,4 +1,9 @@
-import { useModulesStore, type ModulesConfig } from '../store/modulesStore';
+import {
+  useModulesStore,
+  DEFAULT_SIMULATIONS,
+  type ModulesConfig,
+  type SimulationsConfig,
+} from '../store/modulesStore';
 
 export interface UseModulesReturn {
   modules: ModulesConfig;
@@ -15,6 +20,10 @@ export interface UseModulesReturn {
   hasSimulatedScoreTri: boolean;
   /** Whether ABSOLUTO score type is available in simulated reports */
   hasSimulatedScoreAbsoluto: boolean;
+  /** Simulados module config (master toggle + per-type visibility) */
+  simulations: SimulationsConfig;
+  /** Whether the Simulados module is enabled (master toggle) */
+  hasSimulations: boolean;
 }
 
 /**
@@ -38,6 +47,9 @@ export interface UseModulesReturn {
 export const useModules = (): UseModulesReturn => {
   const { modules, loading } = useModulesStore();
 
+  // Defensive fallback: older persisted state or partial mocks may omit it.
+  const simulations = modules.simulations ?? DEFAULT_SIMULATIONS;
+
   return {
     modules,
     loading,
@@ -51,5 +63,7 @@ export const useModules = (): UseModulesReturn => {
     hasExams: modules.exams,
     hasSimulatedScoreTri: modules.simulatedScoreTri,
     hasSimulatedScoreAbsoluto: modules.simulatedScoreAbsoluto,
+    simulations,
+    hasSimulations: simulations.enabled,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -833,8 +833,13 @@ export { useQuestionFiltersStore } from './store/questionFiltersStore';
 export type { QuestionFiltersState } from './store/questionFiltersStore';
 export { useLessonFiltersStore } from './store/lessonFiltersStore';
 export type { LessonFiltersState } from './store/lessonFiltersStore';
-export { useModulesStore } from './store/modulesStore';
-export type { ModulesState, ModulesConfig } from './store/modulesStore';
+export { useModulesStore, DEFAULT_SIMULATIONS } from './store/modulesStore';
+export type {
+  ModulesState,
+  ModulesConfig,
+  SimulationsConfig,
+  SimulationVisibility,
+} from './store/modulesStore';
 export { useModules } from './hooks/useModules';
 export type { UseModulesReturn } from './hooks/useModules';
 export { ModuleProtectedRoute } from './components/ModuleProtectedRoute';

--- a/src/store/modulesStore.test.ts
+++ b/src/store/modulesStore.test.ts
@@ -1,5 +1,9 @@
 import type { AxiosInstance } from 'axios';
-import { useModulesStore, type ModulesConfig } from './modulesStore';
+import {
+  useModulesStore,
+  DEFAULT_SIMULATIONS,
+  type ModulesConfig,
+} from './modulesStore';
 import { KEYS } from '../utils/keys';
 
 // Mock API type for testing
@@ -50,6 +54,7 @@ describe('ModulesStore', () => {
     exams: true,
     simulatedScoreTri: false,
     simulatedScoreAbsoluto: false,
+    simulations: DEFAULT_SIMULATIONS,
   };
 
   beforeEach(() => {
@@ -195,6 +200,7 @@ describe('ModulesStore', () => {
         exams: true,
         simulatedScoreTri: false,
         simulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
       };
 
       mockApi.get.mockResolvedValueOnce({
@@ -242,6 +248,37 @@ describe('ModulesStore', () => {
       expect(modules.simulatedReports).toBe(true); // Default
       expect(modules.activitiesReports).toBe(true); // Default
       expect(modules.lessonsReports).toBe(true); // Default
+      // simulations falls back entirely to defaults when not provided
+      expect(modules.simulations).toEqual(DEFAULT_SIMULATIONS);
+    });
+
+    it('should deep-merge a partial simulations object with defaults', async () => {
+      const institutionId = 'test-institution';
+      // Only the master flag and one type are set; remaining types must default.
+      const partialModules = {
+        simulations: { enabled: false, vestibular: 'HIDDEN' },
+      };
+
+      mockApi.get.mockResolvedValueOnce({
+        data: {
+          data: {
+            featureFlags: {
+              version: partialModules,
+            },
+          },
+        },
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(institutionId, mockApi as unknown as AxiosInstance);
+
+      const { modules } = useModulesStore.getState();
+      expect(modules.simulations.enabled).toBe(false); // From API
+      expect(modules.simulations.vestibular).toBe('HIDDEN'); // From API
+      expect(modules.simulations.enem).toBe('ENABLED'); // Default
+      expect(modules.simulations.prova).toBe('ENABLED'); // Default
+      expect(modules.simulations.simuladao).toBe('ENABLED'); // Default
     });
 
     it('should use defaults when API returns no version', async () => {
@@ -502,6 +539,7 @@ describe('ModulesStore', () => {
         exams: true,
         simulatedScoreTri: false,
         simulatedScoreAbsoluto: false,
+        simulations: DEFAULT_SIMULATIONS,
       });
     });
 
@@ -618,6 +656,7 @@ describe('ModulesStore', () => {
           exams: false,
           simulatedScoreTri: false,
           simulatedScoreAbsoluto: false,
+          simulations: { ...DEFAULT_SIMULATIONS, enabled: false },
         },
         ownerInstitutionId: 'some-institution',
       });

--- a/src/store/modulesStore.ts
+++ b/src/store/modulesStore.ts
@@ -79,11 +79,18 @@ export interface ModulesConfig {
  * Shallow-merges top-level fields and deep-merges the nested `simulations`
  * object so newly added keys keep their defaults when older configs omit them.
  */
-const mergeModules = (version: Partial<ModulesConfig>): ModulesConfig => ({
-  ...defaultModules,
-  ...version,
-  simulations: { ...DEFAULT_SIMULATIONS, ...(version.simulations ?? {}) },
-});
+const mergeModules = (
+  version?: Partial<ModulesConfig> | null
+): ModulesConfig => {
+  // Guard against malformed/legacy persisted state where `modules` is missing.
+  const v = version ?? {};
+  return {
+    ...defaultModules,
+    ...v,
+    // Object spread treats `undefined` as a no-op, so no `?? {}` fallback needed.
+    simulations: { ...DEFAULT_SIMULATIONS, ...v.simulations },
+  };
+};
 
 /**
  * Interface defining the modules state

--- a/src/store/modulesStore.ts
+++ b/src/store/modulesStore.ts
@@ -5,6 +5,38 @@ import { useAuthStore } from './authStore';
 import type { AxiosInstance } from 'axios';
 
 /**
+ * Visibility state of a single simulado type on the student platform.
+ * - ENABLED: shown and clickable
+ * - COMING_SOON: shown but disabled, with an "Em breve" badge
+ * - HIDDEN: not shown at all
+ */
+export type SimulationVisibility = 'ENABLED' | 'COMING_SOON' | 'HIDDEN';
+
+/**
+ * Per-institution configuration of the Simulados module.
+ * `enabled` is the master toggle (gates the whole module/menu); the remaining
+ * keys map 1:1 to each simulado type's `backgroundColor` (the card catalog).
+ */
+export interface SimulationsConfig {
+  enabled: boolean;
+  enem: SimulationVisibility;
+  prova: SimulationVisibility;
+  simuladao: SimulationVisibility;
+  vestibular: SimulationVisibility;
+}
+
+/**
+ * Default simulados configuration - module on, all types enabled
+ */
+export const DEFAULT_SIMULATIONS: SimulationsConfig = {
+  enabled: true,
+  enem: 'ENABLED',
+  prova: 'ENABLED',
+  simuladao: 'ENABLED',
+  vestibular: 'ENABLED',
+};
+
+/**
  * Default modules configuration - all enabled
  */
 const defaultModules: ModulesConfig = {
@@ -18,6 +50,7 @@ const defaultModules: ModulesConfig = {
   exams: true,
   simulatedScoreTri: false,
   simulatedScoreAbsoluto: false,
+  simulations: DEFAULT_SIMULATIONS,
 };
 
 /**
@@ -37,7 +70,20 @@ export interface ModulesConfig {
   simulatedScoreTri: boolean;
   /** Whether ABSOLUTO score type is available in simulated reports */
   simulatedScoreAbsoluto: boolean;
+  /** Simulados module: master toggle + per-type visibility */
+  simulations: SimulationsConfig;
 }
+
+/**
+ * Merge a (possibly partial) feature-flag version onto the defaults.
+ * Shallow-merges top-level fields and deep-merges the nested `simulations`
+ * object so newly added keys keep their defaults when older configs omit them.
+ */
+const mergeModules = (version: Partial<ModulesConfig>): ModulesConfig => ({
+  ...defaultModules,
+  ...version,
+  simulations: { ...DEFAULT_SIMULATIONS, ...(version.simulations ?? {}) },
+});
 
 /**
  * Interface defining the modules state
@@ -165,7 +211,7 @@ export const useModulesStore = create<ModulesState>()(
           set({ modules: defaultModules, loading: false });
         } else {
           set({
-            modules: { ...defaultModules, ...version },
+            modules: mergeModules(version),
             ownerInstitutionId: institutionId,
             loading: false,
           });
@@ -194,7 +240,7 @@ export const useModulesStore = create<ModulesState>()(
 
         // Merge with defaultModules to ensure new fields have proper defaults
         // when loading old localStorage data that may be missing new fields
-        const mergedModules = { ...defaultModules, ...rehydrated.modules };
+        const mergedModules = mergeModules(rehydrated.modules);
         useModulesStore.setState({ modules: mergedModules });
 
         const currentInstitutionId =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cards now support "coming soon" state displaying an "Em breve" badge with disabled styling
  * Cards support disabled state with greyed-out appearance without badge
  * Route protection enhanced with explicit enabled prop for flexible access control

* **Tests**
  * Added comprehensive test coverage for card state transitions and route protection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->