### PR TITLE
AE-2878 - feat(calendar): add loading overlay prop to Calendar

### DIFF
--- a/src/components/Calendar/Calendar.test.tsx
+++ b/src/components/Calendar/Calendar.test.tsx
@@ -515,5 +515,21 @@ describe('Calendar', () => {
       fireEvent.click(nextButton);
       expect(mockOnMonthChange).toHaveBeenCalledTimes(1);
     });
+
+    it('stacks the header above the overlay so navigation stays clickable', () => {
+      // jsdom does not hit-test, so assert structurally that the header wrapper
+      // has a higher stacking order than the z-10 overlay — otherwise the
+      // absolute overlay would intercept clicks in a real browser.
+      render(<Calendar variant="navigation" loading />);
+
+      const overlay = screen.getByTestId('calendar-loading');
+      expect(overlay).toHaveClass('z-10');
+
+      const header = screen
+        .getByLabelText('Próximo mês')
+        .closest('.z-20') as HTMLElement | null;
+      expect(header).not.toBeNull();
+      expect(header).toHaveClass('relative', 'z-20');
+    });
   });
 });

--- a/src/components/Calendar/Calendar.test.tsx
+++ b/src/components/Calendar/Calendar.test.tsx
@@ -479,4 +479,41 @@ describe('Calendar', () => {
       expect(nonTodayElement).not.toHaveAttribute('aria-current');
     });
   });
+
+  describe('Loading state', () => {
+    it('should not render the loading overlay by default', () => {
+      render(<Calendar variant="navigation" />);
+      expect(screen.queryByTestId('calendar-loading')).not.toBeInTheDocument();
+    });
+
+    it('should render the loading overlay when loading is true (navigation)', () => {
+      render(<Calendar variant="navigation" loading />);
+      const overlay = screen.getByTestId('calendar-loading');
+      expect(overlay).toBeInTheDocument();
+      expect(overlay).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('should render the loading overlay when loading is true (selection)', () => {
+      render(<Calendar variant="selection" loading />);
+      expect(screen.getByTestId('calendar-loading')).toBeInTheDocument();
+    });
+
+    it('should keep month navigation visible and interactive while loading', () => {
+      const selectedDate = new Date(2025, 0, 15); // January 2025
+      render(
+        <Calendar
+          variant="navigation"
+          loading
+          selectedDate={selectedDate}
+          onMonthChange={mockOnMonthChange}
+        />
+      );
+
+      // The overlay must not hide/replace the calendar header or nav buttons.
+      expect(screen.getByText(/Janeiro 2025/)).toBeInTheDocument();
+      const nextButton = screen.getByLabelText('Próximo mês');
+      fireEvent.click(nextButton);
+      expect(mockOnMonthChange).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -367,8 +367,9 @@ const Calendar = ({
     return (
       <div className={cn('bg-background rounded-xl pt-6 relative', className)}>
         {loadingOverlay}
-        {/* Compact header */}
-        <div className="flex items-center justify-between mb-4 px-6">
+        {/* Compact header — stacks above the loading overlay so month
+            navigation stays clickable while loading. */}
+        <div className="flex items-center justify-between mb-4 px-6 relative z-20">
           <div className="relative" ref={monthPickerContainerRef}>
             <button
               onClick={toggleMonthPicker}
@@ -520,8 +521,9 @@ const Calendar = ({
   return (
     <div className={cn('bg-background rounded-xl p-4 relative', className)}>
       {loadingOverlay}
-      {/* Full header */}
-      <div className="flex items-center justify-between mb-3.5">
+      {/* Full header — stacks above the loading overlay so month navigation
+          stays clickable while loading. */}
+      <div className="flex items-center justify-between mb-3.5 relative z-20">
         <div className="relative" ref={monthPickerContainerRef}>
           <button
             onClick={toggleMonthPicker}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -54,6 +54,12 @@ export interface CalendarProps {
   activities?: Record<string, CalendarActivity[]>;
   /** Show activities indicators */
   showActivities?: boolean;
+  /**
+   * When true, a subtle overlay + spinner is shown over the grid while the
+   * month header and navigation stay visible and interactive. Lets consumers
+   * refetch a month's activities without hiding/resetting the whole calendar.
+   */
+  loading?: boolean;
   /** Additional CSS classes */
   className?: string;
 }
@@ -215,6 +221,7 @@ const Calendar = ({
   onMonthChange,
   activities = {},
   showActivities = true,
+  loading = false,
   className = '',
 }: CalendarProps) => {
   const [currentDate, setCurrentDate] = useState(selectedDate || new Date());
@@ -335,10 +342,31 @@ const Calendar = ({
     onDateSelect?.(day.date);
   };
 
+  // Subtle loading overlay: fades the grid and shows a spinner while a month's
+  // activities are (re)fetched. The month header/navigation stay above it and
+  // remain interactive. The faded backdrop and the spinner are separate layers
+  // so the spinner keeps full opacity.
+  const loadingOverlay = loading ? (
+    <div
+      className="absolute inset-0 z-10 rounded-xl"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      data-testid="calendar-loading"
+    >
+      <div className="absolute inset-0 rounded-xl bg-background opacity-60" />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="sr-only">Carregando atividades</span>
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-border-200 border-t-primary-800" />
+      </div>
+    </div>
+  ) : null;
+
   // Navigation variant (compact)
   if (variant === 'navigation') {
     return (
-      <div className={cn('bg-background rounded-xl pt-6', className)}>
+      <div className={cn('bg-background rounded-xl pt-6 relative', className)}>
+        {loadingOverlay}
         {/* Compact header */}
         <div className="flex items-center justify-between mb-4 px-6">
           <div className="relative" ref={monthPickerContainerRef}>
@@ -490,7 +518,8 @@ const Calendar = ({
 
   // Selection variant (full)
   return (
-    <div className={cn('bg-background rounded-xl p-4', className)}>
+    <div className={cn('bg-background rounded-xl p-4 relative', className)}>
+      {loadingOverlay}
       {/* Full header */}
       <div className="flex items-center justify-between mb-3.5">
         <div className="relative" ref={monthPickerContainerRef}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional loading state to the calendar, showing a loading overlay while content remains visible.
  * The loading indicator now works across both calendar views and defaults to off.

* **Tests**
  * Added coverage for loading behavior, including overlay visibility, accessibility state, and interaction availability during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->