### PR TITLE
fix lazy load

### DIFF
--- a/src/components/SimulatedPerformance/types.ts
+++ b/src/components/SimulatedPerformance/types.ts
@@ -33,8 +33,11 @@ export interface UseSimulatedPerformanceOptions {
    */
   profileName?: string;
   /**
-   * When false, the hook will not make any API calls.
-   * Useful for lazy loading when the simulated report is not active.
+   * When false, the hook will not make automatic API calls (effect-triggered fetches).
+   * The initial data load and effect-based reloads (e.g., scoreType URL changes) will be
+   * skipped. However, manual handler calls (handlePeriodChange, handleFiltersApply, etc.)
+   * will still trigger API requests if invoked directly.
+   * Useful for lazy loading when the simulated report tab is not active.
    * @default true
    */
   enabled?: boolean;

--- a/src/components/SimulatedPerformance/types.ts
+++ b/src/components/SimulatedPerformance/types.ts
@@ -32,6 +32,12 @@ export interface UseSimulatedPerformanceOptions {
    * - GENERAL_MANAGER, TEACHER, others: shows students (default)
    */
   profileName?: string;
+  /**
+   * When false, the hook will not make any API calls.
+   * Useful for lazy loading when the simulated report is not active.
+   * @default true
+   */
+  enabled?: boolean;
 }
 
 export interface UseSimulatedPerformanceReturn {

--- a/src/components/SimulatedPerformance/useSimulatedPerformance.test.tsx
+++ b/src/components/SimulatedPerformance/useSimulatedPerformance.test.tsx
@@ -141,9 +141,7 @@ describe('useSimulatedPerformance', () => {
   describe('enabled parameter', () => {
     it('does NOT load initial data when enabled is false', async () => {
       const api = createMockApi();
-      renderHook(() =>
-        useSimulatedPerformance({ api, enabled: false })
-      );
+      renderHook(() => useSimulatedPerformance({ api, enabled: false }));
 
       // Wait a tick to ensure effects would have run
       await act(async () => {

--- a/src/components/SimulatedPerformance/useSimulatedPerformance.test.tsx
+++ b/src/components/SimulatedPerformance/useSimulatedPerformance.test.tsx
@@ -126,6 +126,91 @@ describe('useSimulatedPerformance', () => {
         expect(mockFetchGeneralOverview).toHaveBeenCalled();
       });
     });
+
+    it('loads initial data when enabled is true (explicit)', async () => {
+      const api = createMockApi();
+      renderHook(() => useSimulatedPerformance({ api, enabled: true }));
+
+      await waitFor(() => {
+        expect(mockFetchSimulatedOverview).toHaveBeenCalled();
+        expect(mockFetchGeneralOverview).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('enabled parameter', () => {
+    it('does NOT load initial data when enabled is false', async () => {
+      const api = createMockApi();
+      renderHook(() =>
+        useSimulatedPerformance({ api, enabled: false })
+      );
+
+      // Wait a tick to ensure effects would have run
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(mockFetchSimulatedOverview).not.toHaveBeenCalled();
+      expect(mockFetchGeneralOverview).not.toHaveBeenCalled();
+    });
+
+    it('returns default state when disabled', () => {
+      const api = createMockApi();
+      const { result } = renderHook(() =>
+        useSimulatedPerformance({ api, enabled: false })
+      );
+
+      // Hook should still return all the expected properties
+      expect(result.current.period).toBe('1_MONTH');
+      expect(result.current.scoreType).toBe('percentage');
+      expect(result.current.selectedAreaKnowledgeId).toBeNull();
+      expect(result.current.simulatedViewTab).toBe(SimulatedViewTab.STUDENTS);
+      expect(result.current.studentsTableColumns).toBeDefined();
+      expect(result.current.contentsTableColumns).toBeDefined();
+    });
+
+    it('does NOT reload data on scoreType change when disabled', async () => {
+      mockSearchParams.set('scoreType', 'percentage');
+
+      const api = createMockApi();
+      const { rerender } = renderHook(
+        ({ enabled }) => useSimulatedPerformance({ api, enabled }),
+        { initialProps: { enabled: false } }
+      );
+
+      // Clear any mocks
+      jest.clearAllMocks();
+
+      // Simulate scoreType change by updating URL params
+      mockSearchParams.set('scoreType', 'tri');
+      rerender({ enabled: false });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      // Should NOT have made any API calls
+      expect(mockFetchSimulatedOverview).not.toHaveBeenCalled();
+      expect(mockFetchGeneralOverview).not.toHaveBeenCalled();
+    });
+
+    it('handlers still work when disabled (for UI state management)', async () => {
+      const api = createMockApi();
+      const { result } = renderHook(() =>
+        useSimulatedPerformance({ api, enabled: false })
+      );
+
+      // Modals should still be controllable
+      await act(async () => {
+        result.current.filtersModal.open();
+      });
+      expect(result.current.filtersModal.isOpen).toBe(true);
+
+      await act(async () => {
+        result.current.filtersModal.close();
+      });
+      expect(result.current.filtersModal.isOpen).toBe(false);
+    });
   });
 
   describe('handlePeriodChange', () => {

--- a/src/components/SimulatedPerformance/useSimulatedPerformance.tsx
+++ b/src/components/SimulatedPerformance/useSimulatedPerformance.tsx
@@ -195,6 +195,7 @@ const contentsTableColumns: ColumnConfig<SimulatedContentItem>[] = [
 export function useSimulatedPerformance({
   api,
   profileName,
+  enabled = true,
 }: UseSimulatedPerformanceOptions): UseSimulatedPerformanceReturn {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -866,6 +867,8 @@ export function useSimulatedPerformance({
   const hasInitialLoadCompleted = useRef(false);
 
   useEffect(() => {
+    // Skip if hook is disabled (e.g., not on simulated report)
+    if (!enabled) return;
     if (initialLoadRef.current) return;
     initialLoadRef.current = true;
 
@@ -879,10 +882,17 @@ export function useSimulatedPerformance({
     Promise.resolve().then(() => {
       hasInitialLoadCompleted.current = true;
     });
-  }, [loadStudentsData, loadGeneralOverviewData, loadAggregatedOverviewData]);
+  }, [
+    enabled,
+    loadStudentsData,
+    loadGeneralOverviewData,
+    loadAggregatedOverviewData,
+  ]);
 
   // === Recarregar quando scoreType muda ===
   useEffect(() => {
+    // Skip if hook is disabled
+    if (!enabled) return;
     if (!hasInitialLoadCompleted.current) return;
 
     // Always reload aggregated overview
@@ -908,6 +918,7 @@ export function useSimulatedPerformance({
     }
     loadGeneralOverviewData();
   }, [
+    enabled,
     scoreType,
     loadStudentsData,
     loadSkillsData,
@@ -918,6 +929,8 @@ export function useSimulatedPerformance({
   // === Recarregar quando aggregationType muda (perfil carregado após mount) ===
   const previousAggregationTypeRef = useRef(aggregationType);
   useEffect(() => {
+    // Skip if hook is disabled
+    if (!enabled) return;
     // Skip if aggregationType hasn't actually changed
     if (previousAggregationTypeRef.current === aggregationType) return;
     previousAggregationTypeRef.current = aggregationType;
@@ -930,7 +943,7 @@ export function useSimulatedPerformance({
       selectedAreaKnowledgeIdRef.current,
       selectedSubjectIdRef.current
     );
-  }, [aggregationType, loadAggregatedOverviewData]);
+  }, [enabled, aggregationType, loadAggregatedOverviewData]);
 
   return {
     // Query Params


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `enabled` option for simulated performance loading, allowing loading behavior to be toggled for lazy/deferred fetching.
  * When `enabled` is set to `false`, the hook skips initial fetches and prevents reloads on relevant changes until re-enabled.
* **Tests**
  * Added coverage to verify the hook’s disabled behavior, including ensuring no API calls occur and existing UI handlers remain functional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->