### PR TITLE
AE-2828 - feat(modules): expose Tutorial menu link (enabled + url)

### DIFF
--- a/src/components/ModuleProtectedRoute.test.tsx
+++ b/src/components/ModuleProtectedRoute.test.tsx
@@ -55,6 +55,8 @@ const createMockModulesReturn = (
   hasPerformance: true,
   hasDashboard: true,
   hasLessons: true,
+  hasTutorial: false,
+  tutorialUrl: '',
   hasExams: true,
   hasSimulations: true,
   simulations: DEFAULT_SIMULATIONS,

--- a/src/hooks/useModules.test.ts
+++ b/src/hooks/useModules.test.ts
@@ -727,4 +727,61 @@ describe('useModules', () => {
       expect(result.current.hasSimulatedScoreAbsoluto).toBe(false);
     });
   });
+
+  describe('tutorial menu link', () => {
+    it('hasTutorial is false by default (not configured)', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: defaultModules,
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasTutorial).toBe(false);
+      expect(result.current.tutorialUrl).toBe('');
+    });
+
+    it('hasTutorial is true when enabled and url is non-empty', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: {
+          ...defaultModules,
+          tutorial: true,
+          tutorialUrl: 'https://x.com/tutorial',
+        },
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasTutorial).toBe(true);
+      expect(result.current.tutorialUrl).toBe('https://x.com/tutorial');
+    });
+
+    it('hasTutorial is false when enabled but url is blank', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: { ...defaultModules, tutorial: true, tutorialUrl: '   ' },
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasTutorial).toBe(false);
+      expect(result.current.tutorialUrl).toBe('');
+    });
+
+    it('hasTutorial is false when url is set but tutorial is disabled', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: {
+          ...defaultModules,
+          tutorial: false,
+          tutorialUrl: 'https://x.com/tutorial',
+        },
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasTutorial).toBe(false);
+    });
+  });
 });

--- a/src/hooks/useModules.ts
+++ b/src/hooks/useModules.ts
@@ -29,6 +29,10 @@ export interface UseModulesReturn {
   hasDashboard: boolean;
   hasLessons: boolean;
 
+  // Tutorial menu link (true only when enabled AND tutorialUrl is non-empty)
+  hasTutorial: boolean;
+  tutorialUrl: string;
+
   // Exams
   hasExams: boolean;
 
@@ -93,6 +97,7 @@ export const useModules = (): UseModulesReturn => {
     modules.performanceGraphs ?? DEFAULT_PERFORMANCE_GRAPHS;
   const reports = modules.reports ?? DEFAULT_REPORTS;
   const simulatedScore = modules.simulatedScore ?? DEFAULT_SIMULATED_SCORE;
+  const tutorialUrl = (modules.tutorialUrl ?? '').trim();
 
   return {
     modules,
@@ -111,6 +116,10 @@ export const useModules = (): UseModulesReturn => {
     hasPerformance: modules.performance ?? true,
     hasDashboard: modules.dashboard ?? true,
     hasLessons: modules.lessons ?? true,
+
+    // Tutorial: only show the menu link when enabled AND a url is configured
+    hasTutorial: (modules.tutorial ?? false) && tutorialUrl.length > 0,
+    tutorialUrl,
 
     // Exams (simple boolean, with backwards compatibility for old object format)
     hasExams:

--- a/src/types/modulesConfig.ts
+++ b/src/types/modulesConfig.ts
@@ -122,6 +122,10 @@ export interface ModulesConfig {
   dashboard: boolean;
   lessons: boolean;
 
+  // Tutorial menu link (off by default; also needs a non-empty tutorialUrl)
+  tutorial: boolean;
+  tutorialUrl: string;
+
   // Nested configurations
   exams: boolean;
   simulations: SimulationsConfig;
@@ -155,6 +159,10 @@ export const DEFAULT_MODULES: ModulesConfig = {
   performance: true,
   dashboard: true,
   lessons: true,
+
+  // Tutorial off by default (opt-in per institution, requires a url)
+  tutorial: false,
+  tutorialUrl: '',
 
   // Nested configurations
   exams: DEFAULT_EXAMS,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tutorial configuration support to the modules system, enabling tutorials to be toggled and configured with URLs accessible through the platform.

* **Tests**
  * Extended test coverage for tutorial functionality, validating behavior across multiple configurations including enabled/disabled states, empty URLs, and whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->