### PR TITLE
Refactor/relatorios labels videoaulas

### DIFF
--- a/src/components/AccessReportModal/AccessReportModal.test.tsx
+++ b/src/components/AccessReportModal/AccessReportModal.test.tsx
@@ -190,7 +190,9 @@ describe('AccessReportModal', () => {
       );
       expect(screen.getByText('Dados de horas por item')).toBeInTheDocument();
       expect(screen.getAllByText('Atividades').length).toBeGreaterThan(0);
-      expect(screen.getByText('Questionários das Videoaulas')).toBeInTheDocument();
+      expect(
+        screen.getByText('Questionários das Videoaulas')
+      ).toBeInTheDocument();
     });
 
     it('should render SVG pie charts', () => {

--- a/src/components/AccessReportModal/AccessReportModal.test.tsx
+++ b/src/components/AccessReportModal/AccessReportModal.test.tsx
@@ -125,7 +125,7 @@ describe('AccessReportModal', () => {
         />
       );
       expect(screen.getByText('Tempo total')).toBeInTheDocument();
-      expect(screen.getAllByText('Conteúdo').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Videoaulas').length).toBeGreaterThan(0);
       expect(screen.getByText('Aulas recomendadas')).toBeInTheDocument();
       expect(screen.getAllByText('Simulados').length).toBeGreaterThan(0);
       expect(screen.getByText('Quantidade de acessos')).toBeInTheDocument();
@@ -190,7 +190,7 @@ describe('AccessReportModal', () => {
       );
       expect(screen.getByText('Dados de horas por item')).toBeInTheDocument();
       expect(screen.getAllByText('Atividades').length).toBeGreaterThan(0);
-      expect(screen.getByText('Questionários')).toBeInTheDocument();
+      expect(screen.getByText('Questionários das Videoaulas')).toBeInTheDocument();
     });
 
     it('should render SVG pie charts', () => {

--- a/src/components/AccessReportModal/AccessReportModal.tsx
+++ b/src/components/AccessReportModal/AccessReportModal.tsx
@@ -151,7 +151,7 @@ function buildStudentHoursSlices(
       color: 'var(--Success-success700, #206F3E)',
     },
     {
-      label: 'Conteúdo',
+      label: 'Videoaulas',
       value: hoursByItem.content.percentage,
       colorClass: 'bg-success-300',
       color: 'var(--Success-success300, #66B584)',
@@ -163,7 +163,7 @@ function buildStudentHoursSlices(
       color: 'var(--Warning-warning300, #FDAD74)',
     },
     {
-      label: 'Questionários',
+      label: 'Questionários das Videoaulas',
       value: hoursByItem.questionnaires.percentage,
       colorClass: 'bg-indicator-positive',
       color: 'var(--Indicator-Indicator-Positive, #F8CC2E)',
@@ -235,7 +235,7 @@ const StudentModalContent = ({
     metricBoxes={
       <>
         <MetricBox label="Tempo total" value={data.accessData.totalTime} />
-        <MetricBox label="Conteúdo" value={data.accessData.contentTime} />
+        <MetricBox label="Videoaulas" value={data.accessData.contentTime} />
         <MetricBox
           label="Aulas recomendadas"
           value={data.accessData.recommendedLessonsTime}

--- a/src/components/TimeChart/TimeChart.test.tsx
+++ b/src/components/TimeChart/TimeChart.test.tsx
@@ -121,9 +121,9 @@ describe('TimeChart', () => {
     it('renders correct number of legend items for student profile', () => {
       render(<TimeChart data={studentData} />);
       expect(screen.getAllByText('Atividades')).toHaveLength(2);
-      expect(screen.getAllByText('Conteúdo')).toHaveLength(2);
+      expect(screen.getAllByText('Videoaulas')).toHaveLength(2);
       expect(screen.getAllByText('Simulados')).toHaveLength(2);
-      expect(screen.getAllByText('Questionários')).toHaveLength(2);
+      expect(screen.getAllByText('Questionários das Videoaulas')).toHaveLength(2);
     });
 
     it('renders correct number of legend items for teacher profile', () => {

--- a/src/components/TimeChart/TimeChart.test.tsx
+++ b/src/components/TimeChart/TimeChart.test.tsx
@@ -123,7 +123,9 @@ describe('TimeChart', () => {
       expect(screen.getAllByText('Atividades')).toHaveLength(2);
       expect(screen.getAllByText('Videoaulas')).toHaveLength(2);
       expect(screen.getAllByText('Simulados')).toHaveLength(2);
-      expect(screen.getAllByText('Questionários das Videoaulas')).toHaveLength(2);
+      expect(screen.getAllByText('Questionários das Videoaulas')).toHaveLength(
+        2
+      );
     });
 
     it('renders correct number of legend items for teacher profile', () => {

--- a/src/components/TimeChart/TimeChart.tsx
+++ b/src/components/TimeChart/TimeChart.tsx
@@ -90,7 +90,7 @@ export const STUDENT_CATEGORIES: TimeChartCategory[] = [
   },
   {
     key: TIME_CHART_CATEGORY_KEY.CONTENT,
-    label: 'Conteúdo',
+    label: 'Videoaulas',
     colorClass: 'bg-success-300',
   },
   {
@@ -100,7 +100,7 @@ export const STUDENT_CATEGORIES: TimeChartCategory[] = [
   },
   {
     key: TIME_CHART_CATEGORY_KEY.QUESTIONNAIRES,
-    label: 'Questionários',
+    label: 'Questionários das Videoaulas',
     colorClass: 'bg-indicator-positive',
   },
 ];

--- a/src/components/TimeReport/TimeReport.stories.tsx
+++ b/src/components/TimeReport/TimeReport.stories.tsx
@@ -71,7 +71,7 @@ const studentCardsFromApi = (data: TimeReportData): TimeCardData[] => {
     cards.push(
       metricToCard(
         'content',
-        'TEMPO EM CONTEÚDO',
+        'TEMPO EM VIDEOAULAS',
         <ChalkboardTeacherIcon />,
         data.content_time
       )
@@ -243,7 +243,7 @@ export const IndividualCards: Story = () => (
       <TimeCard
         data={metricToCard(
           'down',
-          'TEMPO EM CONTEÚDO',
+          'TEMPO EM VIDEOAULAS',
           <ChalkboardTeacherIcon />,
           { hours: 25.8, variation_percent: -5.2 }
         )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed several student-facing time breakdown labels from “Conteúdo” to “Videoaulas”.
  * Updated “Questionários” to “Questionários das Videoaulas” in the relevant charts and reports.
  * Aligned the displayed metric label in the time report examples to “TEMPO EM VIDEOAULAS”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->