### PR TITLE
AE-2850 - feat(zendesk): resilient useZendesk hook (retry until ready)

### DIFF
--- a/src/hooks/useZendesk.test.ts
+++ b/src/hooks/useZendesk.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, act } from '@testing-library/react';
+import { useZendesk } from '@/hooks/useZendesk';
+
+type GlobalWithZE = { zE?: jest.Mock };
+
+const getScript = () =>
+  document.getElementById('ze-snippet') as HTMLScriptElement | null;
+
+describe('useZendesk', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    delete (globalThis as unknown as GlobalWithZE).zE;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    delete (globalThis as unknown as GlobalWithZE).zE;
+  });
+
+  it('não injeta o script quando enabled é false', () => {
+    renderHook(() => useZendesk({ zendeskKey: 'key', enabled: false }));
+    expect(getScript()).toBeNull();
+  });
+
+  it('não injeta o script sem zendeskKey', () => {
+    renderHook(() => useZendesk({ zendeskKey: '' }));
+    expect(getScript()).toBeNull();
+  });
+
+  it('injeta o script e fica ready quando window.zE aparece', () => {
+    const { result } = renderHook(() => useZendesk({ zendeskKey: 'key' }));
+
+    expect(getScript()).not.toBeNull();
+    expect(result.current.ready).toBe(false);
+
+    const zE = jest.fn();
+    (globalThis as unknown as GlobalWithZE).zE = zE;
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.ready).toBe(true);
+    expect(zE).toHaveBeenCalledWith('messenger:set', 'locale', 'pt-BR');
+  });
+
+  it('re-injeta com backoff quando o script falha', () => {
+    renderHook(() => useZendesk({ zendeskKey: 'key' }));
+
+    const script = getScript();
+    expect(script).not.toBeNull();
+
+    act(() => {
+      script!.dispatchEvent(new Event('error'));
+    });
+    expect(getScript()).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(getScript()).not.toBeNull();
+  });
+
+  it('openChat abre o messenger quando zE existe', () => {
+    const zE = jest.fn();
+    (globalThis as unknown as GlobalWithZE).zE = zE;
+    const { result } = renderHook(() => useZendesk({ zendeskKey: 'key' }));
+
+    act(() => {
+      result.current.openChat();
+    });
+    expect(zE).toHaveBeenCalledWith('messenger', 'open');
+  });
+
+  it('openChat é no-op quando zE não existe', () => {
+    const { result } = renderHook(() => useZendesk({ zendeskKey: 'key' }));
+    expect(() => {
+      act(() => {
+        result.current.openChat();
+      });
+    }).not.toThrow();
+  });
+
+  it('limpa timers no unmount sem erro', () => {
+    const { unmount } = renderHook(() => useZendesk({ zendeskKey: 'key' }));
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/src/hooks/useZendesk.ts
+++ b/src/hooks/useZendesk.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface UseZendeskConfig {
+  /** Chave do canal Zendesk (snippet). */
+  zendeskKey: string;
+  /**
+   * Carrega o messenger apenas quando `true` (ex.: suporte é ZENDESK).
+   * Default: `true`.
+   */
+  enabled?: boolean;
+}
+
+export interface UseZendeskReturn {
+  /** `true` quando o messenger (`window.zE`) está disponível para abrir. */
+  ready: boolean;
+  /** Abre o messenger do Zendesk. No-op enquanto não estiver pronto. */
+  openChat: () => void;
+}
+
+const SCRIPT_ID = 'ze-snippet';
+const INITIAL_RETRY_MS = 2000;
+const MAX_RETRY_MS = 30_000;
+const POLL_MS = 500;
+
+type ZE = (...args: unknown[]) => void;
+
+const getZE = (): ZE | undefined =>
+  (globalThis as unknown as Record<string, unknown>).zE as ZE | undefined;
+
+/**
+ * Carrega o messenger do Zendesk de forma resiliente e isolada:
+ * - injeta o snippet uma única vez (dedupe por id);
+ * - se o script falhar (rede), re-injeta com backoff exponencial até carregar;
+ * - sinaliza `ready` assim que `window.zE` fica disponível;
+ * - `openChat` abre o messenger (no-op enquanto não estiver pronto).
+ *
+ * O loop de carregamento fica confinado a este hook — não bloqueia o restante
+ * da página (form de login, Google, etc. funcionam independentemente).
+ */
+export const useZendesk = ({
+  zendeskKey,
+  enabled = true,
+}: UseZendeskConfig): UseZendeskReturn => {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || !zendeskKey) return;
+
+    let cancelled = false;
+    let attempt = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+    function confirmReady(): boolean {
+      const zE = getZE();
+      if (!zE) return false;
+      zE('messenger:set', 'locale', 'pt-BR');
+      if (!cancelled) setReady(true);
+      return true;
+    }
+
+    function scheduleRetry() {
+      if (cancelled) return;
+      const delay = Math.min(INITIAL_RETRY_MS * 2 ** attempt, MAX_RETRY_MS);
+      attempt += 1;
+      retryTimer = setTimeout(inject, delay);
+    }
+
+    function inject() {
+      if (cancelled || confirmReady()) return;
+      // Injeção já em andamento (script presente, ainda não falhou).
+      if (document.getElementById(SCRIPT_ID)) return;
+
+      const script = document.createElement('script');
+      script.id = SCRIPT_ID;
+      script.src = `https://static.zdassets.com/ekr/snippet.js?key=${zendeskKey}`;
+      script.async = true;
+      script.onerror = () => {
+        document.getElementById(SCRIPT_ID)?.remove();
+        scheduleRetry();
+      };
+      document.body.appendChild(script);
+    }
+
+    inject();
+
+    // Poll leve (sem rede) só para detectar quando o `zE` fica disponível.
+    pollTimer = setInterval(() => {
+      if (cancelled) return;
+      if (confirmReady() && pollTimer) clearInterval(pollTimer);
+    }, POLL_MS);
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      if (pollTimer) clearInterval(pollTimer);
+    };
+  }, [zendeskKey, enabled]);
+
+  const openChat = useCallback(() => {
+    getZE()?.('messenger', 'open');
+  }, []);
+
+  return { ready, openChat };
+};

