### PR TITLE
AE-2831 - feat(use-profile-labels): hook for per-institution profile names

### DIFF
--- a/src/components/ActivitiesHistory/ActivitiesHistory.stories.tsx
+++ b/src/components/ActivitiesHistory/ActivitiesHistory.stories.tsx
@@ -67,7 +67,10 @@ const mockActivitiesResponse: ActivitiesHistoryApiResponse = {
         creator: { id: MOCK_UUIDS.users.user1, name: 'Prof. Carlos' },
         breakdown: [
           {
-            school: { id: MOCK_UUIDS.schools.school1, name: 'Escola Municipal São Paulo' },
+            school: {
+              id: MOCK_UUIDS.schools.school1,
+              name: 'Escola Municipal São Paulo',
+            },
             schoolYear: { id: 'year-2024', name: '2024' },
             class: { id: 'class-9a', name: '9º Ano A' },
             totalStudents: 35,
@@ -91,7 +94,10 @@ const mockActivitiesResponse: ActivitiesHistoryApiResponse = {
         creator: { id: MOCK_UUIDS.users.user1, name: 'Prof. Carlos' },
         breakdown: [
           {
-            school: { id: MOCK_UUIDS.schools.school1, name: 'Escola Municipal São Paulo' },
+            school: {
+              id: MOCK_UUIDS.schools.school1,
+              name: 'Escola Municipal São Paulo',
+            },
             schoolYear: { id: 'year-2024', name: '2024' },
             class: { id: 'class-8b', name: '8º Ano B' },
             totalStudents: 30,
@@ -115,7 +121,10 @@ const mockActivitiesResponse: ActivitiesHistoryApiResponse = {
         creator: { id: MOCK_UUIDS.users.user1, name: 'Prof. Carlos' },
         breakdown: [
           {
-            school: { id: MOCK_UUIDS.schools.school2, name: 'Colégio Estadual Central' },
+            school: {
+              id: MOCK_UUIDS.schools.school2,
+              name: 'Colégio Estadual Central',
+            },
             schoolYear: { id: 'year-2024', name: '2024' },
             class: { id: 'class-1em', name: '1º Ano EM' },
             totalStudents: 28,
@@ -139,7 +148,10 @@ const mockActivitiesResponse: ActivitiesHistoryApiResponse = {
         creator: { id: MOCK_UUIDS.users.user1, name: 'Prof. Carlos' },
         breakdown: [
           {
-            school: { id: MOCK_UUIDS.schools.school1, name: 'Escola Municipal São Paulo' },
+            school: {
+              id: MOCK_UUIDS.schools.school1,
+              name: 'Escola Municipal São Paulo',
+            },
             schoolYear: { id: 'year-2024', name: '2024' },
             class: { id: 'class-7c', name: '7º Ano C' },
             totalStudents: 32,

--- a/src/hooks/useProfileLabels.test.ts
+++ b/src/hooks/useProfileLabels.test.ts
@@ -1,0 +1,187 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useProfileLabels } from '@/hooks/useProfileLabels';
+import { useAppStore } from '@/store/appStore';
+import { PROFILE_ROLES } from '@/types/chat';
+import { DEFAULT_PROFILE_LABELS, getProfileLabel } from '@/types/profileLabels';
+
+type ApiClient = { get: jest.Mock };
+
+const createMockApiClient = (
+  response?: unknown,
+  shouldReject = false
+): ApiClient => ({
+  get: jest.fn().mockImplementation(() => {
+    if (shouldReject) return Promise.reject(new Error('API Error'));
+    return Promise.resolve({ data: response });
+  }),
+});
+
+const flagResponse = (version: Record<string, string>) => ({
+  data: {
+    featureFlags: {
+      institutionId: 'institution-123',
+      page: 'PROFILE_LABELS',
+      version,
+    },
+  },
+});
+
+describe('useProfileLabels', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    act(() => {
+      useAppStore.setState({ institutionId: 'institution-123' });
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useAppStore.setState({ institutionId: null });
+    });
+  });
+
+  describe('estado inicial', () => {
+    it('inicializa com os labels padrão e loading true', () => {
+      const apiClient = createMockApiClient();
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.labels).toEqual(DEFAULT_PROFILE_LABELS);
+      expect(result.current.getProfileLabel(PROFILE_ROLES.STUDENT)).toBe(
+        'Aluno'
+      );
+    });
+  });
+
+  describe('fetch da feature flag', () => {
+    it('busca a page PROFILE_LABELS com o institutionId correto', async () => {
+      const apiClient = createMockApiClient(
+        flagResponse({ STUDENT: 'Estudante' })
+      );
+
+      renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() => {
+        expect(apiClient.get).toHaveBeenCalledWith(
+          '/featureFlags/institution/institution-123/page/PROFILE_LABELS'
+        );
+      });
+    });
+
+    it('mescla os labels customizados sobre os padrão', async () => {
+      const apiClient = createMockApiClient(
+        flagResponse({
+          STUDENT: 'Estudante',
+          UNIT_MANAGER: 'Diretor(a)/Pedagogo(a)',
+        })
+      );
+
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Customizados
+      expect(result.current.getProfileLabel(PROFILE_ROLES.STUDENT)).toBe(
+        'Estudante'
+      );
+      expect(result.current.getProfileLabel(PROFILE_ROLES.UNIT_MANAGER)).toBe(
+        'Diretor(a)/Pedagogo(a)'
+      );
+      // Não customizado mantém o padrão
+      expect(result.current.getProfileLabel(PROFILE_ROLES.TEACHER)).toBe(
+        'Professor'
+      );
+    });
+
+    it('expõe apenas os overrides explícitos em customLabels (sem defaults)', async () => {
+      const apiClient = createMockApiClient(
+        flagResponse({ STUDENT: 'Estudante' })
+      );
+
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.customLabels).toEqual({ STUDENT: 'Estudante' });
+    });
+
+    it('não faz fetch quando institutionId é null', async () => {
+      act(() => {
+        useAppStore.setState({ institutionId: null });
+      });
+
+      const apiClient = createMockApiClient();
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(apiClient.get).not.toHaveBeenCalled();
+      expect(result.current.labels).toEqual(DEFAULT_PROFILE_LABELS);
+    });
+  });
+
+  describe('tratamento de erros', () => {
+    it('mantém os labels padrão quando a API falha', async () => {
+      const apiClient = createMockApiClient(undefined, true);
+
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.labels).toEqual(DEFAULT_PROFILE_LABELS);
+    });
+  });
+
+  describe('reatividade ao institutionId', () => {
+    it('refaz o fetch quando institutionId muda', async () => {
+      const apiClient = createMockApiClient(
+        flagResponse({ STUDENT: 'Estudante' })
+      );
+
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        useAppStore.setState({ institutionId: 'institution-456' });
+      });
+
+      await waitFor(() => {
+        expect(apiClient.get).toHaveBeenCalledTimes(2);
+      });
+
+      expect(apiClient.get).toHaveBeenLastCalledWith(
+        '/featureFlags/institution/institution-456/page/PROFILE_LABELS'
+      );
+    });
+  });
+});
+
+describe('getProfileLabel (pure)', () => {
+  it('prefere o label customizado', () => {
+    expect(
+      getProfileLabel(PROFILE_ROLES.STUDENT, { STUDENT: 'Estudante' })
+    ).toBe('Estudante');
+  });
+
+  it('cai no padrão quando não há customizado', () => {
+    expect(getProfileLabel(PROFILE_ROLES.STUDENT, {})).toBe('Aluno');
+    expect(getProfileLabel(PROFILE_ROLES.STUDENT, null)).toBe('Aluno');
+  });
+
+  it('retorna o valor cru para um role desconhecido', () => {
+    expect(getProfileLabel('UNKNOWN_ROLE')).toBe('UNKNOWN_ROLE');
+  });
+});

--- a/src/hooks/useProfileLabels.test.ts
+++ b/src/hooks/useProfileLabels.test.ts
@@ -166,6 +166,97 @@ describe('useProfileLabels', () => {
         '/featureFlags/institution/institution-456/page/PROFILE_LABELS'
       );
     });
+
+    it('limpa os labels da instituição anterior enquanto o novo fetch está em andamento', async () => {
+      let resolveSecond: (value: unknown) => void = () => {};
+      const apiClient: ApiClient = {
+        get: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: flagResponse({ STUDENT: 'Estudante' }),
+          })
+          .mockImplementationOnce(
+            () =>
+              new Promise((resolve) => {
+                resolveSecond = resolve;
+              })
+          ),
+      };
+
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      await waitFor(() =>
+        expect(result.current.getProfileLabel(PROFILE_ROLES.STUDENT)).toBe(
+          'Estudante'
+        )
+      );
+
+      act(() => {
+        useAppStore.setState({ institutionId: 'institution-456' });
+      });
+
+      // Enquanto o fetch da nova instituição não resolve, não pode exibir o
+      // label customizado da anterior — cai no padrão.
+      expect(result.current.customLabels).toEqual({});
+      expect(result.current.getProfileLabel(PROFILE_ROLES.STUDENT)).toBe(
+        'Aluno'
+      );
+
+      await act(async () => {
+        resolveSecond({ data: flagResponse({ TEACHER: 'Professor(a)' }) });
+      });
+
+      expect(result.current.getProfileLabel(PROFILE_ROLES.TEACHER)).toBe(
+        'Professor(a)'
+      );
+    });
+
+    it('ignora uma resposta antiga que chega depois da troca de institutionId (race)', async () => {
+      let resolveFirst: (value: unknown) => void = () => {};
+      let resolveSecond: (value: unknown) => void = () => {};
+      const apiClient: ApiClient = {
+        get: jest
+          .fn()
+          .mockImplementationOnce(
+            () =>
+              new Promise((resolve) => {
+                resolveFirst = resolve;
+              })
+          )
+          .mockImplementationOnce(
+            () =>
+              new Promise((resolve) => {
+                resolveSecond = resolve;
+              })
+          ),
+      };
+
+      const { result } = renderHook(() => useProfileLabels({ apiClient }));
+
+      act(() => {
+        useAppStore.setState({ institutionId: 'institution-456' });
+      });
+
+      // A resposta da instituição nova (a segunda chamada) chega primeiro.
+      await act(async () => {
+        resolveSecond({ data: flagResponse({ TEACHER: 'Professor(a)' }) });
+      });
+      expect(result.current.getProfileLabel(PROFILE_ROLES.TEACHER)).toBe(
+        'Professor(a)'
+      );
+
+      // A resposta antiga (instituição já trocada) chega por último e deve ser
+      // ignorada pelo guard de cleanup.
+      await act(async () => {
+        resolveFirst({ data: flagResponse({ STUDENT: 'Antigo' }) });
+      });
+      expect(result.current.getProfileLabel(PROFILE_ROLES.STUDENT)).toBe(
+        'Aluno'
+      );
+      expect(result.current.getProfileLabel(PROFILE_ROLES.TEACHER)).toBe(
+        'Professor(a)'
+      );
+    });
   });
 });
 

