### PR TITLE
fix(select): dropdown ocupa largura total do trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytica-frontend-lib",
-  "version": "1.4.91",
+  "version": "1.4.92",
   "description": "Repositório público dos componentes utilizados nas plataformas da Analytica Ensino",
   "main": "dist/index.js",
   "module": "./dist/index.mjs",

--- a/scripts/add-exports.mjs
+++ b/scripts/add-exports.mjs
@@ -97,8 +97,10 @@ function outputPathToExportKey(outputPath) {
 function buildEntry(distBase) {
   return {
     types: `${distBase}/index.d.ts`,
+    module: `${distBase}/index.mjs`,
     import: `${distBase}/index.mjs`,
     require: `${distBase}/index.js`,
+    default: `${distBase}/index.mjs`,
   };
 }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -562,6 +562,7 @@ const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
       const styles: CSSProperties = {
         position: 'fixed',
         zIndex: 9999,
+        width: triggerRect.width,
       };
 
       const isVertical = side === 'top' || side === 'bottom';


### PR DESCRIPTION
## O que muda

- `SelectContent` agora herda a largura do trigger via `triggerRect.width` no `getPositionStyles()` — o dropdown não abre mais com 50% da largura do input
- `add-exports.mjs` passa a incluir condições `module` e `default` em cada entry, corrigindo a resolução de subpath exports no Vite 8 / Rolldown (`./hooks/usetheme` e outros)
- Bump `1.4.91` → `1.4.92`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Select component dropdown menu positioning to properly align with the trigger element's width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->