### PR TITLE
feat(recipient): carregar turmas dinamicamente por escola/série (gest…

### DIFF
--- a/src/components/ActivityCreate/ActivityCreate.stories.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.stories.tsx
@@ -15,8 +15,22 @@ const createMockApiClient = (
   questionTypes: string[],
   onSaveActivity?: (method: string, url: string, payload: unknown) => void
 ) => {
+  // Turmas (classes) available in this mock, keyed for filtering by série.
+  const allClasses = [
+    {
+      id: 'class-1',
+      name: 'A',
+      shift: 'Manhã',
+      institutionId: 'institution-1',
+      schoolId: 'school-1',
+      schoolYearId: 'year-1',
+      createdAt: '2025-12-12T19:16:28.544Z',
+      updatedAt: '2025-12-12T19:16:28.544Z',
+    },
+  ];
+
   return {
-    get: async (url: string) => {
+    get: async (url: string, config?: { params?: Record<string, unknown> }) => {
       if (url === '/questions/exam-institutions') {
         return {
           data: {
@@ -138,28 +152,28 @@ const createMockApiClient = (
         };
       }
 
-      // Mock classes endpoint
+      // Mock classes endpoint: turmas load dynamically, filtered by the
+      // comma-joined `schoolYearId` (and optional `schoolId`) query params.
       if (url === '/classes') {
+        const schoolYearIdParam = config?.params?.schoolYearId;
+        const schoolYearIds =
+          typeof schoolYearIdParam === 'string'
+            ? schoolYearIdParam.split(',')
+            : [];
+        const classes =
+          schoolYearIds.length > 0
+            ? allClasses.filter((c) => schoolYearIds.includes(c.schoolYearId))
+            : allClasses;
+
         return {
           data: {
             message: 'Classes obtidas com sucesso',
             data: {
-              classes: [
-                {
-                  id: 'class-1',
-                  name: 'A',
-                  shift: 'Manhã',
-                  institutionId: 'institution-1',
-                  schoolId: 'school-1',
-                  schoolYearId: 'year-1',
-                  createdAt: '2025-12-12T19:16:28.544Z',
-                  updatedAt: '2025-12-12T19:16:28.544Z',
-                },
-              ],
+              classes,
               pagination: {
                 page: 1,
-                limit: 10,
-                total: 1,
+                limit: 100,
+                total: classes.length,
                 totalPages: 1,
               },
             },

--- a/src/components/ActivityCreate/ActivityCreate.test.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.test.tsx
@@ -1993,9 +1993,15 @@ describe('CreateActivity', () => {
       fireEvent.click(screen.getByText('Enviar atividade'));
 
       await waitFor(() => {
-        expect(mockApiClient.get).toHaveBeenCalledWith('/school');
-        expect(mockApiClient.get).toHaveBeenCalledWith('/schoolYear');
-        expect(mockApiClient.get).toHaveBeenCalledWith('/classes');
+        // /school and /schoolYear are paginated with params; /classes is no
+        // longer eager-fetched (turmas load dynamically once a série is chosen).
+        expect(mockApiClient.get).toHaveBeenCalledWith('/school', {
+          params: { page: 1, limit: 100 },
+        });
+        expect(mockApiClient.get).toHaveBeenCalledWith('/schoolYear', {
+          params: { page: 1, limit: 100 },
+        });
+        expect(mockApiClient.get).not.toHaveBeenCalledWith('/classes');
       });
     });
 
@@ -2065,8 +2071,9 @@ describe('CreateActivity', () => {
       fireEvent.click(screen.getByText('Enviar atividade'));
 
       await waitFor(() => {
-        // Now only 3 calls: /school, /schoolYear, /classes (students are loaded dynamically)
-        expect(mockApiClient.get).toHaveBeenCalledTimes(3);
+        // Now only 2 calls: /school + /schoolYear (turmas and students load
+        // dynamically, so /classes is no longer eager-fetched here).
+        expect(mockApiClient.get).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/src/components/ActivityCreate/ActivityCreate.utils.test.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.test.ts
@@ -734,17 +734,14 @@ describe('ActivityCreate.utils', () => {
         ],
         selectedIds: [],
       });
+      // Turmas load dynamically once a série is selected; loadCategoriesData
+      // no longer eager-fetches /classes, so turma starts with empty items.
       expect(result[2]).toMatchObject({
         key: 'turma',
         label: 'Turma',
         dependsOn: ['serie'],
-        itens: [
-          {
-            id: 'class1',
-            name: 'Turma A',
-            schoolYearId: 'year1',
-          },
-        ],
+        filteredBy: [{ key: 'serie', internalField: 'schoolYearId' }],
+        itens: [],
         selectedIds: [],
       });
       expect(result[3]).toMatchObject({

--- a/src/components/RecommendedLessonCreate/RecommendedLessonCreate.stories.tsx
+++ b/src/components/RecommendedLessonCreate/RecommendedLessonCreate.stories.tsx
@@ -115,8 +115,15 @@ const hasAllFiltersApplied = (filters?: {
 const createMockApiClient = (
   onSave?: (method: string, url: string, payload: unknown) => void
 ) => {
+  // Turmas (classes) available in this mock, filtered dynamically by série.
+  const allClasses = [
+    { id: 'class-1', name: 'Turma A', schoolYearId: 'year-1' },
+    { id: 'class-2', name: 'Turma B', schoolYearId: 'year-1' },
+    { id: 'class-3', name: 'Turma A', schoolYearId: 'year-2' },
+  ];
+
   return {
-    get: async (url: string) => {
+    get: async (url: string, config?: { params?: Record<string, unknown> }) => {
       // Mock subjects endpoint
       if (url === '/subjects') {
         return {
@@ -184,6 +191,7 @@ const createMockApiClient = (
                   companyName: 'Colégio Estadual São Paulo',
                 },
               ],
+              pagination: { page: 1, limit: 100, totalPages: 1 },
             },
           },
         };
@@ -212,34 +220,31 @@ const createMockApiClient = (
                   schoolId: 'school-2',
                 },
               ],
+              pagination: { page: 1, limit: 100, totalPages: 1 },
             },
           },
         };
       }
 
-      // Mock classes endpoint
+      // Mock classes endpoint: turmas load dynamically, filtered by the
+      // comma-joined `schoolYearId` (and optional `schoolId`) query params.
       if (url === '/classes') {
+        const schoolYearIdParam = config?.params?.schoolYearId;
+        const schoolYearIds =
+          typeof schoolYearIdParam === 'string'
+            ? schoolYearIdParam.split(',')
+            : [];
+        const classes =
+          schoolYearIds.length > 0
+            ? allClasses.filter((c) => schoolYearIds.includes(c.schoolYearId))
+            : allClasses;
+
         return {
           data: {
             message: 'Classes fetched successfully',
             data: {
-              classes: [
-                {
-                  id: 'class-1',
-                  name: 'Turma A',
-                  schoolYearId: 'year-1',
-                },
-                {
-                  id: 'class-2',
-                  name: 'Turma B',
-                  schoolYearId: 'year-1',
-                },
-                {
-                  id: 'class-3',
-                  name: 'Turma A',
-                  schoolYearId: 'year-2',
-                },
-              ],
+              classes,
+              pagination: { page: 1, limit: 100, totalPages: 1 },
             },
           },
         };

--- a/src/components/RecommendedLessonsHistory/RecommendedLessonsHistory.test.tsx
+++ b/src/components/RecommendedLessonsHistory/RecommendedLessonsHistory.test.tsx
@@ -1488,6 +1488,109 @@ describe('RecommendedLessonsHistory', () => {
     });
   });
 
+  describe('Actions Column ownership gating (currentUserId)', () => {
+    // The default mocked row is created by this user id (creator.id).
+    const OWNER_ID = '123e4567-e89b-12d3-a456-426614174002';
+    const OTHER_ID = '00000000-0000-0000-0000-000000000999';
+
+    const responseWithCreator = (
+      creator: { id: string; name: string } | null
+    ): RecommendedClassHistoryApiResponse => ({
+      message: 'Success',
+      data: {
+        recommendedClass: [
+          {
+            recommendedClass: {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              title: 'Aula de Matemática',
+              startDate: '2024-06-01',
+              finalDate: '2024-12-31',
+              createdAt: '2024-06-01T10:00:00Z',
+              progress: 50,
+              totalLessons: 10,
+            },
+            subject: {
+              id: '123e4567-e89b-12d3-a456-426614174001',
+              name: 'Matemática',
+            },
+            creator,
+            stats: {
+              totalStudents: 30,
+              completedCount: 15,
+              completionPercentage: 50,
+            },
+            breakdown: [
+              {
+                classId: '123e4567-e89b-12d3-a456-426614174003',
+                className: 'Turma A',
+                schoolId: 'school-1',
+                schoolName: 'Escola Exemplo',
+                studentCount: 30,
+                completedCount: 15,
+              },
+            ],
+          },
+        ],
+        total: 1,
+      },
+    });
+
+    it('should show edit/delete actions when currentUserId matches the row creator', async () => {
+      render(
+        <RecommendedLessonsHistory {...defaultProps} currentUserId={OWNER_ID} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('table')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTitle('Excluir')).toBeInTheDocument();
+      expect(screen.getByTitle('Editar')).toBeInTheDocument();
+    });
+
+    it('should hide edit/delete actions when currentUserId does not match the row creator', async () => {
+      render(
+        <RecommendedLessonsHistory {...defaultProps} currentUserId={OTHER_ID} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('table')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTitle('Excluir')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Editar')).not.toBeInTheDocument();
+    });
+
+    it('should hide edit/delete actions when the row has no creator (creatorId null)', async () => {
+      mockFetchRecommendedClassHistory.mockResolvedValue(
+        responseWithCreator(null)
+      );
+
+      render(
+        <RecommendedLessonsHistory {...defaultProps} currentUserId={OWNER_ID} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('table')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTitle('Excluir')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Editar')).not.toBeInTheDocument();
+    });
+
+    it('should show actions for every row when currentUserId is not provided', async () => {
+      // No currentUserId → opt-in gate disabled, behavior unchanged.
+      render(<RecommendedLessonsHistory {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('table')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTitle('Excluir')).toBeInTheDocument();
+      expect(screen.getByTitle('Editar')).toBeInTheDocument();
+    });
+  });
+
   describe('Row Click', () => {
     it('should call onRowClick when row is clicked', async () => {
       render(<RecommendedLessonsHistory {...defaultProps} />);

--- a/src/components/RecommendedLessonsHistory/RecommendedLessonsHistory.tsx
+++ b/src/components/RecommendedLessonsHistory/RecommendedLessonsHistory.tsx
@@ -131,6 +131,14 @@ export interface RecommendedLessonsHistoryProps {
    * Merged with default filters when provided.
    */
   extraFilterCategories?: FilterConfig[];
+  /**
+   * Id of the current user. When provided, the edit/delete actions are shown
+   * only for rows the current user created (i.e. rows whose `creatorId`
+   * matches this id). When undefined, the actions behave as before and are
+   * shown for every row (subject to the delete/edit capabilities), keeping
+   * other consumers of this shared component unaffected.
+   */
+  currentUserId?: string;
 }
 
 /**
@@ -311,7 +319,8 @@ const createRecommendedClassFiltersConfig = (
 const createTableColumns = (
   mapSubjectNameToEnum: ((name: string) => SubjectEnum | null) | undefined,
   onDelete: ((row: RecommendedClassTableItem) => void) | undefined,
-  onEdit: ((row: RecommendedClassTableItem) => void) | undefined
+  onEdit: ((row: RecommendedClassTableItem) => void) | undefined,
+  currentUserId?: string
 ): ColumnConfig<RecommendedClassTableItem>[] => [
   {
     key: 'startDate',
@@ -434,6 +443,13 @@ const createTableColumns = (
         return null;
       }
 
+      // Opt-in ownership gate: when a current user id is provided, only the
+      // row's creator may see the edit/delete actions. Rows created by others
+      // (or with an unknown creator) hide the actions.
+      if (currentUserId && row.creatorId !== currentUserId) {
+        return null;
+      }
+
       const handleDelete = (e: MouseEvent) => {
         e.stopPropagation();
         onDelete?.(row);
@@ -512,6 +528,7 @@ export const RecommendedLessonsHistory = ({
   defaultTab,
   onTabChange,
   extraFilterCategories,
+  currentUserId,
 }: RecommendedLessonsHistoryProps) => {
   const [activeTab, setActiveTab] = useState<RecommendedClassPageTab>(
     defaultTab ?? RecommendedClassPageTab.HISTORY
@@ -656,7 +673,8 @@ export const RecommendedLessonsHistory = ({
       createTableColumns(
         mapSubjectNameToEnum,
         deleteEnabled ? handleOpenDelete : undefined,
-        editEnabled ? handleOpenEdit : undefined
+        editEnabled ? handleOpenEdit : undefined,
+        currentUserId
       ),
     [
       mapSubjectNameToEnum,
@@ -664,6 +682,7 @@ export const RecommendedLessonsHistory = ({
       editEnabled,
       handleOpenDelete,
       handleOpenEdit,
+      currentUserId,
     ]
   );
 

--- a/src/components/shared/SendModalBase/hooks/useCategorySync.test.ts
+++ b/src/components/shared/SendModalBase/hooks/useCategorySync.test.ts
@@ -1,0 +1,126 @@
+import { RefObject } from 'react';
+import { renderHook } from '@testing-library/react';
+import { useCategorySync } from './useCategorySync';
+import type { CategoryConfig } from '../../../CheckBoxGroup/CheckBoxGroup';
+
+const makeRef = (value: boolean): RefObject<boolean> =>
+  ({ current: value }) as RefObject<boolean>;
+
+const category = (key: string, ids: string[] = []): CategoryConfig =>
+  ({
+    key,
+    label: key,
+    itens: ids.map((id) => ({ id, name: id })),
+  }) as CategoryConfig;
+
+type Params = Parameters<typeof useCategorySync>[0];
+
+const renderSync = (overrides: Partial<Params> = {}) => {
+  const setCategories = jest.fn();
+  const props: Params = {
+    isOpen: true,
+    initialCategories: [category('turma')],
+    storeCategories: [category('turma')],
+    setCategories,
+    categoriesInitializedRef: makeRef(true),
+    ...overrides,
+  };
+  renderHook(() => useCategorySync(props));
+  return { setCategories };
+};
+
+describe('useCategorySync', () => {
+  it('syncs when parent gains turma itens the store does not have', () => {
+    const { setCategories } = renderSync({
+      initialCategories: [category('turma', ['t1', 't2'])],
+      storeCategories: [category('turma')],
+    });
+
+    const initialCategories = [category('turma', ['t1', 't2'])];
+    expect(setCategories).toHaveBeenCalledTimes(1);
+    expect(setCategories.mock.calls[0][0]).toEqual(initialCategories);
+  });
+
+  it('syncs when parent gains students itens the store does not have', () => {
+    const initialCategories = [category('students', ['a1', 'a2'])];
+    const { setCategories } = renderSync({
+      initialCategories,
+      storeCategories: [category('students')],
+    });
+
+    expect(setCategories).toHaveBeenCalledTimes(1);
+    expect(setCategories).toHaveBeenCalledWith(initialCategories);
+  });
+
+  it('syncs on same-length-different-content turma change (id signature)', () => {
+    const initialCategories = [category('turma', ['c', 'd'])];
+    const { setCategories } = renderSync({
+      initialCategories,
+      storeCategories: [category('turma', ['a', 'b'])],
+    });
+
+    expect(setCategories).toHaveBeenCalledTimes(1);
+    expect(setCategories).toHaveBeenCalledWith(initialCategories);
+  });
+
+  it('does not sync when turma and students signatures already match', () => {
+    const { setCategories } = renderSync({
+      initialCategories: [
+        category('turma', ['t1', 't2']),
+        category('students', ['a1']),
+      ],
+      storeCategories: [
+        category('turma', ['t1', 't2']),
+        category('students', ['a1']),
+      ],
+    });
+
+    expect(setCategories).not.toHaveBeenCalled();
+  });
+
+  it('syncs on turma change even when students are already populated (students segment must not mask turma change)', () => {
+    const initialCategories = [
+      category('turma', ['c', 'd']),
+      category('students', ['s1']),
+    ];
+    const { setCategories } = renderSync({
+      initialCategories,
+      storeCategories: [
+        category('turma', ['a', 'b']),
+        category('students', ['s1']),
+      ],
+    });
+
+    expect(setCategories).toHaveBeenCalledTimes(1);
+    expect(setCategories).toHaveBeenCalledWith(initialCategories);
+  });
+
+  it('does not sync when isOpen is false', () => {
+    const { setCategories } = renderSync({
+      isOpen: false,
+      initialCategories: [category('turma', ['t1'])],
+      storeCategories: [category('turma')],
+    });
+
+    expect(setCategories).not.toHaveBeenCalled();
+  });
+
+  it('does not sync when categories are not initialized', () => {
+    const { setCategories } = renderSync({
+      categoriesInitializedRef: makeRef(false),
+      initialCategories: [category('turma', ['t1'])],
+      storeCategories: [category('turma')],
+    });
+
+    expect(setCategories).not.toHaveBeenCalled();
+  });
+
+  it('does not sync when initialCategories is empty', () => {
+    const { setCategories } = renderSync({
+      initialCategories: [],
+      storeCategories: [category('turma', ['t1'])],
+    });
+
+    expect(setCategories).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/shared/SendModalBase/hooks/useCategorySync.ts
+++ b/src/components/shared/SendModalBase/hooks/useCategorySync.ts
@@ -9,9 +9,23 @@ export interface UseCategorySyncProps {
   categoriesInitializedRef: RefObject<boolean>;
 }
 
+/** Categories whose itens are loaded dynamically (async) by the parent. */
+const DYNAMIC_KEYS = ['turma', 'students'] as const;
+
+/** Signature of the dynamically-loaded categories' item ids, to detect changes
+ *  the store hasn't picked up yet (robust to same-length, different-content). */
+function dynamicItemsSignature(categories: CategoryConfig[]): string {
+  return DYNAMIC_KEYS.map((key) => {
+    const category = categories.find((c) => c.key === key);
+    const ids = (category?.itens ?? []).map((item) => item.id).join(',');
+    return `${key}:${ids}`;
+  }).join('|');
+}
+
 /**
- * Hook to sync categories from parent when they change (e.g., after fetching students)
- * This ensures the store is updated when parent updates categories
+ * Hook to sync categories from parent when they change (e.g., after fetching
+ * turmas or alunos). This ensures the store is updated when the parent updates
+ * the dynamically-loaded categories.
  */
 export function useCategorySync({
   isOpen,
@@ -26,22 +40,12 @@ export function useCategorySync({
       initialCategories.length > 0 &&
       categoriesInitializedRef.current
     ) {
-      // Only sync if categories have students (indicates they were fetched)
-      const studentsCategory = initialCategories.find(
-        (c) => c.key === 'students'
-      );
-      const storeStudentsCategory = storeCategories.find(
-        (c) => c.key === 'students'
-      );
-
-      // If parent has students but store doesn't, or vice versa, sync
-      const parentHasStudents =
-        studentsCategory?.itens && studentsCategory.itens.length > 0;
-      const storeHasStudents =
-        storeStudentsCategory?.itens && storeStudentsCategory.itens.length > 0;
-
-      if (parentHasStudents !== storeHasStudents || parentHasStudents) {
-        // Update store with parent categories to sync students
+      // Sync only when the dynamic categories (turma/students) actually differ
+      // from the store, comparing item ids so same-length content changes count.
+      if (
+        dynamicItemsSignature(initialCategories) !==
+        dynamicItemsSignature(storeCategories)
+      ) {
         setCategories(initialCategories);
       }
     }

--- a/src/hooks/useRecommendedLessons.test.ts
+++ b/src/hooks/useRecommendedLessons.test.ts
@@ -108,6 +108,26 @@ describe('useRecommendedLessons', () => {
       expect(result.class).toBe('Turma A');
       expect(result.completionPercentage).toBe(50);
       expect(result.status).toBe(RecommendedClassDisplayStatus.ATIVA);
+      expect(result.creator).toBe('Professor João');
+      expect(result.creatorId).toBe('creator-1');
+    });
+
+    it('should populate creatorId from the creator id', () => {
+      const result = transformRecommendedClassToTableItem(
+        baseRecommendedClassHistoryItem
+      );
+      expect(result.creatorId).toBe('creator-1');
+    });
+
+    it('should set creatorId to null when creator is null', () => {
+      const item: RecommendedClassHistoryItem = {
+        ...baseRecommendedClassHistoryItem,
+        creator: null,
+      };
+
+      const result = transformRecommendedClassToTableItem(item);
+      expect(result.creatorId).toBeNull();
+      expect(result.creator).toBe('-');
     });
 
     it('should handle null startDate', () => {

--- a/src/hooks/useRecommendedLessons.ts
+++ b/src/hooks/useRecommendedLessons.ts
@@ -142,6 +142,7 @@ export const transformRecommendedClassToTableItem = (
     school: schoolName,
     year: '-', // API doesn't provide year directly
     creator: item.creator?.name || '-',
+    creatorId: item.creator?.id ?? null,
     subject: item.subject?.name || '-',
     class: classDisplay,
     status: determineRecommendedClassStatus(

--- a/src/hooks/useRecommendedLessonsPage.test.ts
+++ b/src/hooks/useRecommendedLessonsPage.test.ts
@@ -600,6 +600,7 @@ describe('useRecommendedLessonsPage', () => {
       startDate: '01/06',
       deadline: '15/06',
       creator: 'Prof. Test',
+      creatorId: '123e4567-e89b-12d3-a456-426614174002',
       title: 'Test RecommendedClass',
       school: 'School One',
       year: '-',

--- a/src/hooks/useSendActivity.test.ts
+++ b/src/hooks/useSendActivity.test.ts
@@ -211,10 +211,19 @@ describe('useSendActivity', () => {
         expect(result.current.isCategoriesLoading).toBe(false);
       });
 
-      expect(config.api.get).toHaveBeenCalledWith('/school');
-      expect(config.api.get).toHaveBeenCalledWith('/schoolYear');
-      expect(config.api.get).toHaveBeenCalledWith('/classes');
+      // /school and /schoolYear are paginated with params; /classes is no longer
+      // eager-fetched (turmas load dynamically once a série is selected).
+      expect(config.api.get).toHaveBeenCalledWith('/school', {
+        params: { page: 1, limit: 100 },
+      });
+      expect(config.api.get).toHaveBeenCalledWith('/schoolYear', {
+        params: { page: 1, limit: 100 },
+      });
+      expect(config.api.get).not.toHaveBeenCalledWith('/classes');
       expect(result.current.categories).toHaveLength(4);
+      // turma category exists but its items load dynamically (starts empty)
+      expect(result.current.categories[2].key).toBe('turma');
+      expect(result.current.categories[2].itens).toEqual([]);
     });
 
     it('should transform categories to CategoryConfig format', async () => {

--- a/src/types/recommendedLessons.ts
+++ b/src/types/recommendedLessons.ts
@@ -108,6 +108,8 @@ export interface RecommendedClassTableItem extends Record<string, unknown> {
   startDate: string | null;
   deadline: string | null;
   creator: string;
+  /** Id of the user who created the recommended class, or null when unknown. */
+  creatorId: string | null;
   title: string;
   school: string;
   year: string;

--- a/src/utils/categoryDataUtils.test.ts
+++ b/src/utils/categoryDataUtils.test.ts
@@ -1,5 +1,6 @@
 import {
   fetchStudentsByFilters,
+  fetchClassesByFilters,
   loadCategoriesData,
   formatTime,
   type School,
@@ -228,7 +229,7 @@ describe('categoryDataUtils', () => {
       expect(apiClient.get).not.toHaveBeenCalled();
     });
 
-    it('should fetch and transform categories from API', async () => {
+    it('should fetch and transform categories from API (single page)', async () => {
       const mockSchools: School[] = [
         { id: 'school-1', companyName: 'School One' },
         { id: 'school-2', companyName: 'School Two' },
@@ -239,34 +240,45 @@ describe('categoryDataUtils', () => {
         { id: 'year-2', name: '2nd Grade', schoolId: 'school-2' },
       ];
 
-      const mockClasses: Class[] = [
-        { id: 'class-1', name: 'Class A', schoolYearId: 'year-1' },
-        { id: 'class-2', name: 'Class B', schoolYearId: 'year-2' },
-      ];
-
       const apiClient = createMockApiClient({
-        get: jest
-          .fn()
-          .mockResolvedValueOnce({
-            data: { message: 'Success', data: { schools: mockSchools } },
-          })
-          .mockResolvedValueOnce({
-            data: {
-              message: 'Success',
-              data: { schoolYears: mockSchoolYears },
-            },
-          })
-          .mockResolvedValueOnce({
-            data: { message: 'Success', data: { classes: mockClasses } },
-          }),
+        get: jest.fn().mockImplementation((url: string) => {
+          if (url === '/school') {
+            return Promise.resolve({
+              data: {
+                message: 'Success',
+                data: { schools: mockSchools, pagination: { totalPages: 1 } },
+              },
+            });
+          }
+          if (url === '/schoolYear') {
+            return Promise.resolve({
+              data: {
+                message: 'Success',
+                data: {
+                  schoolYears: mockSchoolYears,
+                  pagination: { totalPages: 1 },
+                },
+              },
+            });
+          }
+          return Promise.reject(new Error('Unknown URL'));
+        }),
       });
 
       const result = await loadCategoriesData(apiClient, []);
 
-      expect(apiClient.get).toHaveBeenCalledTimes(3);
-      expect(apiClient.get).toHaveBeenCalledWith('/school');
-      expect(apiClient.get).toHaveBeenCalledWith('/schoolYear');
-      expect(apiClient.get).toHaveBeenCalledWith('/classes');
+      // Only /school and /schoolYear are fetched now; /classes is dynamic
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+      expect(apiClient.get).toHaveBeenCalledWith('/school', {
+        params: { page: 1, limit: 100 },
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/schoolYear', {
+        params: { page: 1, limit: 100 },
+      });
+      expect(apiClient.get).not.toHaveBeenCalledWith(
+        '/classes',
+        expect.anything()
+      );
 
       expect(result).toHaveLength(4);
 
@@ -294,16 +306,13 @@ describe('categoryDataUtils', () => {
         selectedIds: [],
       });
 
-      // Check turma category
+      // Check turma category — now dynamic (empty), no eager classes
       expect(result[2]).toEqual({
         key: 'turma',
         label: 'Turma',
         dependsOn: ['serie'],
         filteredBy: [{ key: 'serie', internalField: 'schoolYearId' }],
-        itens: [
-          { id: 'class-1', name: 'Class A', schoolYearId: 'year-1' },
-          { id: 'class-2', name: 'Class B', schoolYearId: 'year-2' },
-        ],
+        itens: [],
         selectedIds: [],
       });
 
@@ -322,34 +331,408 @@ describe('categoryDataUtils', () => {
       });
     });
 
-    it('should make parallel API calls', async () => {
+    it('should paginate /school and /schoolYear across all pages', async () => {
+      const apiClient = createMockApiClient({
+        get: jest
+          .fn()
+          .mockImplementation(
+            (url: string, config?: { params?: { page?: number } }) => {
+              const page = config?.params?.page;
+              if (url === '/school') {
+                if (page === 1) {
+                  return Promise.resolve({
+                    data: {
+                      message: 'Success',
+                      data: {
+                        schools: [
+                          { id: 'school-1', companyName: 'School One' },
+                        ],
+                        pagination: { totalPages: 2 },
+                      },
+                    },
+                  });
+                }
+                return Promise.resolve({
+                  data: {
+                    message: 'Success',
+                    data: {
+                      schools: [{ id: 'school-2', companyName: 'School Two' }],
+                      pagination: { totalPages: 2 },
+                    },
+                  },
+                });
+              }
+              if (url === '/schoolYear') {
+                if (page === 1) {
+                  return Promise.resolve({
+                    data: {
+                      message: 'Success',
+                      data: {
+                        schoolYears: [
+                          { id: 'year-1', name: '1st', schoolId: 'school-1' },
+                        ],
+                        pagination: { totalPages: 2 },
+                      },
+                    },
+                  });
+                }
+                return Promise.resolve({
+                  data: {
+                    message: 'Success',
+                    data: {
+                      schoolYears: [
+                        { id: 'year-2', name: '2nd', schoolId: 'school-2' },
+                      ],
+                      pagination: { totalPages: 2 },
+                    },
+                  },
+                });
+              }
+              return Promise.reject(new Error('Unknown URL'));
+            }
+          ),
+      });
+
+      const result = await loadCategoriesData(apiClient, []);
+
+      // 2 pages each for /school and /schoolYear
+      expect(apiClient.get).toHaveBeenCalledTimes(4);
+      expect(apiClient.get).toHaveBeenCalledWith('/school', {
+        params: { page: 1, limit: 100 },
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/school', {
+        params: { page: 2, limit: 100 },
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/schoolYear', {
+        params: { page: 1, limit: 100 },
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/schoolYear', {
+        params: { page: 2, limit: 100 },
+      });
+
+      // escola aggregates items from BOTH pages
+      expect(result[0].itens).toEqual([
+        { id: 'school-1', name: 'School One' },
+        { id: 'school-2', name: 'School Two' },
+      ]);
+
+      // serie aggregates items from BOTH pages
+      expect(result[1].itens).toEqual([
+        { id: 'year-1', name: '1st', schoolId: 'school-1' },
+        { id: 'year-2', name: '2nd', schoolId: 'school-2' },
+      ]);
+    });
+
+    it('should not fetch /classes eagerly (turma is dynamic)', async () => {
       const apiClient = createMockApiClient({
         get: jest.fn().mockImplementation((url: string) => {
           if (url === '/school') {
             return Promise.resolve({
-              data: { message: 'Success', data: { schools: [] } },
+              data: {
+                message: 'Success',
+                data: { schools: [], pagination: { totalPages: 1 } },
+              },
             });
           }
           if (url === '/schoolYear') {
             return Promise.resolve({
-              data: { message: 'Success', data: { schoolYears: [] } },
-            });
-          }
-          if (url === '/classes') {
-            return Promise.resolve({
-              data: { message: 'Success', data: { classes: [] } },
+              data: {
+                message: 'Success',
+                data: { schoolYears: [], pagination: { totalPages: 1 } },
+              },
             });
           }
           return Promise.reject(new Error('Unknown URL'));
         }),
       });
 
-      await loadCategoriesData(apiClient, []);
+      const result = await loadCategoriesData(apiClient, []);
 
-      // All calls should have been made
-      expect(apiClient.get).toHaveBeenCalledWith('/school');
-      expect(apiClient.get).toHaveBeenCalledWith('/schoolYear');
-      expect(apiClient.get).toHaveBeenCalledWith('/classes');
+      const calledUrls = (apiClient.get as jest.Mock).mock.calls.map(
+        (call) => call[0]
+      );
+      expect(calledUrls).not.toContain('/classes');
+
+      const turma = result.find((c) => c.key === 'turma');
+      expect(turma?.itens).toEqual([]);
+    });
+  });
+
+  describe('fetchClassesByFilters', () => {
+    it('should return empty array when no filters are provided', async () => {
+      const apiClient = createMockApiClient();
+
+      const result = await fetchClassesByFilters(apiClient, {});
+
+      expect(result).toEqual([]);
+      expect(apiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array when filter arrays are empty', async () => {
+      const apiClient = createMockApiClient();
+
+      const result = await fetchClassesByFilters(apiClient, {
+        schoolIds: [],
+        schoolYearIds: [],
+      });
+
+      expect(result).toEqual([]);
+      expect(apiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('should fetch classes with comma-joined schoolId and schoolYearId', async () => {
+      const mockClasses: Class[] = [
+        { id: 'class-1', name: 'Class A', schoolYearId: 'year-1' },
+      ];
+
+      const apiClient = createMockApiClient({
+        get: jest.fn().mockResolvedValue({
+          data: { message: 'Success', data: { classes: mockClasses } },
+        }),
+      });
+
+      const result = await fetchClassesByFilters(apiClient, {
+        schoolIds: ['school-1', 'school-2'],
+        schoolYearIds: ['year-1', 'year-2'],
+      });
+
+      expect(result).toEqual(mockClasses);
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: {
+          schoolId: 'school-1,school-2',
+          schoolYearId: 'year-1,year-2',
+          page: 1,
+          limit: 100,
+        },
+      });
+    });
+
+    it('should send only schoolYearId when only schoolYearIds provided', async () => {
+      const apiClient = createMockApiClient({
+        get: jest.fn().mockResolvedValue({
+          data: { message: 'Success', data: { classes: [] } },
+        }),
+      });
+
+      await fetchClassesByFilters(apiClient, {
+        schoolYearIds: ['year-1'],
+      });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: {
+          schoolYearId: 'year-1',
+          page: 1,
+          limit: 100,
+        },
+      });
+    });
+
+    it('should send only schoolId when only schoolIds provided', async () => {
+      const apiClient = createMockApiClient({
+        get: jest.fn().mockResolvedValue({
+          data: { message: 'Success', data: { classes: [] } },
+        }),
+      });
+
+      await fetchClassesByFilters(apiClient, {
+        schoolIds: ['school-1'],
+      });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: {
+          schoolId: 'school-1',
+          page: 1,
+          limit: 100,
+        },
+      });
+    });
+
+    it('should aggregate classes across multiple pages', async () => {
+      const apiClient = createMockApiClient({
+        get: jest
+          .fn()
+          .mockImplementation(
+            (_url: string, config?: { params?: { page?: number } }) => {
+              const page = config?.params?.page;
+              if (page === 1) {
+                return Promise.resolve({
+                  data: {
+                    message: 'Success',
+                    data: {
+                      classes: [
+                        { id: 'class-1', name: 'Class A', schoolYearId: 'y-1' },
+                      ],
+                      pagination: { totalPages: 2 },
+                    },
+                  },
+                });
+              }
+              return Promise.resolve({
+                data: {
+                  message: 'Success',
+                  data: {
+                    classes: [
+                      { id: 'class-2', name: 'Class B', schoolYearId: 'y-2' },
+                    ],
+                    pagination: { totalPages: 2 },
+                  },
+                },
+              });
+            }
+          ),
+      });
+
+      const result = await fetchClassesByFilters(apiClient, {
+        schoolIds: ['school-1', 'school-2'],
+        schoolYearIds: ['year-1'],
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: {
+          schoolId: 'school-1,school-2',
+          schoolYearId: 'year-1',
+          page: 1,
+          limit: 100,
+        },
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: {
+          schoolId: 'school-1,school-2',
+          schoolYearId: 'year-1',
+          page: 2,
+          limit: 100,
+        },
+      });
+      expect(result).toEqual([
+        { id: 'class-1', name: 'Class A', schoolYearId: 'y-1' },
+        { id: 'class-2', name: 'Class B', schoolYearId: 'y-2' },
+      ]);
+    });
+
+    it('should aggregate three pages IN ORDER even when later pages resolve first', async () => {
+      // Page 3 resolves before page 2 to prove ordering comes from the
+      // Promise.all array index, not resolution order.
+      let resolvePage2: (value: unknown) => void = () => {};
+      const page2Promise = new Promise((resolve) => {
+        resolvePage2 = resolve;
+      });
+
+      const apiClient = createMockApiClient({
+        get: jest
+          .fn()
+          .mockImplementation(
+            (_url: string, config?: { params?: { page?: number } }) => {
+              const page = config?.params?.page;
+              if (page === 1) {
+                return Promise.resolve({
+                  data: {
+                    message: 'Success',
+                    data: {
+                      classes: [
+                        { id: 'class-1', name: 'Class A', schoolYearId: 'y-1' },
+                      ],
+                      pagination: { totalPages: 3 },
+                    },
+                  },
+                });
+              }
+              if (page === 2) {
+                // Deferred: only resolves after page 3 has already resolved.
+                return page2Promise;
+              }
+              // page === 3 resolves immediately, then releases page 2.
+              const page3 = Promise.resolve({
+                data: {
+                  message: 'Success',
+                  data: {
+                    classes: [
+                      { id: 'class-3', name: 'Class C', schoolYearId: 'y-3' },
+                    ],
+                    pagination: { totalPages: 3 },
+                  },
+                },
+              });
+              page3.then(() =>
+                resolvePage2({
+                  data: {
+                    message: 'Success',
+                    data: {
+                      classes: [
+                        { id: 'class-2', name: 'Class B', schoolYearId: 'y-2' },
+                      ],
+                      pagination: { totalPages: 3 },
+                    },
+                  },
+                })
+              );
+              return page3;
+            }
+          ),
+      });
+
+      const result = await fetchClassesByFilters(apiClient, {
+        schoolIds: ['school-1'],
+      });
+
+      // Page 1 requested first.
+      expect((apiClient.get as jest.Mock).mock.calls[0]).toEqual([
+        '/classes',
+        { params: { schoolId: 'school-1', page: 1, limit: 100 } },
+      ]);
+      // Pages 2 AND 3 both requested with limit:100 and the extraParams.
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: { schoolId: 'school-1', page: 2, limit: 100 },
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/classes', {
+        params: { schoolId: 'school-1', page: 3, limit: 100 },
+      });
+      expect(apiClient.get).toHaveBeenCalledTimes(3);
+      // Final result concatenated IN PAGE ORDER (page1, page2, page3) despite
+      // page 3 resolving before page 2.
+      expect(result).toEqual([
+        { id: 'class-1', name: 'Class A', schoolYearId: 'y-1' },
+        { id: 'class-2', name: 'Class B', schoolYearId: 'y-2' },
+        { id: 'class-3', name: 'Class C', schoolYearId: 'y-3' },
+      ]);
+    });
+
+    it('should make a single request when response has no pagination (fallback to 1 page)', async () => {
+      const apiClient = createMockApiClient({
+        get: jest.fn().mockResolvedValue({
+          data: {
+            message: 'Success',
+            data: {
+              classes: [
+                { id: 'class-1', name: 'Class A', schoolYearId: 'y-1' },
+              ],
+            },
+          },
+        }),
+      });
+
+      const result = await fetchClassesByFilters(apiClient, {
+        schoolIds: ['school-1'],
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
+        { id: 'class-1', name: 'Class A', schoolYearId: 'y-1' },
+      ]);
+    });
+
+    it('should return empty array when API returns undefined classes', async () => {
+      const apiClient = createMockApiClient({
+        get: jest.fn().mockResolvedValue({
+          data: { message: 'Success', data: {} },
+        }),
+      });
+
+      const result = await fetchClassesByFilters(apiClient, {
+        schoolIds: ['school-1'],
+      });
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/src/utils/categoryDataUtils.ts
+++ b/src/utils/categoryDataUtils.ts
@@ -111,6 +111,108 @@ export async function fetchStudentsByFilters(
 }
 
 /**
+ * Fetch classes filtered by selected schools/schoolYears via GET /classes.
+ * Wire format is comma-joined strings (NOT arrays): axios serializes an array
+ * param with brackets (`schoolId[]=a`) which the backend's default querystring
+ * parser does not fold into `schoolId`; a comma-joined string (`schoolId=a,b`)
+ * is serializer-agnostic and the backend splits it. A UUID never contains a comma.
+ *
+ * @param apiClient - API client instance
+ * @param filters - Object with schoolIds and/or schoolYearIds arrays
+ * @returns Promise resolving to array of classes
+ *
+ * @example
+ * ```ts
+ * const classes = await fetchClassesByFilters(apiClient, {
+ *   schoolIds: ['school-1'],
+ *   schoolYearIds: ['year-1'],
+ * });
+ * ```
+ */
+export async function fetchClassesByFilters(
+  apiClient: BaseApiClient,
+  filters: { schoolIds?: string[]; schoolYearIds?: string[] }
+): Promise<Class[]> {
+  const hasSchools = !!filters.schoolIds && filters.schoolIds.length > 0;
+  const hasYears = !!filters.schoolYearIds && filters.schoolYearIds.length > 0;
+  if (!hasSchools && !hasYears) return [];
+  // Paginate ALL matching pages: a regional manager selecting many schools +
+  // series can have > 100 filtered classes, which a single page would truncate.
+  return fetchAllPages<Class>(
+    apiClient,
+    '/classes',
+    (data) => {
+      const d = data as {
+        classes: Class[];
+        pagination?: { totalPages: number };
+      };
+      return {
+        items: d.classes ?? [],
+        totalPages: d.pagination?.totalPages ?? 1,
+      };
+    },
+    {
+      ...(hasSchools && { schoolId: filters.schoolIds!.join(',') }),
+      ...(hasYears && { schoolYearId: filters.schoolYearIds!.join(',') }),
+    }
+  );
+}
+
+/**
+ * Fetch every page of a paginated list endpoint and aggregate the items.
+ *
+ * @param apiClient - API client instance
+ * @param url - Endpoint to fetch (e.g. '/school')
+ * @param extract - Reads `data.data` and returns the page items and totalPages
+ * @param extraParams - Extra query params merged into `{ page, limit }` on every
+ *   request (e.g. comma-joined `schoolId`/`schoolYearId` filters for `/classes`)
+ * @returns Promise resolving to all items across every page
+ */
+async function fetchAllPages<T>(
+  apiClient: BaseApiClient,
+  url: string,
+  extract: (data: unknown) => { items: T[]; totalPages: number },
+  extraParams: Record<string, unknown> = {}
+): Promise<T[]> {
+  // Fetch page 1 first to learn totalPages and get the initial items.
+  const firstResponse = await apiClient.get<{ message: string; data: unknown }>(
+    url,
+    { params: { ...extraParams, page: 1, limit: 100 } }
+  );
+  const first = extract(firstResponse.data.data);
+  const totalPages = first.totalPages || 1;
+  const all: T[] = [...(first.items ?? [])];
+
+  // Single page: return page-1 items unchanged.
+  if (totalPages <= 1) {
+    return all;
+  }
+
+  // Fetch remaining pages 2..totalPages in parallel. The browser caps
+  // concurrent requests per host (~6), so firing them all is safe.
+  const remainingPages = Array.from(
+    { length: totalPages - 1 },
+    (_, i) => i + 2
+  );
+  const responses = await Promise.all(
+    remainingPages.map((page) =>
+      apiClient.get<{ message: string; data: unknown }>(url, {
+        params: { ...extraParams, page, limit: 100 },
+      })
+    )
+  );
+
+  // Concatenate in PAGE ORDER via the array index (Promise.all preserves
+  // input order regardless of resolution order).
+  for (const response of responses) {
+    const { items } = extract(response.data.data);
+    all.push(...(items ?? []));
+  }
+
+  return all;
+}
+
+/**
  * Load categories data from API and transform to CategoryConfig format
  *
  * @param apiClient - API client instance
@@ -130,24 +232,25 @@ export async function loadCategoriesData(
     return existingCategories;
   }
 
-  const [schoolsResponse, schoolYearsResponse, classesResponse] =
-    await Promise.all([
-      apiClient.get<{ message: string; data: { schools: School[] } }>(
-        '/school'
-      ),
-      apiClient.get<{
-        message: string;
-        data: { schoolYears: SchoolYear[] };
-      }>('/schoolYear'),
-      apiClient.get<{
-        message: string;
-        data: { classes: Class[] };
-      }>('/classes'),
-    ]);
-
-  const schools = schoolsResponse.data.data.schools;
-  const schoolYears = schoolYearsResponse.data.data.schoolYears;
-  const classes = classesResponse.data.data.classes;
+  const [schools, schoolYears] = await Promise.all([
+    fetchAllPages<School>(apiClient, '/school', (data) => {
+      const d = data as {
+        schools: School[];
+        pagination?: { totalPages: number };
+      };
+      return { items: d.schools, totalPages: d.pagination?.totalPages ?? 1 };
+    }),
+    fetchAllPages<SchoolYear>(apiClient, '/schoolYear', (data) => {
+      const d = data as {
+        schoolYears: SchoolYear[];
+        pagination?: { totalPages: number };
+      };
+      return {
+        items: d.schoolYears,
+        totalPages: d.pagination?.totalPages ?? 1,
+      };
+    }),
+  ]);
 
   const transformedCategories: CategoryConfig[] = [
     {
@@ -173,11 +276,8 @@ export async function loadCategoriesData(
       label: 'Turma',
       dependsOn: ['serie'],
       filteredBy: [{ key: 'serie', internalField: 'schoolYearId' }],
-      itens: classes.map((c) => ({
-        id: c.id,
-        name: c.name,
-        schoolYearId: c.schoolYearId,
-      })),
+      // Classes are loaded dynamically based on selected schools/schoolYears
+      itens: [],
       selectedIds: [],
     },
     {

--- a/src/utils/useDynamicStudentFetching.test.ts
+++ b/src/utils/useDynamicStudentFetching.test.ts
@@ -1,0 +1,745 @@
+import { renderHook } from '@testing-library/react';
+import type { SetStateAction } from 'react';
+import { useDynamicStudentFetching } from './useDynamicStudentFetching';
+import type { CategoryConfig } from '../components/CheckBoxGroup/CheckBoxGroup';
+import type { BaseApiClient } from '../types/api';
+import type { Class } from './categoryDataUtils';
+import type { StudentWithNestedData } from './studentTypes';
+
+// Mock API client
+const createMockApiClient = (
+  overrides: Partial<BaseApiClient> = {}
+): BaseApiClient => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn(),
+  ...overrides,
+});
+
+/**
+ * Stateful setCategories mock that supports functional updates, so we can assert
+ * the composed final state and prove functional write-backs do not clobber.
+ */
+function createSetCategories(initial: CategoryConfig[]): {
+  fn: jest.Mock;
+  getState: () => CategoryConfig[];
+} {
+  let state = initial;
+  const fn = jest.fn((update: SetStateAction<CategoryConfig[]>) => {
+    state =
+      typeof update === 'function'
+        ? (update as (prev: CategoryConfig[]) => CategoryConfig[])(state)
+        : update;
+  });
+  return { fn, getState: () => state };
+}
+
+const buildCategories = (
+  selected: {
+    escola?: string[];
+    serie?: string[];
+    turma?: string[];
+    students?: string[];
+  } = {},
+  itens: {
+    turma?: CategoryConfig['itens'];
+    students?: CategoryConfig['itens'];
+  } = {}
+): CategoryConfig[] => [
+  {
+    key: 'escola',
+    label: 'Escola',
+    itens: [{ id: 's1', name: 'Escola 1' }],
+    selectedIds: selected.escola ?? [],
+  },
+  {
+    key: 'serie',
+    label: 'Série',
+    dependsOn: ['escola'],
+    filteredBy: [{ key: 'escola', internalField: 'schoolId' }],
+    itens: [
+      { id: 'y1', name: '1º Ano', schoolId: 's1' },
+      { id: 'y2', name: '2º Ano', schoolId: 's1' },
+    ],
+    selectedIds: selected.serie ?? [],
+  },
+  {
+    key: 'turma',
+    label: 'Turma',
+    dependsOn: ['serie'],
+    filteredBy: [{ key: 'serie', internalField: 'schoolYearId' }],
+    itens: itens.turma ?? [],
+    selectedIds: selected.turma ?? [],
+  },
+  {
+    key: 'students',
+    label: 'Alunos',
+    dependsOn: ['turma'],
+    filteredBy: [
+      { key: 'escola', internalField: 'escolaId' },
+      { key: 'serie', internalField: 'serieId' },
+      { key: 'turma', internalField: 'turmaId' },
+    ],
+    itens: itens.students ?? [],
+    selectedIds: selected.students ?? [],
+  },
+];
+
+const sampleClasses: Class[] = [
+  { id: 'c1', name: 'Turma A', schoolYearId: 'y1' },
+  { id: 'c2', name: 'Turma B', schoolYearId: 'y1' },
+];
+
+const sampleStudents: StudentWithNestedData[] = [
+  {
+    id: 'st1',
+    email: 'aluno1@example.com',
+    name: 'Aluno 1',
+    active: true,
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    userInstitutionId: 'ui1',
+    institutionId: 'inst1',
+    profileId: 'prof1',
+    school: { id: 's1', name: 'Escola 1' },
+    schoolYear: { id: 'y1', name: '1º Ano' },
+    class: { id: 'c1', name: 'Turma A' },
+  },
+];
+
+const getCategory = (categories: CategoryConfig[], key: string) =>
+  categories.find((c) => c.key === key)!;
+
+describe('useDynamicStudentFetching', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('no fetch function provided', () => {
+    it('just updates categories as-is', async () => {
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories)
+      );
+
+      const cats = buildCategories({ escola: ['s1'], serie: ['y1'] });
+      await result.current.handleCategoriesChange(cats);
+
+      expect(getState()).toBe(cats);
+    });
+  });
+
+  describe('no apiClient (consumer-managed turma, e.g. AlertsManager)', () => {
+    const preloadedTurma: CategoryConfig['itens'] = [
+      { id: 'c1', name: 'Turma A', schoolYearId: 'y1' },
+      { id: 'c2', name: 'Turma B', schoolYearId: 'y1' },
+    ];
+
+    it('never clears or fetches turma on a série change when there is no apiClient', async () => {
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue([]);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, { fetchStudentsByFilters })
+      );
+
+      // Série selected: without apiClient the hook must leave turma.itens intact.
+      await result.current.handleCategoriesChange(
+        buildCategories(
+          { escola: ['s1'], serie: ['y1'] },
+          { turma: preloadedTurma }
+        )
+      );
+
+      expect(getCategory(getState(), 'turma').itens).toEqual(preloadedTurma);
+    });
+
+    it('does not clear turma when the série selection becomes empty', async () => {
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue([]);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, { fetchStudentsByFilters })
+      );
+
+      // Série selected, then deselected: the else/clear branch must be a no-op
+      // so AlertsManager's pre-populated turma survives.
+      await result.current.handleCategoriesChange(
+        buildCategories(
+          { escola: ['s1'], serie: ['y1'] },
+          { turma: preloadedTurma }
+        )
+      );
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'] }, { turma: preloadedTurma })
+      );
+
+      expect(getCategory(getState(), 'turma').itens).toEqual(preloadedTurma);
+    });
+
+    it('still fetches students via the custom fetcher when a turma is selected', async () => {
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue(sampleStudents);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, { fetchStudentsByFilters })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories(
+          { escola: ['s1'], serie: ['y1'], turma: ['c1'] },
+          { turma: preloadedTurma }
+        )
+      );
+
+      expect(fetchStudentsByFilters).toHaveBeenCalledWith({
+        schoolIds: ['s1'],
+        schoolYearIds: ['y1'],
+        classIds: ['c1'],
+      });
+      // Students populated, turma still untouched by the hook.
+      expect(getCategory(getState(), 'students').itens).toHaveLength(1);
+      expect(getCategory(getState(), 'turma').itens).toEqual(preloadedTurma);
+    });
+  });
+
+  describe('dynamic turma (class) fetching', () => {
+    it('fetches classes on série change and writes them into turma.itens with schoolYearId', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue(sampleClasses);
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue([]);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          fetchStudentsByFilters,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'] })
+      );
+
+      expect(fetchClassesByFilters).toHaveBeenCalledWith(apiClient, {
+        schoolIds: ['s1'],
+        schoolYearIds: ['y1'],
+      });
+
+      const turma = getCategory(getState(), 'turma');
+      expect(turma.itens).toEqual([
+        { id: 'c1', name: 'Turma A', schoolYearId: 'y1' },
+        { id: 'c2', name: 'Turma B', schoolYearId: 'y1' },
+      ]);
+      // Every turma item must carry schoolYearId so `filteredBy` keeps it visible
+      expect(turma.itens!.every((i) => 'schoolYearId' in i)).toBe(true);
+    });
+
+    it('clears turma.itens when the série selection becomes empty', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue(sampleClasses);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+        })
+      );
+
+      // Select a série -> populates turma
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'] })
+      );
+      expect(getCategory(getState(), 'turma').itens).toHaveLength(2);
+
+      // Deselect all séries -> turma reset to []
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: [] })
+      );
+      expect(getCategory(getState(), 'turma').itens).toEqual([]);
+    });
+
+    it('drops a stale class response superseded by a newer change', async () => {
+      const apiClient = createMockApiClient();
+      let resolveFirst!: (value: Class[]) => void;
+      const firstResponse = new Promise<Class[]>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const staleClasses: Class[] = [
+        { id: 'stale', name: 'Stale', schoolYearId: 'y1' },
+      ];
+      const freshClasses: Class[] = [
+        { id: 'fresh', name: 'Fresh', schoolYearId: 'y2' },
+      ];
+      // Resolve by input (not call order) so the test is deterministic under
+      // concurrent async: the y1 (older) request stays pending, y2 resolves.
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, { schoolYearIds?: string[] }]>()
+        .mockImplementation((_api, filters) =>
+          filters.schoolYearIds?.includes('y1')
+            ? firstResponse
+            : Promise.resolve(freshClasses)
+        );
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+        })
+      );
+
+      // First change starts a fetch that will resolve LATE
+      const firstCall = result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'] })
+      );
+      // Second change supersedes it and resolves immediately
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y2'] })
+      );
+
+      // Now let the stale (first) response resolve
+      resolveFirst(staleClasses);
+      await firstCall;
+
+      const turma = getCategory(getState(), 'turma');
+      expect(turma.itens).toEqual([
+        { id: 'fresh', name: 'Fresh', schoolYearId: 'y2' },
+      ]);
+    });
+
+    it('clears turma on class fetch error and reports via onError', async () => {
+      const apiClient = createMockApiClient();
+      const error = new Error('boom');
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockRejectedValue(error);
+      const onError = jest.fn();
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          onError,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories(
+          { escola: ['s1'], serie: ['y1'] },
+          { turma: [{ id: 'c1', name: 'Turma A', schoolYearId: 'y1' }] }
+        )
+      );
+
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(getCategory(getState(), 'turma').itens).toEqual([]);
+    });
+  });
+
+  describe('dynamic aluno (student) fetching', () => {
+    it('fetches students when a turma is selected and writes them into students.itens', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue([]);
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue(sampleStudents);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          fetchStudentsByFilters,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'], turma: ['c1'] })
+      );
+
+      expect(fetchStudentsByFilters).toHaveBeenCalledWith({
+        schoolIds: ['s1'],
+        schoolYearIds: ['y1'],
+        classIds: ['c1'],
+      });
+
+      const students = getCategory(getState(), 'students');
+      expect(students.itens).toEqual([
+        {
+          id: 'ui1-c1',
+          name: 'Aluno 1',
+          classId: 'c1',
+          schoolId: 's1',
+          schoolYearId: 'y1',
+          studentId: 'st1',
+          userInstitutionId: 'ui1',
+          escolaId: 's1',
+          serieId: 'y1',
+          turmaId: 'c1',
+        },
+      ]);
+    });
+
+    it('clears students when no turma is selected after a change', async () => {
+      const apiClient = createMockApiClient();
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue(sampleStudents);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchStudentsByFilters,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories(
+          { escola: ['s1'], serie: ['y1'] },
+          { students: [{ id: 'stale-student', name: 'x' }] }
+        )
+      );
+
+      expect(fetchStudentsByFilters).not.toHaveBeenCalled();
+      expect(getCategory(getState(), 'students').itens).toEqual([]);
+    });
+
+    it('drops a stale student response superseded by a newer change', async () => {
+      const apiClient = createMockApiClient();
+      let resolveFirst!: (value: StudentWithNestedData[]) => void;
+      const firstResponse = new Promise<StudentWithNestedData[]>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const staleStudents: StudentWithNestedData[] = [
+        { ...sampleStudents[0], id: 'stale', userInstitutionId: 'stale-ui' },
+      ];
+      // Resolve by input (not call order) so the test is deterministic under
+      // concurrent async: the c1 (older) request stays pending, c2 resolves.
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [{ classIds?: string[] }]>()
+        .mockImplementation((filters) =>
+          filters.classIds?.includes('c1')
+            ? firstResponse
+            : Promise.resolve(sampleStudents)
+        );
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue([]);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchStudentsByFilters,
+          fetchClassesByFilters,
+        })
+      );
+
+      // Prime school/série so the two racing changes only toggle turma and thus
+      // never trigger a class fetch (whose await would otherwise reorder the
+      // student request ids).
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'] })
+      );
+
+      const firstCall = result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'], turma: ['c1'] })
+      );
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'], turma: ['c2'] })
+      );
+
+      resolveFirst(staleStudents);
+      await firstCall;
+
+      expect(getCategory(getState(), 'students').itens).toEqual([
+        {
+          id: 'ui1-c1',
+          name: 'Aluno 1',
+          classId: 'c1',
+          schoolId: 's1',
+          schoolYearId: 'y1',
+          studentId: 'st1',
+          userInstitutionId: 'ui1',
+          escolaId: 's1',
+          serieId: 'y1',
+          turmaId: 'c1',
+        },
+      ]);
+    });
+
+    it('clears students on fetch error and reports via onError', async () => {
+      const apiClient = createMockApiClient();
+      const error = new Error('student boom');
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockRejectedValue(error);
+      const onError = jest.fn();
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchStudentsByFilters,
+          onError,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories(
+          { escola: ['s1'], serie: ['y1'], turma: ['c1'] },
+          { students: [{ id: 'old', name: 'old' }] }
+        )
+      );
+
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(getCategory(getState(), 'students').itens).toEqual([]);
+    });
+  });
+
+  describe('only-student-toggle changes', () => {
+    it('does not refetch classes or students when only student selection changes', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue(sampleClasses);
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue(sampleStudents);
+
+      const { fn: setCategories } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          fetchStudentsByFilters,
+        })
+      );
+
+      // First change selects turma -> fetches both classes and students
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'], turma: ['c1'] })
+      );
+      fetchClassesByFilters.mockClear();
+      fetchStudentsByFilters.mockClear();
+
+      // Second change toggles only the student selection
+      await result.current.handleCategoriesChange(
+        buildCategories({
+          escola: ['s1'],
+          serie: ['y1'],
+          turma: ['c1'],
+          students: ['ui1-c1'],
+        })
+      );
+
+      expect(fetchClassesByFilters).not.toHaveBeenCalled();
+      expect(fetchStudentsByFilters).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('functional write-backs do not clobber each other', () => {
+    it('the class write-back only replaces turma, preserving a concurrent students write', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue(sampleClasses);
+
+      const { fn: setCategories } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'] })
+      );
+
+      // Find the functional updater that writes classes into turma
+      const classUpdater = setCategories.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (arg): arg is (prev: CategoryConfig[]) => CategoryConfig[] =>
+            typeof arg === 'function'
+        )
+        .find((fnArg) => {
+          const out = fnArg(buildCategories());
+          return getCategory(out, 'turma').itens!.length > 0;
+        });
+      expect(classUpdater).toBeDefined();
+
+      // Apply it to a state that already has a students write -> students preserved
+      const stateWithStudents = buildCategories(
+        {},
+        { students: [{ id: 'ui1-c1', name: 'Aluno 1' }] }
+      );
+      const next = classUpdater!(stateWithStudents);
+
+      expect(getCategory(next, 'turma').itens).toEqual([
+        { id: 'c1', name: 'Turma A', schoolYearId: 'y1' },
+        { id: 'c2', name: 'Turma B', schoolYearId: 'y1' },
+      ]);
+      expect(getCategory(next, 'students').itens).toEqual([
+        { id: 'ui1-c1', name: 'Aluno 1' },
+      ]);
+    });
+
+    it('the student write-back only replaces students, preserving a concurrent turma write', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue([]);
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue(sampleStudents);
+
+      const { fn: setCategories } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          fetchStudentsByFilters,
+        })
+      );
+
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'], turma: ['c1'] })
+      );
+
+      const studentUpdater = setCategories.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (arg): arg is (prev: CategoryConfig[]) => CategoryConfig[] =>
+            typeof arg === 'function'
+        )
+        .find((fnArg) => {
+          const out = fnArg(buildCategories());
+          return getCategory(out, 'students').itens!.length > 0;
+        });
+      expect(studentUpdater).toBeDefined();
+
+      // Apply it to a state that already has a turma write -> turma preserved
+      const stateWithTurma = buildCategories(
+        {},
+        { turma: [{ id: 'c1', name: 'Turma A', schoolYearId: 'y1' }] }
+      );
+      const next = studentUpdater!(stateWithTurma);
+
+      expect(getCategory(next, 'turma').itens).toEqual([
+        { id: 'c1', name: 'Turma A', schoolYearId: 'y1' },
+      ]);
+      expect(getCategory(next, 'students').itens).toHaveLength(1);
+    });
+
+    it('a single cascade with both fetches non-empty ends with BOTH turma and students populated', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue(sampleClasses);
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue(sampleStudents);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          fetchStudentsByFilters,
+        })
+      );
+
+      // Selecting escola + série + turma in one change fetches BOTH classes and
+      // students; the composed final state must carry both, neither clobbering
+      // the other.
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'], turma: ['c1'] })
+      );
+
+      expect(fetchClassesByFilters).toHaveBeenCalledTimes(1);
+      expect(fetchStudentsByFilters).toHaveBeenCalledTimes(1);
+
+      expect(getCategory(getState(), 'turma').itens).toEqual([
+        { id: 'c1', name: 'Turma A', schoolYearId: 'y1' },
+        { id: 'c2', name: 'Turma B', schoolYearId: 'y1' },
+      ]);
+      expect(getCategory(getState(), 'students').itens).toEqual([
+        {
+          id: 'ui1-c1',
+          name: 'Aluno 1',
+          classId: 'c1',
+          schoolId: 's1',
+          schoolYearId: 'y1',
+          studentId: 'st1',
+          userInstitutionId: 'ui1',
+          escolaId: 's1',
+          serieId: 'y1',
+          turmaId: 'c1',
+        },
+      ]);
+    });
+
+    it('the eager selection commit preserves async-loaded itens against a later stale snapshot', async () => {
+      const apiClient = createMockApiClient();
+      const fetchClassesByFilters = jest
+        .fn<Promise<Class[]>, [BaseApiClient, unknown]>()
+        .mockResolvedValue(sampleClasses);
+      const fetchStudentsByFilters = jest
+        .fn<Promise<StudentWithNestedData[]>, [unknown]>()
+        .mockResolvedValue([]);
+
+      const { fn: setCategories, getState } = createSetCategories([]);
+      const { result } = renderHook(() =>
+        useDynamicStudentFetching(setCategories, {
+          apiClient,
+          fetchClassesByFilters,
+          fetchStudentsByFilters,
+        })
+      );
+
+      // Load turmas for série y1
+      await result.current.handleCategoriesChange(
+        buildCategories({ escola: ['s1'], serie: ['y1'] })
+      );
+      expect(getCategory(getState(), 'turma').itens).toHaveLength(2);
+
+      // A later change that only toggles a student selection carries a STALE
+      // snapshot with empty turma.itens. The eager commit must NOT revert the
+      // async-loaded turmas (only its selectedIds should be committed).
+      await result.current.handleCategoriesChange(
+        buildCategories({
+          escola: ['s1'],
+          serie: ['y1'],
+          students: ['ui1-c1'],
+        })
+      );
+
+      expect(getCategory(getState(), 'turma').itens).toHaveLength(2);
+    });
+  });
+});

