### PR TITLE
AE-2883: fix map colors

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -220,6 +220,7 @@ describe('ChoroplethMap', () => {
     expect(screen.getByText('Acima da média')).toBeInTheDocument();
     expect(screen.getByText('Abaixo da média')).toBeInTheDocument();
     expect(screen.getByText('Ponto de atenção')).toBeInTheDocument();
+    expect(screen.getByText('Sem acesso')).toBeInTheDocument();
   });
 
   it('shows loading skeleton when loading is true', () => {
@@ -501,6 +502,50 @@ describe('ChoroplethMap color classification', () => {
 
     const styleFunction = mockSetStyle.mock.calls[0][0];
     expect(typeof styleFunction).toBe('function');
+  });
+
+  it('paints zero-access regions with the "Sem acesso" color, distinct from low-value regions with access', async () => {
+    const data: RegionData[] = [
+      {
+        id: 'r1',
+        name: 'R1',
+        value: 0,
+        accessCount: 0,
+        geoJson: {
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'Polygon', coordinates: [[]] },
+        },
+      },
+    ];
+
+    render(<ChoroplethMap data={data} apiKey={mockApiKey} />);
+
+    await waitFor(() => {
+      expect(mockSetStyle).toHaveBeenCalled();
+    });
+
+    const styleFunction = mockSetStyle.mock.calls[0][0];
+
+    // Zero access → "Sem acesso" band (background-800 fallback), regardless of value.
+    const noAccessFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionValue') return 0;
+        if (prop === 'regionAccessCount') return 0;
+        return null;
+      },
+    };
+    // Low normalized value but WITH access → stays "Ponto de atenção" (error-700 fallback).
+    const lowWithAccessFeature = {
+      getProperty: (prop: string) => {
+        if (prop === 'regionValue') return 0.1;
+        if (prop === 'regionAccessCount') return 5;
+        return null;
+      },
+    };
+
+    expect(styleFunction(noAccessFeature).fillColor).toBe('#414040');
+    expect(styleFunction(lowWithAccessFeature).fillColor).toBe('#b91c1c');
   });
 });
 
