### PR TITLE
AE-2845: fix notifications refreshing

### DIFF
--- a/src/components/NotificationCard/NotificationCard.refresh.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.refresh.test.tsx
@@ -181,6 +181,6 @@ describe('NotificationList loading gate (no skeleton flash on refresh)', () => {
     );
 
     expect(screen.getByText('Test Notification 1')).toBeInTheDocument();
-    expect(document.querySelectorAll('.animate-pulse').length).toBe(0);
+    expect(document.querySelectorAll('.animate-pulse')).toHaveLength(0);
   });
 });

--- a/src/components/NotificationCard/NotificationCard.refresh.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.refresh.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, act } from '@testing-library/react';
+import NotificationCard, { NotificationGroup } from './NotificationCard';
+import { NotificationEntityType } from '../../types/notifications';
+import { DeviceType, useMobile } from '../../hooks/useMobile';
+
+jest.mock(
+  '../../assets/img/no-notification-result.png',
+  () => 'test-file-stub'
+);
+
+jest.mock('../../hooks/useMobile');
+const mockUseMobile = useMobile as jest.MockedFunction<typeof useMobile>;
+
+const makeUseMobileMock = (
+  overrides?: Partial<ReturnType<typeof useMobile>>
+): ReturnType<typeof useMobile> => ({
+  isMobile: false,
+  isTablet: false,
+  isSmallMobile: false,
+  isExtraSmallMobile: false,
+  isUltraSmallMobile: false,
+  isTinyMobile: false,
+  getFormContainerClasses: jest.fn(() => ''),
+  getHeaderClasses: jest.fn(() => ''),
+  getMobileHeaderClasses: jest.fn(() => ''),
+  getDesktopHeaderClasses: jest.fn(() => ''),
+  getVideoContainerClasses: jest.fn(() => ''),
+  getDeviceType: jest.fn(() => 'desktop' as DeviceType),
+  ...overrides,
+});
+
+const mockGroupedNotifications: NotificationGroup[] = [
+  {
+    label: 'Hoje',
+    notifications: [
+      {
+        id: '1',
+        title: 'Test Notification 1',
+        message: 'Test message 1',
+        type: 'ACTIVITY' as const,
+        isRead: false,
+        entityType: NotificationEntityType.ACTIVITY,
+        entityId: 'act-1',
+        createdAt: new Date(),
+      },
+    ],
+  },
+];
+
+describe('NotificationCenter auto-refresh (polling)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockUseMobile.mockReturnValue(makeUseMobileMock());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('polls onFetchNotifications while the center is open', () => {
+    const onFetchNotifications = jest.fn();
+    render(
+      <NotificationCard
+        mode="center"
+        isActive
+        groupedNotifications={mockGroupedNotifications}
+        onFetchNotifications={onFetchNotifications}
+        refreshIntervalMs={1000}
+      />
+    );
+
+    // Initial fetch on open
+    expect(onFetchNotifications).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(onFetchNotifications).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(onFetchNotifications).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not poll while the center is closed', () => {
+    const onFetchNotifications = jest.fn();
+    render(
+      <NotificationCard
+        mode="center"
+        isActive={false}
+        groupedNotifications={mockGroupedNotifications}
+        onFetchNotifications={onFetchNotifications}
+        refreshIntervalMs={1000}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(onFetchNotifications).not.toHaveBeenCalled();
+  });
+
+  it('stops polling when the center closes', () => {
+    const onFetchNotifications = jest.fn();
+    const { rerender } = render(
+      <NotificationCard
+        mode="center"
+        isActive
+        groupedNotifications={mockGroupedNotifications}
+        onFetchNotifications={onFetchNotifications}
+        refreshIntervalMs={1000}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(onFetchNotifications).toHaveBeenCalledTimes(2);
+
+    rerender(
+      <NotificationCard
+        mode="center"
+        isActive={false}
+        groupedNotifications={mockGroupedNotifications}
+        onFetchNotifications={onFetchNotifications}
+        refreshIntervalMs={1000}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    // No further calls after closing
+    expect(onFetchNotifications).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not poll when refreshIntervalMs is 0', () => {
+    const onFetchNotifications = jest.fn();
+    render(
+      <NotificationCard
+        mode="center"
+        isActive
+        groupedNotifications={mockGroupedNotifications}
+        onFetchNotifications={onFetchNotifications}
+        refreshIntervalMs={0}
+      />
+    );
+
+    // Only the initial open fetch
+    expect(onFetchNotifications).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(onFetchNotifications).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('NotificationList loading gate (no skeleton flash on refresh)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseMobile.mockReturnValue(makeUseMobileMock());
+  });
+
+  it('shows the skeleton only when loading with no notifications yet', () => {
+    render(<NotificationCard mode="list" loading groupedNotifications={[]} />);
+    expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThan(
+      0
+    );
+  });
+
+  it('keeps the list visible (no skeleton) when refreshing with items', () => {
+    render(
+      <NotificationCard
+        mode="list"
+        loading
+        groupedNotifications={mockGroupedNotifications}
+      />
+    );
+
+    expect(screen.getByText('Test Notification 1')).toBeInTheDocument();
+    expect(document.querySelectorAll('.animate-pulse').length).toBe(0);
+  });
+});

--- a/src/components/NotificationCard/NotificationCard.tsx
+++ b/src/components/NotificationCard/NotificationCard.tsx
@@ -21,6 +21,12 @@ import type {
 import { formatTimeAgo } from '../../store/notificationStore';
 import mockContentImage from '../../assets/img/mock-content.png';
 
+/**
+ * Default interval (in ms) to auto-refresh the notification center while it is
+ * open, so newly received notifications appear without reopening it.
+ */
+const DEFAULT_REFRESH_INTERVAL_MS = 3000;
+
 // Extended notification item for component usage with time string
 export interface NotificationItem extends Omit<Notification, 'createdAt'> {
   time: string;
@@ -207,6 +213,12 @@ interface NotificationCenterMode extends BaseNotificationProps {
    * Callback when dropdown open state changes (for synchronization with parent)
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Interval (in ms) to auto-refresh the list while the center is open, so newly
+   * received notifications appear without reopening it. Defaults to 3000 (3s).
+   * Set to 0 to disable polling.
+   */
+  refreshIntervalMs?: number;
 }
 
 // Union type for all modes
@@ -506,8 +518,9 @@ const NotificationList = ({
     );
   }
 
-  // Loading state
-  if (loading) {
+  // Loading state — only show the skeleton on the initial load (empty list).
+  // Background refreshes (e.g. while the center polls) keep the list visible.
+  if (loading && groupedNotifications.length === 0) {
     return (
       <div className="flex flex-col gap-0 w-full">
         {['skeleton-first', 'skeleton-second', 'skeleton-third'].map(
@@ -649,6 +662,7 @@ const NotificationCenter = ({
   emptyStateTitle,
   emptyStateDescription,
   className,
+  refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS,
 }: NotificationCenterProps) => {
   const { isMobile } = useMobile();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -688,6 +702,20 @@ const NotificationCenter = ({
       onFetchNotifications?.();
     }
   }, [isActive, onFetchNotifications]);
+
+  // While the center is open, poll periodically so newly received notifications
+  // appear without the user having to reopen it. The list is not replaced by a
+  // skeleton on these background refreshes (see NotificationList loading gate).
+  const isCenterOpen = isMobile ? isModalOpen : Boolean(isActive);
+  useEffect(() => {
+    if (!isCenterOpen || !onFetchNotifications || refreshIntervalMs <= 0) {
+      return;
+    }
+    const intervalId = setInterval(() => {
+      onFetchNotifications();
+    }, refreshIntervalMs);
+    return () => clearInterval(intervalId);
+  }, [isCenterOpen, onFetchNotifications, refreshIntervalMs]);
 
   const renderEmptyState = () => (
     <NotificationEmpty


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification center now auto-refreshes while open, keeping notifications up to date.
  * Added a configurable refresh interval, including an option to disable polling.

* **Bug Fixes**
  * Loading placeholders now appear only during the initial load, so existing notifications stay visible during background refreshes.
  * Polling stops when the notification center is no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->