### PR TITLE
AE-2803: add filter and use title in simulados

### DIFF
--- a/src/components/SimulationsPage/SimulationsDetailModal.test.tsx
+++ b/src/components/SimulationsPage/SimulationsDetailModal.test.tsx
@@ -295,6 +295,114 @@ describe('SimulationsDetailModal', () => {
     );
   });
 
+  it('shows the title the student gave the simulation', async () => {
+    const titledList = {
+      message: 'ok',
+      data: {
+        student: {
+          userInstitutionId: 'ui-1',
+          name: 'Ana Costa',
+          simulationsAnswered: 1,
+        },
+        simulations: {
+          data: [
+            {
+              id: 'sim-1',
+              title: 'Prova ENEM Matemática',
+              correctCount: 0,
+              incorrectCount: 0,
+              blankCount: 0,
+              totalQuestions: 0,
+              createdAt: null,
+            },
+          ],
+          page: 1,
+          limit: 20,
+          total: 1,
+        },
+      },
+    };
+    const get = jest.fn((url: string) => {
+      if (url.endsWith('/note')) {
+        return Promise.resolve({ data: { message: 'ok', data: null } });
+      }
+      return Promise.resolve({ data: titledList });
+    });
+    const api = {
+      get,
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as BaseApiClient;
+
+    render(
+      <SimulationsDetailModal
+        api={api}
+        isOpen
+        onClose={jest.fn()}
+        student={student}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Prova ENEM Matemática')).toBeInTheDocument()
+    );
+  });
+
+  it('falls back to "Simulado N" when the simulation has no title', async () => {
+    const untitledList = {
+      message: 'ok',
+      data: {
+        student: {
+          userInstitutionId: 'ui-1',
+          name: 'Ana Costa',
+          simulationsAnswered: 1,
+        },
+        simulations: {
+          data: [
+            {
+              id: 'sim-1',
+              title: '   ',
+              correctCount: 0,
+              incorrectCount: 0,
+              blankCount: 0,
+              totalQuestions: 0,
+              createdAt: null,
+            },
+          ],
+          page: 1,
+          limit: 20,
+          total: 1,
+        },
+      },
+    };
+    const get = jest.fn((url: string) => {
+      if (url.endsWith('/note')) {
+        return Promise.resolve({ data: { message: 'ok', data: null } });
+      }
+      return Promise.resolve({ data: untitledList });
+    });
+    const api = {
+      get,
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as BaseApiClient;
+
+    render(
+      <SimulationsDetailModal
+        api={api}
+        isOpen
+        onClose={jest.fn()}
+        student={student}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Simulado 1')).toBeInTheDocument()
+    );
+  });
+
   it('renders LaTeX in the question statement', async () => {
     const mathDetail = {
       message: 'ok',

--- a/src/components/SimulationsPage/SimulationsDetailModal.test.tsx
+++ b/src/components/SimulationsPage/SimulationsDetailModal.test.tsx
@@ -308,7 +308,7 @@ describe('SimulationsDetailModal', () => {
           data: [
             {
               id: 'sim-1',
-              title: 'Prova ENEM Matemática',
+              title: '  Prova ENEM Matemática  ',
               correctCount: 0,
               incorrectCount: 0,
               blankCount: 0,
@@ -344,9 +344,9 @@ describe('SimulationsDetailModal', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(screen.getByText('Prova ENEM Matemática')).toBeInTheDocument()
-    );
+    const titleNode = await screen.findByText('Prova ENEM Matemática');
+    // The title is rendered trimmed (no leading/trailing whitespace).
+    expect(titleNode.textContent).toBe('Prova ENEM Matemática');
   });
 
   it('falls back to "Simulado N" when the simulation has no title', async () => {

--- a/src/components/SimulationsPage/SimulationsDetailModal.tsx
+++ b/src/components/SimulationsPage/SimulationsDetailModal.tsx
@@ -260,7 +260,7 @@ function SimulationItem({
         <div className="flex-1 py-4">
           <Text weight="bold" className="text-text-950">
             {simulation.title?.trim()
-              ? simulation.title
+              ? simulation.title.trim()
               : `Simulado ${index + 1}`}
           </Text>
         </div>

--- a/src/components/SimulationsPage/SimulationsDetailModal.tsx
+++ b/src/components/SimulationsPage/SimulationsDetailModal.tsx
@@ -259,7 +259,9 @@ function SimulationItem({
       trigger={
         <div className="flex-1 py-4">
           <Text weight="bold" className="text-text-950">
-            Simulado {index + 1}
+            {simulation.title?.trim()
+              ? simulation.title
+              : `Simulado ${index + 1}`}
           </Text>
         </div>
       }

--- a/src/components/SimulationsPage/SimulationsPage.test.tsx
+++ b/src/components/SimulationsPage/SimulationsPage.test.tsx
@@ -34,9 +34,24 @@ const studentSimulationsPayload = {
   },
 };
 
+const accessPayload = {
+  message: 'ok',
+  data: {
+    schools: [{ id: 'sch-1', name: 'Escola 1' }],
+    schoolYears: [{ id: 'sy-1', name: '3º Ano', schoolId: 'sch-1' }],
+    classes: [
+      { id: 'c1', name: 'Turma A', schoolId: 'sch-1', schoolYearId: 'sy-1' },
+      { id: 'c2', name: 'Turma B', schoolId: 'sch-1', schoolYearId: 'sy-1' },
+    ],
+  },
+};
+
 function makeApi(): BaseApiClient {
   return {
     get: jest.fn((url: string) => {
+      if (url.endsWith('/auth/me')) {
+        return Promise.resolve({ data: accessPayload });
+      }
       if (url.endsWith('/students')) {
         return Promise.resolve({ data: studentsPayload });
       }
@@ -74,5 +89,35 @@ describe('SimulationsPage', () => {
     await waitFor(() =>
       expect(screen.getByText('40 simulados respondidos')).toBeInTheDocument()
     );
+  });
+
+  it('lists the manager classes inside the filter modal', async () => {
+    render(<SimulationsPage api={makeApi()} />);
+
+    await screen.findByText('Ana Costa');
+    fireEvent.click(screen.getByText('Filtros'));
+
+    expect(await screen.findByText('Turma A')).toBeInTheDocument();
+    expect(screen.getByText('Turma B')).toBeInTheDocument();
+  });
+
+  it('refetches students with classIds when a turma filter is applied', async () => {
+    const api = makeApi();
+    render(<SimulationsPage api={api} />);
+
+    await screen.findByText('Ana Costa');
+    fireEvent.click(screen.getByText('Filtros'));
+
+    // Select "Turma A" and apply the filter.
+    fireEvent.click(await screen.findByText('Turma A'));
+    fireEvent.click(screen.getByText('Aplicar'));
+
+    await waitFor(() => {
+      const studentsCalls = (api.get as jest.Mock).mock.calls.filter(
+        ([url]: [string]) => url.endsWith('/students')
+      );
+      const lastCall = studentsCalls.at(-1);
+      expect(lastCall?.[1]?.params?.classIds).toEqual(['c1']);
+    });
   });
 });

--- a/src/components/SimulationsPage/SimulationsPage.tsx
+++ b/src/components/SimulationsPage/SimulationsPage.tsx
@@ -5,6 +5,8 @@ import Text from '../Text/Text';
 import Button from '../Button/Button';
 import { TableProvider } from '../TableProvider';
 import type { ColumnConfig, TableParams } from '../TableProvider';
+import type { FilterConfig } from '../Filter/useTableFilter';
+import { useUserAccessData } from '../SimulatedFilters/hooks';
 import type { BaseApiClient } from '../../types/api';
 import { createUseSimulations } from '../../hooks/useSimulations';
 import type { SimulationsStudentItem } from '../../types/simulations';
@@ -27,6 +29,7 @@ const DEFAULT_LIMIT = 10;
 export function SimulationsPage({ api, noSearchImage }: SimulationsPageProps) {
   const useSimulations = useMemo(() => createUseSimulations(api), [api]);
   const { fetchStudents } = useSimulations();
+  const { classes } = useUserAccessData(api);
 
   const [students, setStudents] = useState<SimulationsStudentItem[]>([]);
   const [total, setTotal] = useState(0);
@@ -36,13 +39,38 @@ export function SimulationsPage({ api, noSearchImage }: SimulationsPageProps) {
     name: string;
   } | null>(null);
 
+  // Build a single-category "Turma" filter so the TableProvider's native filter
+  // modal handles multi-selection. The category key is `classIds`, so the
+  // selected ids surface in TableParams as `params.classIds`.
+  const initialFilters = useMemo<FilterConfig[]>(
+    () => [
+      {
+        key: 'turma',
+        label: 'Turma',
+        categories: [
+          {
+            key: 'classIds',
+            label: 'Turma',
+            selectedIds: [],
+            itens: classes.map((c) => ({ id: c.id, name: c.name })),
+          },
+        ],
+      },
+    ],
+    [classes]
+  );
+
   const handleParamsChange = useCallback(
     (params: TableParams) => {
+      const classIds = Array.isArray(params.classIds)
+        ? (params.classIds as string[])
+        : undefined;
       setLoading(true);
       fetchStudents({
         page: params.page,
         limit: params.limit,
         search: params.search?.trim() || undefined,
+        classIds: classIds?.length ? classIds : undefined,
       })
         .then((result) => {
           setStudents(result.data);
@@ -130,7 +158,9 @@ export function SimulationsPage({ api, noSearchImage }: SimulationsPageProps) {
         loading={loading}
         variant="borderless"
         enableSearch
+        enableFilters
         enablePagination
+        initialFilters={initialFilters}
         rowKey="userInstitutionId"
         searchPlaceholder="Buscar estudante"
         onParamsChange={handleParamsChange}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulations can now display custom titles when provided; defaults to "Simulado {number}" if unavailable.
  * Added class filtering capability to the simulations page, allowing users to filter simulations by their assigned classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->