@@ -1146,7 +1191,11 @@ describe('ChoroplethMap legend interaction', () => {
 
   it('hides features on map when legend class is toggled off', async () => {
     const mockFeature = {
-      getProperty: (prop: string) => (prop === 'regionValue' ? 0.9 : null),
+      getProperty: (prop: string) => {
+        if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 100;
+        return null;
+      },
       getGeometry: () => ({ forEachLatLng: jest.fn() }),
     };
     mockForEach.mockImplementation((cb: (f: typeof mockFeature) => void) => {
@@ -1176,7 +1225,11 @@ describe('ChoroplethMap legend interaction', () => {
 
   it('shows features on map when legend class is toggled back on', async () => {
     const mockFeature = {
-      getProperty: (prop: string) => (prop === 'regionValue' ? 0.9 : null),
+      getProperty: (prop: string) => {
+        if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 100;
+        return null;
+      },
       getGeometry: () => ({ forEachLatLng: jest.fn() }),
     };
     mockForEach.mockImplementation((cb: (f: typeof mockFeature) => void) => {
@@ -1219,7 +1272,11 @@ describe('ChoroplethMap legend interaction', () => {
   it('adjusts map zoom to fit visible features when legend toggled', async () => {
     const mockForEachLatLng = jest.fn();
     const mockFeature = {
-      getProperty: (prop: string) => (prop === 'regionValue' ? 0.9 : null),
+      getProperty: (prop: string) => {
+        if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 100;
+        return null;
+      },
       getGeometry: () => ({ forEachLatLng: mockForEachLatLng }),
     };
     mockForEach.mockImplementation((cb: (f: typeof mockFeature) => void) => {
@@ -1369,11 +1426,12 @@ describe('ChoroplethMap isManagedRegion', () => {
       getProperty: (prop: string) => {
         if (prop === 'regionIsManaged') return true;
         if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 500;
         return null;
       },
     };
     expect(styleFn(managedFeature)).toEqual({
-      fillColor: '#2c7bb6',
+      fillColor: '#66b584',
       fillOpacity: 0,
       strokeColor: '#ffffff',
       strokeWeight: 0.3,
@@ -1545,6 +1603,7 @@ describe('ChoroplethMap isManagedRegion', () => {
       getProperty: (prop: string) => {
         if (prop === 'regionIsManaged') return true;
         if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 100;
         if (prop === 'regionName') return 'NRE Gerido';
         return null;
       },
@@ -1605,6 +1664,7 @@ describe('ChoroplethMap isManagedRegion', () => {
       getProperty: (prop: string) => {
         if (prop === 'regionIsManaged') return true;
         if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 100;
         if (prop === 'regionName') return 'NRE Gerido';
         return null;
       },
@@ -1633,6 +1693,7 @@ describe('ChoroplethMap isManagedRegion', () => {
       getProperty: (prop: string) => {
         if (prop === 'regionIsManaged') return true;
         if (prop === 'regionValue') return 0.9;
+        if (prop === 'regionAccessCount') return 100;
         if (prop === 'regionName') return 'NRE Destaque';
         return null;
       },
@@ -1642,6 +1703,7 @@ describe('ChoroplethMap isManagedRegion', () => {
       getProperty: (prop: string) => {
         if (prop === 'regionIsManaged') return true;
         if (prop === 'regionValue') return 0.1;
+        if (prop === 'regionAccessCount') return 20;
         if (prop === 'regionName') return 'NRE Atenção';
         return null;
       },

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -220,7 +220,6 @@ describe('ChoroplethMap', () => {
     expect(screen.getByText('Acima da média')).toBeInTheDocument();
     expect(screen.getByText('Abaixo da média')).toBeInTheDocument();
     expect(screen.getByText('Ponto de atenção')).toBeInTheDocument();
-    expect(screen.getByText('Sem acesso')).toBeInTheDocument();
   });
 
   it('shows loading skeleton when loading is true', () => {
@@ -502,50 +501,6 @@ describe('ChoroplethMap color classification', () => {
 
     const styleFunction = mockSetStyle.mock.calls[0][0];
     expect(typeof styleFunction).toBe('function');
-  });
-
-  it('paints zero-access regions with the "Sem acesso" color, distinct from low-value regions with access', async () => {
-    const data: RegionData[] = [
-      {
-        id: 'r1',
-        name: 'R1',
-        value: 0,
-        accessCount: 0,
-        geoJson: {
-          type: 'Feature',
-          properties: {},
-          geometry: { type: 'Polygon', coordinates: [[]] },
-        },
-      },
-    ];
-
-    render(<ChoroplethMap data={data} apiKey={mockApiKey} />);
-
-    await waitFor(() => {
-      expect(mockSetStyle).toHaveBeenCalled();
-    });
-
-    const styleFunction = mockSetStyle.mock.calls[0][0];
-
-    // Zero access → "Sem acesso" band (background-800 fallback), regardless of value.
-    const noAccessFeature = {
-      getProperty: (prop: string) => {
-        if (prop === 'regionValue') return 0;
-        if (prop === 'regionAccessCount') return 0;
-        return null;
-      },
-    };
-    // Low normalized value but WITH access → stays "Ponto de atenção" (error-700 fallback).
-    const lowWithAccessFeature = {
-      getProperty: (prop: string) => {
-        if (prop === 'regionValue') return 0.1;
-        if (prop === 'regionAccessCount') return 5;
-        return null;
-      },
-    };
-
-    expect(styleFunction(noAccessFeature).fillColor).toBe('#414040');
-    expect(styleFunction(lowWithAccessFeature).fillColor).toBe('#b91c1c');
   });
 });
 

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -55,35 +55,46 @@ const getColorClasses = (): ColorClass[] => [
   {
     min: 0.75,
     max: 1.01,
-    fillColor: getCssVar('--color-map-highlight', '#2c7bb6'),
-    strokeColor: getCssVar('--color-map-highlight', '#2c7bb6'),
+    fillColor: getCssVar('--color-map-highlight', '#66b584'),
+    strokeColor: getCssVar('--color-map-highlight', '#66b584'),
     label: 'Destaque',
   },
   {
     min: 0.5,
     max: 0.75,
-    fillColor: getCssVar('--color-map-above-avg', '#abd9e9'),
-    strokeColor: getCssVar('--color-map-above-avg', '#abd9e9'),
+    fillColor: getCssVar('--color-map-above-avg', '#f8cc2e'),
+    strokeColor: getCssVar('--color-map-above-avg', '#f8cc2e'),
     label: 'Acima da média',
   },
   {
     min: 0.25,
     max: 0.5,
-    fillColor: getCssVar('--color-map-below-avg', '#fdae61'),
-    strokeColor: getCssVar('--color-map-below-avg', '#fdae61'),
+    fillColor: getCssVar('--color-map-below-avg', '#fb954b'),
+    strokeColor: getCssVar('--color-map-below-avg', '#fb954b'),
     label: 'Abaixo da média',
   },
   {
     min: 0,
     max: 0.25,
-    fillColor: getCssVar('--color-map-attention', '#d7191c'),
-    strokeColor: getCssVar('--color-map-attention', '#d7191c'),
+    fillColor: getCssVar('--color-map-attention', '#b91c1c'),
+    strokeColor: getCssVar('--color-map-attention', '#b91c1c'),
     label: 'Ponto de atenção',
+  },
+  {
+    // Selected by a zero access count, not by the value range: min/max are set
+    // so getColorClass() never matches this band.
+    min: 0,
+    max: 0,
+    noAccess: true,
+    fillColor: getCssVar('--color-map-no-access', '#414040'),
+    strokeColor: getCssVar('--color-border-500', '#8c8d8d'),
+    label: 'Sem acesso',
   },
 ];
 
 /**
- * Get color class based on value
+ * Get color class based on the normalized value.
+ * Skips the `noAccess` band, which is keyed by access count (see classifyRegion).
  * @param value - Normalized value between 0 and 1
  * @param colorClasses - Array of color class configurations
  * @returns Color class configuration
@@ -93,11 +104,38 @@ const getColorClass = (
   colorClasses: ColorClass[]
 ): ColorClass => {
   for (const colorClass of colorClasses) {
+    if (colorClass.noAccess) continue;
     if (value >= colorClass.min && value < colorClass.max) {
       return colorClass;
     }
   }
   return colorClasses[0];
+};
+
+/**
+ * Classify a region into a color class.
+ *
+ * A zero `accessCount` maps to the "Sem acesso" band regardless of the
+ * normalized value (min-max normalization gives the lowest region a value of 0
+ * even when it has access, so the band must key off the raw count). Any region
+ * with access falls back to the value-based color scale.
+ *
+ * @param value - Normalized value between 0 and 1
+ * @param accessCount - Raw access count for the region
+ * @param colorClasses - Array of color class configurations
+ * @returns Color class configuration
+ */
+const classifyRegion = (
+  value: number,
+  accessCount: number,
+  colorClasses: ColorClass[]
+): ColorClass => {
+  if (accessCount === 0) {
+    return (
+      colorClasses.find((colorClass) => colorClass.noAccess) ?? colorClasses[0]
+    );
+  }
+  return getColorClass(value, colorClasses);
 };
 
 /**
@@ -166,7 +204,12 @@ const createStyleFunction = (
       };
     }
     const value = feature.getProperty('regionValue') as number;
-    const colorClass = getColorClass(value ?? 0, colorClasses);
+    const accessCount = feature.getProperty('regionAccessCount') as number;
+    const colorClass = classifyRegion(
+      value ?? 0,
+      accessCount ?? 0,
+      colorClasses
+    );
     return {
       fillColor: colorClass.fillColor,
       fillOpacity: opacity,
@@ -252,7 +295,8 @@ const LoadingSkeleton = () => (
  * ChoroplethMap component for displaying regional performance data
  *
  * Displays an interactive Google Map with colored regions based on normalized values.
- * Uses 4 color classes to represent different performance levels.
+ * Uses 5 color classes to represent different performance levels (including a
+ * "Sem acesso" band for zero-access regions).
  * Includes fade-in animation, smooth hover transitions, and zoom-to-region on click.
  * NRE boundaries are rendered as a separate overlay with thicker strokes.
  *
@@ -294,7 +338,7 @@ const ChoroplethMap = ({
     y: number;
   } | null>(null);
   const [activeClasses, setActiveClasses] = useState<Set<number>>(
-    new Set([0, 1, 2, 3])
+    new Set([0, 1, 2, 3, 4])
   );
   const fadeAnimationRef = useRef<number | null>(null);
   const hoverAnimationsRef = useRef<Map<string, number>>(new Map());
@@ -723,7 +767,12 @@ const ChoroplethMap = ({
       }
 
       const value = feature.getProperty('regionValue') as number;
-      const colorClass = getColorClass(value ?? 0, colorClasses);
+      const accessCount = feature.getProperty('regionAccessCount') as number;
+      const colorClass = classifyRegion(
+        value ?? 0,
+        accessCount ?? 0,
+        colorClasses
+      );
       const classIndex = colorClasses.indexOf(colorClass);
 
       if (activeClasses.has(classIndex)) {

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -80,21 +80,10 @@ const getColorClasses = (): ColorClass[] => [
     strokeColor: getCssVar('--color-map-attention', '#b91c1c'),
     label: 'Ponto de atenção',
   },
-  {
-    // Selected by a zero access count, not by the value range: min/max are set
-    // so getColorClass() never matches this band.
-    min: 0,
-    max: 0,
-    noAccess: true,
-    fillColor: getCssVar('--color-map-no-access', '#414040'),
-    strokeColor: getCssVar('--color-border-500', '#8c8d8d'),
-    label: 'Sem acesso',
-  },
 ];
 
 /**
- * Get color class based on the normalized value.
- * Skips the `noAccess` band, which is keyed by access count (see classifyRegion).
+ * Get color class based on value
  * @param value - Normalized value between 0 and 1
  * @param colorClasses - Array of color class configurations
  * @returns Color class configuration
@@ -104,38 +93,11 @@ const getColorClass = (
   colorClasses: ColorClass[]
 ): ColorClass => {
   for (const colorClass of colorClasses) {
-    if (colorClass.noAccess) continue;
     if (value >= colorClass.min && value < colorClass.max) {
       return colorClass;
     }
   }
   return colorClasses[0];
-};
-
-/**
- * Classify a region into a color class.
- *
- * A zero `accessCount` maps to the "Sem acesso" band regardless of the
- * normalized value (min-max normalization gives the lowest region a value of 0
- * even when it has access, so the band must key off the raw count). Any region
- * with access falls back to the value-based color scale.
- *
- * @param value - Normalized value between 0 and 1
- * @param accessCount - Raw access count for the region
- * @param colorClasses - Array of color class configurations
- * @returns Color class configuration
- */
-const classifyRegion = (
-  value: number,
-  accessCount: number,
-  colorClasses: ColorClass[]
-): ColorClass => {
-  if (accessCount === 0) {
-    return (
-      colorClasses.find((colorClass) => colorClass.noAccess) ?? colorClasses[0]
-    );
-  }
-  return getColorClass(value, colorClasses);
 };
 
 /**
@@ -204,12 +166,7 @@ const createStyleFunction = (
       };
     }
     const value = feature.getProperty('regionValue') as number;
-    const accessCount = feature.getProperty('regionAccessCount') as number;
-    const colorClass = classifyRegion(
-      value ?? 0,
-      accessCount ?? 0,
-      colorClasses
-    );
+    const colorClass = getColorClass(value ?? 0, colorClasses);
     return {
       fillColor: colorClass.fillColor,
       fillOpacity: opacity,
@@ -295,8 +252,7 @@ const LoadingSkeleton = () => (
  * ChoroplethMap component for displaying regional performance data
  *
  * Displays an interactive Google Map with colored regions based on normalized values.
- * Uses 5 color classes to represent different performance levels (including a
- * "Sem acesso" band for zero-access regions).
+ * Uses 4 color classes to represent different performance levels.
  * Includes fade-in animation, smooth hover transitions, and zoom-to-region on click.
  * NRE boundaries are rendered as a separate overlay with thicker strokes.
  *
@@ -338,7 +294,7 @@ const ChoroplethMap = ({
     y: number;
   } | null>(null);
   const [activeClasses, setActiveClasses] = useState<Set<number>>(
-    new Set([0, 1, 2, 3, 4])
+    new Set([0, 1, 2, 3])
   );
   const fadeAnimationRef = useRef<number | null>(null);
   const hoverAnimationsRef = useRef<Map<string, number>>(new Map());
@@ -767,12 +723,7 @@ const ChoroplethMap = ({
       }
 
       const value = feature.getProperty('regionValue') as number;
-      const accessCount = feature.getProperty('regionAccessCount') as number;
-      const colorClass = classifyRegion(
-        value ?? 0,
-        accessCount ?? 0,
-        colorClasses
-      );
+      const colorClass = getColorClass(value ?? 0, colorClasses);
       const classIndex = colorClasses.indexOf(colorClass);
 
       if (activeClasses.has(classIndex)) {

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -82,10 +82,4 @@ export interface ColorClass {
   strokeColor: string;
   /** Label for the legend */
   label: string;
-  /**
-   * When true, this class is selected by a zero access count instead of by the
-   * normalized `value` range (used for the "Sem acesso" band). Its `min`/`max`
-   * are set so the value-range matcher never picks it.
-   */
-  noAccess?: boolean;
 }

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -82,4 +82,10 @@ export interface ColorClass {
   strokeColor: string;
   /** Label for the legend */
   label: string;
+  /**
+   * When true, this class is selected by a zero access count instead of by the
+   * normalized `value` range (used for the "Sem acesso" band). Its `min`/`max`
+   * are set so the value-range matcher never picks it.
+   */
+  noAccess?: boolean;
 }

--- a/src/themes/analytica/dark.css
+++ b/src/themes/analytica/dark.css
@@ -194,7 +194,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/analytica/dark.css
+++ b/src/themes/analytica/dark.css
@@ -190,10 +190,11 @@
     --color-question-type-matching: #C084FC;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/analytica/light.css
+++ b/src/themes/analytica/light.css
@@ -192,7 +192,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/analytica/light.css
+++ b/src/themes/analytica/light.css
@@ -188,10 +188,11 @@
     --color-question-type-matching: #6a4ac2;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/base/dark.css
+++ b/src/themes/base/dark.css
@@ -189,10 +189,11 @@
     --color-question-type-matching: #C084FC;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/base/dark.css
+++ b/src/themes/base/dark.css
@@ -193,7 +193,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/paraiba/dark.css
+++ b/src/themes/paraiba/dark.css
@@ -189,10 +189,11 @@
     --color-question-type-matching: #C084FC;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/paraiba/dark.css
+++ b/src/themes/paraiba/dark.css
@@ -193,7 +193,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/paraiba/light.css
+++ b/src/themes/paraiba/light.css
@@ -183,10 +183,11 @@
     --color-question-type-matching: #660CB0;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/paraiba/light.css
+++ b/src/themes/paraiba/light.css
@@ -187,7 +187,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/parana/dark.css
+++ b/src/themes/parana/dark.css
@@ -189,10 +189,11 @@
     --color-question-type-matching: #C084FC;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/parana/dark.css
+++ b/src/themes/parana/dark.css
@@ -193,7 +193,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/parana/light.css
+++ b/src/themes/parana/light.css
@@ -183,10 +183,11 @@
     --color-question-type-matching: #660CB0;
 
     /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-    --color-map-highlight: #2c7bb6;
-    --color-map-above-avg: #abd9e9;
-    --color-map-below-avg: #fdae61;
-    --color-map-attention: #d7191c;
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/parana/light.css
+++ b/src/themes/parana/light.css
@@ -187,7 +187,6 @@
     --color-map-above-avg: #f8cc2e;
     --color-map-below-avg: #fb954b;
     --color-map-attention: #b91c1c;
-    --color-map-no-access: #414040;
     --color-map-stroke-city: #ffffff;
     --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -187,13 +187,11 @@
   --color-question-type-image: #715904;
   --color-question-type-matching: #660CB0;
 
-  /* Map Choropleth Colors — semantic scale: highlight/green (best) → attention/red (worst),
-     plus no-access/dark for zero-access regions */
+  /* Map Choropleth Colors — semantic scale: highlight/green (best) → attention/red (worst) */
   --color-map-highlight: #66b584; /* success-300 — Destaque */
   --color-map-above-avg: #f8cc2e; /* indicator-positive — Acima da média */
   --color-map-below-avg: #fb954b; /* warning-400 — Abaixo da média */
   --color-map-attention: #b91c1c; /* error-700 — Ponto de atenção */
-  --color-map-no-access: #414040; /* background-800 — Sem acesso */
   --color-map-stroke-city: #ffffff;
   --color-map-stroke-nre: #ffffff;
 

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -187,11 +187,13 @@
   --color-question-type-image: #715904;
   --color-question-type-matching: #660CB0;
 
-  /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
-  --color-map-highlight: #2c7bb6;
-  --color-map-above-avg: #abd9e9;
-  --color-map-below-avg: #fdae61;
-  --color-map-attention: #d7191c;
+  /* Map Choropleth Colors — semantic scale: highlight/green (best) → attention/red (worst),
+     plus no-access/dark for zero-access regions */
+  --color-map-highlight: #66b584; /* success-300 — Destaque */
+  --color-map-above-avg: #f8cc2e; /* indicator-positive — Acima da média */
+  --color-map-below-avg: #fb954b; /* warning-400 — Abaixo da média */
+  --color-map-attention: #b91c1c; /* error-700 — Ponto de atenção */
+  --color-map-no-access: #414040; /* background-800 — Sem acesso */
   --color-map-stroke-city: #ffffff;
   --color-map-stroke-nre: #ffffff;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Sem acesso” map legend category for regions with no access.
  * Regions with zero access now use a dedicated color band, separate from other low-value areas.

* **Bug Fixes**
  * Improved choropleth coloring and filtering so map regions are classified more accurately.
  * Updated map colors across themes for clearer visual distinction, including a new no-access color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->