### PR TITLE
fix: use leaf output paths in generated exports

### DIFF
--- a/scripts/add-exports.mjs
+++ b/scripts/add-exports.mjs
@@ -94,11 +94,12 @@ function outputPathToExportKey(outputPath) {
  * fallback for legacy consumers. `types` points at the per-entry .d.ts emitted
  * by `build:types` (tsc + fix-dts-paths.mjs).
  */
-function buildEntry(distBase) {
+function buildEntry(outputPath) {
+  const distFileBase = `./dist/${outputPath}`;
   return {
-    types: `${distBase}/index.d.ts`,
-    import: `${distBase}/index.mjs`,
-    require: `${distBase}/index.js`,
+    types: `${distFileBase}.d.ts`,
+    import: `${distFileBase}.mjs`,
+    require: `${distFileBase}.js`,
   };
 }
 
@@ -117,9 +118,8 @@ async function addExports() {
       continue;
     }
     const exportKey = outputPathToExportKey(outputPath);
-    const distBase = `./dist/${outputPath.replace(/\/index$/, '')}`;
-    derivedExports[exportKey] = buildEntry(distBase);
-    console.log(`✅ ${exportKey} -> ${distBase}/index.mjs`);
+    derivedExports[exportKey] = buildEntry(outputPath);
+    console.log(`✅ ${exportKey} -> ./dist/${outputPath}.mjs`);
   }
 
   // Merge: keep any base exports (e.g. ./styles.css), then force the root "."


### PR DESCRIPTION
## Summary
- generate subpath export targets from the exact `tsup` output path
- preserve existing `*/index` entries like `Button/index`
- fix leaf entries like `SendActivityModal/types` so they point to `dist/SendActivityModal/types.*` instead of missing `dist/SendActivityModal/types/index.*`

## Validation
- `node scripts/add-exports.mjs` on a local copy of `package.json`
- verified `./button` still maps to `./dist/Button/index.*`
- verified `./send-activity-modal/types`, `validation`, `hooks/usesendactivitymodal`, and `sendactivitymodal` map to the leaf files that the published tarball contains
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal build script to streamline package export configuration and subpath export generation. Updated module distribution paths to resolve directly to individual entry points, improving consistency and maintainability of the export structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->