### PR TITLE
AE-2838 - fix(badge): correct misplaced notification badge on the bell icon

### DIFF
--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -295,6 +295,8 @@ describe('Badge', () => {
       render(<Badge variant="notification" notificationActive={true} />);
       const dot = screen.getByTestId('notification-dot');
       expect(dot).toBeInTheDocument();
+      // The dot must sit at the bell's top-right corner (not over its body).
+      expect(dot).toHaveClass('absolute', 'top-[2px]', 'right-[2px]');
     });
 
     it('does not show notification dot when inactive', () => {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -157,7 +157,7 @@ const Badge = ({
         {notificationActive && (
           <span
             data-testid="notification-dot"
-            className="absolute top-[5px] right-[10px] block h-2 w-2 rounded-full bg-indicator-error ring-2 ring-white"
+            className="absolute top-[2px] right-[2px] block h-2 w-2 rounded-full bg-indicator-error ring-2 ring-white"
           />
         )}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the notification badge dot position for a more precise alignment.
  * Updated validation to ensure the notification indicator appears with the expected placement styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->