--- a/src/hooks/useProfileLabels.ts
+++ b/src/hooks/useProfileLabels.ts
@@ -50,10 +50,19 @@ export const useProfileLabels = (
   const { institutionId } = useAppStore();
 
   useEffect(() => {
+    // Clear the previous institution's labels so we never render stale
+    // nomenclatura while the next fetch is in flight (or when it goes null).
+    setCustomLabels({});
+
     if (!institutionId) {
       setLoading(false);
       return;
     }
+
+    // Guard against out-of-order responses: a slower earlier request must not
+    // overwrite the labels of a newer institutionId.
+    let active = true;
+    setLoading(true);
 
     const fetchProfileLabels = async () => {
       try {
@@ -61,17 +70,22 @@ export const useProfileLabels = (
           data: { featureFlags: ProfileLabelsFeatureFlag };
         }>(`/featureFlags/institution/${institutionId}/page/PROFILE_LABELS`);
 
+        if (!active) return;
         const version = response?.data?.featureFlags?.version;
         setCustomLabels(version ?? {});
       } catch {
-        setCustomLabels({});
+        if (active) setCustomLabels({});
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     };
 
     fetchProfileLabels();
-  }, [institutionId]);
+
+    return () => {
+      active = false;
+    };
+  }, [institutionId, config.apiClient]);
 
   const labels = useMemo(
     () => ({ ...DEFAULT_PROFILE_LABELS, ...customLabels }),

--- a/src/hooks/useProfileLabels.ts
+++ b/src/hooks/useProfileLabels.ts
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAppStore } from '../store/appStore';
+import { PROFILE_ROLES } from '../types/chat';
+import {
+  DEFAULT_PROFILE_LABELS,
+  getProfileLabel as resolveProfileLabel,
+  type ProfileLabelsMap,
+  type ProfileLabelsFeatureFlag,
+} from '../types/profileLabels';
+import type { BaseApiClient } from '../types/api';
+
+export interface UseProfileLabelsConfig {
+  apiClient: Pick<BaseApiClient, 'get'>;
+}
+
+export interface UseProfileLabelsReturn {
+  /** Full resolved label map (custom labels merged over the defaults). */
+  labels: Record<PROFILE_ROLES, string>;
+  /**
+   * Only the institution's explicit overrides (the raw feature flag `version`),
+   * with no defaults merged in. Use this when a consumer has its own fallback
+   * label and only wants to replace it when the institution customized it.
+   */
+  customLabels: ProfileLabelsMap;
+  /** Resolve a single role's display label using the resolved map. */
+  getProfileLabel: (role: PROFILE_ROLES | string) => string;
+  loading: boolean;
+}
+
+/**
+ * Resolve the institution's custom profile nomenclatura (PROFILE_LABELS feature
+ * flag) and expose a label map + resolver. Falls back to DEFAULT_PROFILE_LABELS
+ * when the institution has no custom labels, so apps render correctly even
+ * without the flag.
+ *
+ * Mirrors `useSupportFeatureFlag`: `institutionId` comes from `useAppStore` and
+ * the HTTP client is injected so each app passes its authenticated instance.
+ *
+ * @example
+ * ```tsx
+ * const { getProfileLabel } = useProfileLabels({ apiClient });
+ * <span>{getProfileLabel(PROFILE_ROLES.STUDENT)}</span> // "Estudante"
+ * ```
+ */
+export const useProfileLabels = (
+  config: UseProfileLabelsConfig
+): UseProfileLabelsReturn => {
+  const [customLabels, setCustomLabels] = useState<ProfileLabelsMap>({});
+  const [loading, setLoading] = useState(true);
+  const { institutionId } = useAppStore();
+
+  useEffect(() => {
+    if (!institutionId) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchProfileLabels = async () => {
+      try {
+        const { data: response } = await config.apiClient.get<{
+          data: { featureFlags: ProfileLabelsFeatureFlag };
+        }>(`/featureFlags/institution/${institutionId}/page/PROFILE_LABELS`);
+
+        const version = response?.data?.featureFlags?.version;
+        setCustomLabels(version ?? {});
+      } catch {
+        setCustomLabels({});
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfileLabels();
+  }, [institutionId]);
+
+  const labels = useMemo(
+    () => ({ ...DEFAULT_PROFILE_LABELS, ...customLabels }),
+    [customLabels]
+  );
+
+  const getProfileLabel = useMemo(
+    () => (role: PROFILE_ROLES | string) => resolveProfileLabel(role, labels),
+    [labels]
+  );
+
+  return { labels, customLabels, getProfileLabel, loading };
+};

--- a/src/types/profileLabels.ts
+++ b/src/types/profileLabels.ts
@@ -1,0 +1,61 @@
+/**
+ * Profile labels (nomenclatura) types
+ *
+ * Some institutions rename the default profiles (e.g. Aluno -> Estudante,
+ * Gestor Unidade -> Diretor(a)/Pedagogo(a)). Those overrides are stored in a
+ * per-institution PROFILE_LABELS feature flag and consumed here so the apps can
+ * render the institution's preferred nomenclatura.
+ */
+
+import { PROFILE_ROLES } from './chat';
+
+/**
+ * Map of canonical profile role -> custom display label (nomenclatura).
+ * Mirrors the backend PROFILE_LABELS feature flag `version`. Any role may be
+ * omitted, in which case the default label applies.
+ */
+export type ProfileLabelsMap = Partial<Record<PROFILE_ROLES, string>>;
+
+/**
+ * Default profile labels — mirror the seeded `profiles.description` values on
+ * the backend. Used as the fallback baseline when an institution has no
+ * PROFILE_LABELS feature flag (or omits a given role).
+ */
+export const DEFAULT_PROFILE_LABELS: Record<PROFILE_ROLES, string> = {
+  [PROFILE_ROLES.SUPER_ADMIN]: 'Super Admin',
+  [PROFILE_ROLES.GENERAL_MANAGER]: 'Gestor Geral',
+  [PROFILE_ROLES.REGIONAL_MANAGER]: 'Gestor Regional',
+  [PROFILE_ROLES.UNIT_MANAGER]: 'Gestor de Unidade',
+  [PROFILE_ROLES.TEACHER]: 'Professor',
+  [PROFILE_ROLES.STUDENT]: 'Aluno',
+};
+
+/**
+ * Resolve the display label for a profile role, preferring the institution's
+ * custom nomenclatura and falling back to the default. Unknown roles return the
+ * raw value so callers never render `undefined`.
+ *
+ * @param role - Canonical profile role (e.g. PROFILE_ROLES.STUDENT)
+ * @param labels - Optional custom label map (from the PROFILE_LABELS flag)
+ * @returns The display label to render
+ */
+export const getProfileLabel = (
+  role: PROFILE_ROLES | string,
+  labels?: ProfileLabelsMap | null
+): string => {
+  return (
+    labels?.[role as PROFILE_ROLES] ||
+    DEFAULT_PROFILE_LABELS[role as PROFILE_ROLES] ||
+    String(role)
+  );
+};
+
+/**
+ * Shape of the PROFILE_LABELS feature flag record returned by
+ * `GET /featureFlags/institution/:id/page/PROFILE_LABELS`.
+ */
+export interface ProfileLabelsFeatureFlag {
+  institutionId: string;
+  page: string;
+  version: ProfileLabelsMap;
+}

--- a/src/utils/filterHelpers.test.ts
+++ b/src/utils/filterHelpers.test.ts
@@ -515,11 +515,23 @@ describe('filterHelpers', () => {
       const result = extractBreakdownFilterOptions([
         {
           subject: { id: 'sub-1', name: 'Matemática' },
-          breakdown: [{ school: { id: 'sch-1', name: 'Escola A' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-1', name: 'Escola A' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
         {
           subject: { id: 'sub-1', name: 'Matemática' },
-          breakdown: [{ school: { id: 'sch-1', name: 'Escola A' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-1', name: 'Escola A' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
       ]);
 
@@ -531,11 +543,23 @@ describe('filterHelpers', () => {
       const result = extractBreakdownFilterOptions([
         {
           subject: { id: 'sub-1', name: 'Matemática' },
-          breakdown: [{ school: { id: 'sch-1', name: 'Escola A' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-1', name: 'Escola A' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
         {
           subject: { id: 'sub-2', name: 'Português' },
-          breakdown: [{ school: { id: 'sch-2', name: 'Escola B' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-2', name: 'Escola B' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
       ]);
 
@@ -548,8 +572,16 @@ describe('filterHelpers', () => {
         {
           subject: { id: 'sub-1', name: 'Matemática' },
           breakdown: [
-            { school: { id: 'sch-1', name: 'Escola A' }, schoolYear: { id: 'sy-1', name: '2024' }, class: { id: 'cls-1', name: 'Turma A' } },
-            { school: { id: 'sch-2', name: 'Escola B' }, schoolYear: { id: 'sy-2', name: '2025' }, class: { id: 'cls-2', name: 'Turma B' } },
+            {
+              school: { id: 'sch-1', name: 'Escola A' },
+              schoolYear: { id: 'sy-1', name: '2024' },
+              class: { id: 'cls-1', name: 'Turma A' },
+            },
+            {
+              school: { id: 'sch-2', name: 'Escola B' },
+              schoolYear: { id: 'sy-2', name: '2025' },
+              class: { id: 'cls-2', name: 'Turma B' },
+            },
           ],
         },
       ]);
@@ -563,11 +595,23 @@ describe('filterHelpers', () => {
       const result = extractBreakdownFilterOptions([
         {
           subject: { id: 'sub-2', name: 'Português' },
-          breakdown: [{ school: { id: 'sch-2', name: 'Zebra School' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-2', name: 'Zebra School' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
         {
           subject: { id: 'sub-1', name: 'Matemática' },
-          breakdown: [{ school: { id: 'sch-1', name: 'Alpha School' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-1', name: 'Alpha School' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
       ]);
 
@@ -581,7 +625,13 @@ describe('filterHelpers', () => {
       const result = extractBreakdownFilterOptions([
         {
           subject: null,
-          breakdown: [{ school: { id: 'sch-1', name: 'Escola A' }, schoolYear: null, class: null }],
+          breakdown: [
+            {
+              school: { id: 'sch-1', name: 'Escola A' },
+              schoolYear: null,
+              class: null,
+            },
+          ],
         },
       ]);
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -228,6 +228,10 @@ export default defineConfig({
     'hooks/useSupportFeatureFlag/index': 'src/hooks/useSupportFeatureFlag.ts',
     'hooks/useZendesk/index': 'src/hooks/useZendesk.ts',
 
+    // Profile labels (per-institution custom nomenclatura)
+    'hooks/useProfileLabels/index': 'src/hooks/useProfileLabels.ts',
+    'types/profileLabels/index': 'src/types/profileLabels.ts',
+
     // ============================================================
     // Bundle migration: subpath entries for symbols consumed by the
     // apps. Grouped by kind for legibility. Each entry maps a public


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for institution-specific profile label names, with sensible defaults when no custom labels are available.
  * Improved label display so unknown roles still show a readable value instead of appearing blank.
* **Bug Fixes**
  * Ensured profile labels continue to load correctly when switching institutions or if the label service is unavailable.
* **Tests**
  * Expanded automated coverage for label loading, fallback behavior, and label resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->