--- a/src/hooks/useZendesk.ts
+++ b/src/hooks/useZendesk.ts
@@ -66,19 +66,31 @@ export const useZendesk = ({
       retryTimer = setTimeout(inject, delay);
     }
 
+    function handleScriptError() {
+      if (cancelled) return;
+      document.getElementById(SCRIPT_ID)?.remove();
+      scheduleRetry();
+    }
+
     function inject() {
       if (cancelled || confirmReady()) return;
-      // Injeção já em andamento (script presente, ainda não falhou).
-      if (document.getElementById(SCRIPT_ID)) return;
+
+      // Se o snippet já existe (ex.: injetado por outro ponto, como o
+      // ZendeskWidget), não injeta de novo — mas adota o tratamento de erro
+      // para manter o retry e não deixar `ready` travado caso ele falhe.
+      const existing = document.getElementById(
+        SCRIPT_ID
+      ) as HTMLScriptElement | null;
+      if (existing) {
+        existing.addEventListener('error', handleScriptError, { once: true });
+        return;
+      }
 
       const script = document.createElement('script');
       script.id = SCRIPT_ID;
       script.src = `https://static.zdassets.com/ekr/snippet.js?key=${zendeskKey}`;
       script.async = true;
-      script.onerror = () => {
-        document.getElementById(SCRIPT_ID)?.remove();
-        scheduleRetry();
-      };
+      script.addEventListener('error', handleScriptError, { once: true });
       document.body.appendChild(script);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1041,6 +1041,13 @@ export type {
   UseSupportFeatureFlagReturn,
 } from './hooks/useSupportFeatureFlag';
 
+// Zendesk messenger loader (resilient: retry until ready)
+export { useZendesk } from './hooks/useZendesk';
+export type {
+  UseZendeskConfig,
+  UseZendeskReturn,
+} from './hooks/useZendesk';
+
 // SendActivityModal Component
 export { SendActivityModal } from './components/SendActivityModal';
 export { useSendActivityModal } from './components/SendActivityModal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1043,10 +1043,7 @@ export type {
 
 // Zendesk messenger loader (resilient: retry until ready)
 export { useZendesk } from './hooks/useZendesk';
-export type {
-  UseZendeskConfig,
-  UseZendeskReturn,
-} from './hooks/useZendesk';
+export type { UseZendeskConfig, UseZendeskReturn } from './hooks/useZendesk';
 
 // SendActivityModal Component
 export { SendActivityModal } from './components/SendActivityModal';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -226,6 +226,7 @@ export default defineConfig({
     // Support / Zendesk (consumed directly by the apps)
     'ZendeskWidget/index': 'src/components/ZendeskWidget/ZendeskWidget.tsx',
     'hooks/useSupportFeatureFlag/index': 'src/hooks/useSupportFeatureFlag.ts',
+    'hooks/useZendesk/index': 'src/hooks/useZendesk.ts',
 
     // ============================================================
     // Bundle migration: subpath entries for symbols consumed by the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `useZendesk` hook with lifecycle management, automatic error recovery using exponential backoff, and configurable script loading via `enabled` and `zendeskKey` parameters.

* **Tests**
  * Added comprehensive test suite for `useZendesk` validating initialization, ready state detection, error handling and recovery, chat opening functionality, and cleanup on unmount.

* **Chores**
  * Updated build configuration to export new hook via subpath bundle entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->