### PR TITLE
AE-2814: add description and 6 rows support to StatisticsCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.93",
+  "version": "1.4.91",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.91",
+  "version": "1.5.0",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.5.0",
+  "version": "1.4.93",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/components/StatisticsCard/StatisticsCard.test.tsx
+++ b/src/components/StatisticsCard/StatisticsCard.test.tsx
@@ -27,6 +27,25 @@ describe('StatisticsCard', () => {
       ).toBeInTheDocument();
     });
 
+    it('should render the description when provided', () => {
+      render(
+        <StatisticsCard
+          {...defaultProps}
+          description="Resumo geral dos dados"
+        />
+      );
+
+      expect(screen.getByText('Resumo geral dos dados')).toBeInTheDocument();
+    });
+
+    it('should not render a description when not provided', () => {
+      render(<StatisticsCard {...defaultProps} />);
+
+      expect(
+        screen.queryByText('Resumo geral dos dados')
+      ).not.toBeInTheDocument();
+    });
+
     it('should render empty state message', () => {
       render(<StatisticsCard {...defaultProps} />);
 
@@ -404,6 +423,49 @@ describe('StatisticsCard', () => {
         'grid-cols-1',
         'sm:grid-cols-2',
         'lg:grid-cols-2'
+      );
+    });
+
+    it('should render grid with 5 columns for 5 items', () => {
+      const fiveItemData = [
+        { label: 'Item 1', value: 10, variant: 'high' as const },
+        { label: 'Item 2', value: 20, variant: 'medium' as const },
+        { label: 'Item 3', value: 30, variant: 'total' as const },
+        { label: 'Item 4', value: 40, variant: 'low' as const },
+        { label: 'Item 5', value: 50, variant: 'high' as const },
+      ];
+
+      const { container } = render(
+        <StatisticsCard title="Estatística" data={fiveItemData} />
+      );
+
+      const grid = container.querySelector('.grid');
+      expect(grid).toHaveClass(
+        'grid-cols-1',
+        'sm:grid-cols-2',
+        'lg:grid-cols-5'
+      );
+    });
+
+    it('should render grid with 6 columns for 6 items', () => {
+      const sixItemData = [
+        { label: 'Item 1', value: 10, variant: 'high' as const },
+        { label: 'Item 2', value: 20, variant: 'medium' as const },
+        { label: 'Item 3', value: 30, variant: 'total' as const },
+        { label: 'Item 4', value: 40, variant: 'low' as const },
+        { label: 'Item 5', value: 50, variant: 'high' as const },
+        { label: 'Item 6', value: 60, variant: 'total' as const },
+      ];
+
+      const { container } = render(
+        <StatisticsCard title="Estatística" data={sixItemData} />
+      );
+
+      const grid = container.querySelector('.grid');
+      expect(grid).toHaveClass(
+        'grid-cols-1',
+        'sm:grid-cols-2',
+        'lg:grid-cols-6'
       );
     });
 

--- a/src/components/StatisticsCard/StatisticsCard.tsx
+++ b/src/components/StatisticsCard/StatisticsCard.tsx
@@ -26,6 +26,8 @@ interface StatItem {
 interface StatisticsCardProps {
   /** Title displayed at the top of the card */
   title: string;
+  /** Optional description displayed below the title */
+  description?: string;
   /** Statistics data to display */
   data?: StatItem[];
   /** Show placeholder "-" in values when true (for created items without data yet) */
@@ -108,6 +110,8 @@ const StatCard = ({ item, showPlaceholder = false }: StatCardProps) => {
  * Get grid column class based on number of items
  */
 const getGridColumnsClass = (itemCount: number): string => {
+  if (itemCount === 6) return 'lg:grid-cols-6';
+  if (itemCount === 5) return 'lg:grid-cols-5';
   if (itemCount === 4) return 'lg:grid-cols-4';
   if (itemCount === 3) return 'lg:grid-cols-3';
   if (itemCount === 2) return 'lg:grid-cols-2';
@@ -147,6 +151,7 @@ const getGridColumnsClass = (itemCount: number): string => {
  */
 export const StatisticsCard = ({
   title,
+  description,
   data,
   showPlaceholder = false,
   emptyStateMessage,
@@ -164,19 +169,20 @@ export const StatisticsCard = ({
 
   return (
     <div
-      className={`bg-background rounded-xl p-4 h-auto lg:h-[185px] flex flex-col gap-2 ${className}`}
+      className={`bg-background rounded-xl p-4 h-auto lg:min-h-[185px] flex flex-col gap-2 ${className}`}
     >
       {/* Header with title and optional dropdown */}
       <div className="flex flex-row justify-between items-center gap-4">
-        <Text
-          as="h3"
-          size="sm"
-          weight="medium"
-          color="text-text-600"
-          className="flex-1 min-w-0"
-        >
-          {title}
-        </Text>
+        <div className="flex-1 min-w-0 flex flex-col gap-1">
+          <Text as="h3" size="sm" weight="medium" color="text-text-600">
+            {title}
+          </Text>
+          {description && (
+            <Text size="sm" color="text-text-700">
+              {description}
+            </Text>
+          )}
+        </div>
 
         {dropdownOptions && dropdownOptions.length > 0 && (
           <div className="w-[120px] min-w-[90px] sm:shrink-0">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StatisticsCard now supports an optional description that renders beneath the title.
  * Improved responsive layout handling for StatisticsCard when there are 5–6 data items.
  * Card height behavior updated to adapt more flexibly based on content.
* **Tests**
  * Added coverage to verify description rendering when provided vs. omitted.
  * Extended tests to confirm correct responsive grid column classes for 5- and 6-item datasets.
* **Chores**
  * Bumped package version to 1.4.93.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->