--- a/src/utils/useDynamicStudentFetching.ts
+++ b/src/utils/useDynamicStudentFetching.ts
@@ -1,15 +1,29 @@
 import { useCallback, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import type { CategoryConfig } from '../components/CheckBoxGroup/CheckBoxGroup';
 import type { BaseApiClient } from '../types/api';
-import { fetchStudentsByFilters } from './categoryDataUtils';
+import {
+  fetchStudentsByFilters,
+  fetchClassesByFilters as defaultFetchClassesByFilters,
+} from './categoryDataUtils';
+import type { Class } from './categoryDataUtils';
 import type {
   FetchStudentsByFiltersFunction,
   StudentWithNestedData,
 } from './studentTypes';
 
+/**
+ * Function type for fetching classes by filters
+ */
+export type FetchClassesByFiltersFunction = (
+  apiClient: BaseApiClient,
+  filters: { schoolIds?: string[]; schoolYearIds?: string[] }
+) => Promise<Class[]>;
+
 export interface UseDynamicStudentFetchingOptions {
   apiClient?: BaseApiClient;
   fetchStudentsByFilters?: FetchStudentsByFiltersFunction;
+  fetchClassesByFilters?: FetchClassesByFiltersFunction;
   onError?: (error: Error) => void;
 }
 
@@ -121,54 +135,74 @@ function transformStudentsToItems(students: StudentWithNestedData[]): Array<{
 }
 
 /**
- * Update categories with student items
+ * Transform classes to items format.
+ *
+ * Each item MUST carry `schoolYearId`: the turma category's `filteredBy` is
+ * `[{ key: 'serie', internalField: 'schoolYearId' }]`, so items without it are
+ * filtered out and never render.
  */
-function updateCategoriesWithStudents(
+function transformClassesToItems(classes: Class[]): Array<{
+  id: string;
+  name: string;
+  schoolYearId: string;
+}> {
+  return classes.map((c) => ({
+    id: c.id,
+    name: c.name,
+    schoolYearId: c.schoolYearId,
+  }));
+}
+
+/**
+ * Immutably replace the `itens` of a single category (by key), leaving every
+ * other category untouched. Clearing a category is `setCategoryItems(cats, key, [])`.
+ */
+function setCategoryItems(
+  categories: CategoryConfig[],
+  key: string,
+  itens: NonNullable<CategoryConfig['itens']>
+): CategoryConfig[] {
+  return categories.map((cat) => (cat.key === key ? { ...cat, itens } : cat));
+}
+
+/**
+ * Commit the new `selectedIds` from a change while preserving each category's
+ * prior `itens`. The `itens` for turma/alunos are owned exclusively by the async
+ * write-backs, so the eager commit must never overwrite them (which would revert
+ * async-loaded options when a rapid second call carries a stale snapshot).
+ */
+function commitSelectionsPreservingItems(
   updatedCategories: CategoryConfig[],
-  studentItems: Array<{
-    id: string;
-    name: string;
-    classId: string;
-    schoolId: string;
-    schoolYearId: string;
-    studentId: string;
-    userInstitutionId: string;
-    escolaId: string;
-    serieId: string;
-    turmaId: string;
-  }>
+  prev: CategoryConfig[]
 ): CategoryConfig[] {
-  return updatedCategories.map((cat) =>
-    cat.key === 'students' ? { ...cat, itens: studentItems } : cat
-  );
+  return updatedCategories.map((cat) => {
+    const prior = prev.find((p) => p.key === cat.key);
+    return prior ? { ...cat, itens: prior.itens } : cat;
+  });
 }
 
 /**
- * Clear students from categories
- */
-function clearStudentsFromCategories(
-  updatedCategories: CategoryConfig[]
-): CategoryConfig[] {
-  return updatedCategories.map((cat) =>
-    cat.key === 'students' ? { ...cat, itens: [] } : cat
-  );
-}
-
-/**
- * Hook to handle dynamic student fetching based on category selections.
+ * Hook to dynamically load BOTH turmas and alunos based on category selections.
  *
  * This hook provides a `handleCategoriesChange` function that:
  * - Detects changes in school/series/class selections
- * - Fetches students only when these selections change (not when only students are toggled)
- * - Transforms fetched students into the correct format for CategoryConfig
+ * - Fetches turmas (classes) when the school/série selection changes and a série
+ *   is selected; clears turmas when the série selection becomes empty
+ * - Fetches alunos (students) only when school/series/class selections change and
+ *   a turma is selected (not when only students are toggled); clears alunos otherwise
+ * - Writes each fetched set back into ONLY its own category via functional state
+ *   updates, so a late turma response never clobbers a student write and vice-versa
+ * - Transforms fetched turmas/alunos into the correct format for CategoryConfig
+ *   (turma items carry `schoolYearId` so the turma `filteredBy` does not hide them)
+ * - Uses separate request-id guards for turmas and alunos to drop stale responses
  * - Handles errors gracefully
  *
- * @param setCategories - Function to update categories state
+ * @param setCategories - React state setter for categories (supports functional updates)
  * @param options - Configuration options
  * @returns Object with handleCategoriesChange function
  */
 export function useDynamicStudentFetching(
-  setCategories: (categories: CategoryConfig[]) => void,
+  setCategories: Dispatch<SetStateAction<CategoryConfig[]>>,
   options: UseDynamicStudentFetchingOptions = {}
 ): {
   handleCategoriesChange: (
@@ -178,6 +212,7 @@ export function useDynamicStudentFetching(
   const {
     apiClient,
     fetchStudentsByFilters: customFetchStudents,
+    fetchClassesByFilters: fetchClasses = defaultFetchClassesByFilters,
     onError,
   } = options;
 
@@ -192,8 +227,11 @@ export function useDynamicStudentFetching(
     classIds: [],
   });
 
-  // Ref to track fetch request ID and prevent race conditions
+  // Refs to track fetch request IDs and prevent race conditions.
+  // Separate ids for turmas and alunos so the two async writes never invalidate
+  // each other.
   const fetchRequestId = useRef(0);
+  const fetchClassesRequestId = useRef(0);
 
   /**
    * Build filters object for student fetching
@@ -304,24 +342,46 @@ export function useDynamicStudentFetching(
   );
 
   /**
-   * Handle successful student fetch
+   * Fetch classes (turmas) filtered by selected schools/schoolYears
+   */
+  const performClassFetch = useCallback(
+    async (
+      selectedSchoolIds: string[],
+      selectedSchoolYearIds: string[],
+      localRequestId: number
+    ): Promise<Class[] | null> => {
+      if (!apiClient) {
+        return null;
+      }
+
+      const filters = {
+        schoolIds: selectedSchoolIds.length > 0 ? selectedSchoolIds : undefined,
+        schoolYearIds:
+          selectedSchoolYearIds.length > 0 ? selectedSchoolYearIds : undefined,
+      };
+      const classes = await fetchClasses(apiClient, filters);
+
+      if (localRequestId !== fetchClassesRequestId.current) {
+        return null;
+      }
+
+      return classes;
+    },
+    [apiClient, fetchClasses]
+  );
+
+  /**
+   * Handle successful student fetch. Patches ONLY the students category on top of
+   * the latest state so a concurrent turma write is not clobbered.
    */
   const handleSuccessfulFetch = useCallback(
-    (
-      students: StudentWithNestedData[],
-      updatedCategories: CategoryConfig[],
-      localRequestId: number
-    ): boolean => {
+    (students: StudentWithNestedData[], localRequestId: number): boolean => {
       if (localRequestId !== fetchRequestId.current) {
         return false;
       }
 
       const studentItems = transformStudentsToItems(students);
-      const finalCategories = updateCategoriesWithStudents(
-        updatedCategories,
-        studentItems
-      );
-      setCategories(finalCategories);
+      setCategories((prev) => setCategoryItems(prev, 'students', studentItems));
       return true;
     },
     [setCategories]
@@ -331,11 +391,7 @@ export function useDynamicStudentFetching(
    * Handle error during student fetch
    */
   const handleFetchError = useCallback(
-    (
-      error: unknown,
-      updatedCategories: CategoryConfig[],
-      localRequestId: number
-    ): boolean => {
+    (error: unknown, localRequestId: number): boolean => {
       console.error('Error fetching students:', error);
       if (onError && error instanceof Error) {
         onError(error);
@@ -345,11 +401,139 @@ export function useDynamicStudentFetching(
         return false;
       }
 
-      const finalCategories = clearStudentsFromCategories(updatedCategories);
-      setCategories(finalCategories);
+      setCategories((prev) => setCategoryItems(prev, 'students', []));
       return true;
     },
     [onError, setCategories]
+  );
+
+  /**
+   * Handle successful class fetch. Patches ONLY the turma category on top of the
+   * latest state so a concurrent student write is not clobbered.
+   */
+  const handleSuccessfulClassFetch = useCallback(
+    (classes: Class[], localRequestId: number): boolean => {
+      if (localRequestId !== fetchClassesRequestId.current) {
+        return false;
+      }
+
+      const classItems = transformClassesToItems(classes);
+      setCategories((prev) => setCategoryItems(prev, 'turma', classItems));
+      return true;
+    },
+    [setCategories]
+  );
+
+  /**
+   * Handle error during class fetch
+   */
+  const handleClassFetchError = useCallback(
+    (error: unknown, localRequestId: number): boolean => {
+      console.error('Error fetching classes:', error);
+      if (onError && error instanceof Error) {
+        onError(error);
+      }
+
+      if (localRequestId !== fetchClassesRequestId.current) {
+        return false;
+      }
+
+      setCategories((prev) => setCategoryItems(prev, 'turma', []));
+      return true;
+    },
+    [onError, setCategories]
+  );
+
+  /**
+   * Fetch turmas (or clear them) in response to a school/série selection change
+   */
+  const handleClassesChange = useCallback(
+    async (
+      selectedSchoolIds: string[],
+      selectedSchoolYearIds: string[]
+    ): Promise<void> => {
+      // No apiClient => this consumer manages `turma` itself (e.g. AlertsManager
+      // with pre-populated categories). Never fetch OR clear turma in that case.
+      if (!apiClient) return;
+
+      // Turma depends on a selected série: fetch only when a série is selected.
+      if (selectedSchoolYearIds.length > 0) {
+        fetchClassesRequestId.current += 1;
+        const localRequestId = fetchClassesRequestId.current;
+
+        try {
+          const classes = await performClassFetch(
+            selectedSchoolIds,
+            selectedSchoolYearIds,
+            localRequestId
+          );
+
+          if (classes === null) {
+            return; // Request was invalidated
+          }
+
+          handleSuccessfulClassFetch(classes, localRequestId);
+        } catch (error) {
+          handleClassFetchError(error, localRequestId);
+        }
+      } else {
+        // Série selection became empty -> reset turma options
+        fetchClassesRequestId.current += 1;
+        setCategories((prev) => setCategoryItems(prev, 'turma', []));
+      }
+    },
+    [
+      apiClient,
+      performClassFetch,
+      handleSuccessfulClassFetch,
+      handleClassFetchError,
+      setCategories,
+    ]
+  );
+
+  /**
+   * Fetch alunos (or clear them) in response to a selection change
+   */
+  const handleStudentsChange = useCallback(
+    async (
+      selectedSchoolIds: string[],
+      selectedSchoolYearIds: string[],
+      selectedClassIds: string[],
+      studentsCategory: CategoryConfig | undefined
+    ): Promise<void> => {
+      if (selectedClassIds.length > 0 && studentsCategory) {
+        // Increment request ID to invalidate any in-flight requests
+        fetchRequestId.current += 1;
+        const localRequestId = fetchRequestId.current;
+
+        try {
+          const students = await performStudentFetch(
+            selectedSchoolIds,
+            selectedSchoolYearIds,
+            selectedClassIds,
+            localRequestId
+          );
+
+          if (students === null) {
+            return; // Request was invalidated
+          }
+
+          handleSuccessfulFetch(students, localRequestId);
+        } catch (error) {
+          handleFetchError(error, localRequestId);
+        }
+      } else if (studentsCategory) {
+        // If no classes selected after a change, clear students
+        fetchRequestId.current += 1;
+        setCategories((prev) => setCategoryItems(prev, 'students', []));
+      }
+    },
+    [
+      performStudentFetch,
+      handleSuccessfulFetch,
+      handleFetchError,
+      setCategories,
+    ]
   );
 
   const handleCategoriesChange = useCallback(
@@ -370,14 +554,12 @@ export function useDynamicStudentFetching(
 
       // Detect if selections have changed
       const previousSelections = previousSelectionsRef.current;
-      const { shouldFetchStudents } = detectSelectionChanges(
-        previousSelections,
-        {
+      const { schoolIdsChanged, schoolYearIdsChanged, shouldFetchStudents } =
+        detectSelectionChanges(previousSelections, {
           schoolIds: selectedSchoolIds,
           schoolYearIds: selectedSchoolYearIds,
           classIds: selectedClassIds,
-        }
-      );
+        });
 
       // Update previous selections
       previousSelectionsRef.current = {
@@ -386,49 +568,35 @@ export function useDynamicStudentFetching(
         classIds: [...selectedClassIds],
       };
 
-      // Only fetch students if school/series/class selections changed
-      if (
-        shouldFetchStudents &&
-        selectedClassIds.length > 0 &&
-        studentsCategory
-      ) {
-        // Increment request ID to invalidate any in-flight requests
-        fetchRequestId.current += 1;
-        const localRequestId = fetchRequestId.current;
+      // Commit the new selections immediately, but NEVER the snapshot's `itens`
+      // (owned exclusively by the async write-backs below). This keeps the
+      // no-clobber invariant regardless of caller timing.
+      setCategories((prev) =>
+        commitSelectionsPreservingItems(updatedCategories, prev)
+      );
 
-        try {
-          const students = await performStudentFetch(
-            selectedSchoolIds,
-            selectedSchoolYearIds,
-            selectedClassIds,
-            localRequestId
-          );
+      // Dynamic TURMA fetching: react to school/série selection changes
+      if (schoolIdsChanged || schoolYearIdsChanged) {
+        await handleClassesChange(selectedSchoolIds, selectedSchoolYearIds);
+      }
 
-          if (students === null) {
-            return; // Request was invalidated
-          }
-
-          handleSuccessfulFetch(students, updatedCategories, localRequestId);
-        } catch (error) {
-          handleFetchError(error, updatedCategories, localRequestId);
-        }
-      } else if (shouldFetchStudents && studentsCategory) {
-        // If no classes selected after a change, clear students
-        fetchRequestId.current += 1;
-        const finalCategories = clearStudentsFromCategories(updatedCategories);
-        setCategories(finalCategories);
-      } else {
-        // No relevant changes (only student selections changed), just update categories as-is
-        setCategories(updatedCategories);
+      // Dynamic ALUNOS fetching: react to school/série/turma selection changes
+      // (skipped when only student selections changed)
+      if (shouldFetchStudents) {
+        await handleStudentsChange(
+          selectedSchoolIds,
+          selectedSchoolYearIds,
+          selectedClassIds,
+          studentsCategory
+        );
       }
     },
     [
       apiClient,
       customFetchStudents,
       setCategories,
-      performStudentFetch,
-      handleSuccessfulFetch,
-      handleFetchError,
+      handleClassesChange,
+      handleStudentsChange,
     ]
   );
 


### PR DESCRIPTION
## Problema 1
No seletor de destinatários (Escola → Série → Turma → Alunos) de "Enviar aula
recomendada"/"Enviar atividade", as **Turmas não apareciam para o gestor regional**
("Sem dados"), mesmo com escolas e séries selecionadas.

## Causa
`loadCategoriesData` buscava `/school`, `/schoolYear` e `/classes` só na 1ª página
(limit 10) e filtrava no cliente. Para o regional, `/classes` tem ~14 mil turmas →
a 1ª página quase nunca casava com as séries carregadas.

## Mudança
- **Turma dinâmica**: deixa de ser carregada eager; passa a ser buscada por
  escola+série selecionadas via `fetchClassesByFilters` (novo), espelhando o padrão
  de Alunos. Write-back funcional (sem clobber entre turma/alunos), race-guard
  próprio e guard `!apiClient` (protege consumidores que já fornecem turmas prontas,
  ex.: AlertsManager/professor).
- **Escola/Série paginadas**: `loadCategoriesData` busca todas as páginas
  (`fetchAllPages`, limit 100), agora **em paralelo** (página 1 → totalPages →
  2..N via `Promise.all`), reduzindo o waterfall.
- `useCategorySync` re-sincroniza `turma` além de `students` (assinatura por ids).
- Formato de fio do filtro: **CSV** (`schoolId=a,b`) — axios serializa array com
  colchetes que o parser default do Fastify não dobra; CSV é agnóstico de serializer.

## Dependências de backend
- Escopo por gestor em `/classes`, `/school`, `/schoolYear`: **#565 (mergeado)**
- Split CSV no `/classes`: **#568** (necessário para multi-seleção; seleção única
  já funciona sem ele)

## Testes
Suíte completa verde (9935 testes). Novos: `fetchClassesByFilters`, `fetchAllPages`
(paralelo + ordem), `useDynamicStudentFetching` (cascata turma→alunos, no-clobber,
race), `useCategorySync`.

> Após merge: bump de versão da lib e atualização dos consumidores.

## Problema 2
Na lista de aulas recomendadas ("/aulas-recomendadas"), os botões de
**editar/excluir** passam a aparecer apenas nas aulas criadas pelo próprio usuário.
O endpoint `/recommended-class/history` já traz o `creator` de cada aula.

## Mudança
- `RecommendedClassTableItem` ganha `creatorId`; o transform popula
  `creatorId: item.creator?.id ?? null`.
- `RecommendedLessonsHistory` ganha prop opcional `currentUserId`; a coluna de ações
  esconde editar/excluir quando `currentUserId && row.creatorId !== currentUserId`.
- **Opt-in**: sem `currentUserId`, comportamento inalterado (protege o professor-web,
  que não passa a prop). Espelha o precedente de `UnifiedHistoryPage` (atividades).
  Compara `creator.id === user.id`.

## Consumidor
Requer o gestor passar `currentUserId` (PR no frontend-gestor-web). Professor-web
inalterado.

## Testes
Suites tocadas verdes: dono mostra / não-dono esconde / creator null esconde / sem
`currentUserId` inalterado. typecheck + lint limpos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Class options now load dynamically based on the selected school year, with pagination handled in the background.
  * History actions can now be limited to items created by the current user.

* **Bug Fixes**
  * Improved category loading so send dialogs open faster and avoid unnecessary class requests.
  * Fixed category updates to keep class and student selections in sync without overwriting recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->