### PR TITLE
AE-2894: using city instead of nre in map

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -1732,4 +1732,30 @@ describe('ChoroplethMap isManagedRegion', () => {
       expect(mockAddGeoJson).toHaveBeenCalledTimes(4);
     });
   });
+
+  it('re-adds GeoJSON data when only groupName changes (NRE reassignment)', async () => {
+    const { rerender } = render(
+      <ChoroplethMap
+        data={[{ ...managedRegion, groupName: 'NRE A' }]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(1);
+    });
+
+    // Only the NRE (groupName) changes while every other field stays the same:
+    // signature must differ so stableData/nreBoundaries recompute.
+    rerender(
+      <ChoroplethMap
+        data={[{ ...managedRegion, groupName: 'NRE B' }]}
+        apiKey={mockApiKey}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -312,7 +312,7 @@ const ChoroplethMap = ({
       data
         .map(
           (d) =>
-            `${d.id}:${d.value}:${d.name}:${d.accessCount}:${
+            `${d.id}:${d.value}:${d.name}:${d.groupName ?? ''}:${d.accessCount}:${
               d.isManagedRegion === false ? 0 : 1
             }`
         )

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -101,7 +101,9 @@ const getColorClass = (
 };
 
 /**
- * Compute NRE boundary polygons by merging city polygons that share the same regionName
+ * Compute NRE boundary polygons by merging city polygons that share the same
+ * group (the NRE). Grouping uses `groupName` (the NRE label); when a region has
+ * no `groupName`, it falls back to its own `name` so it forms its own group.
  * @param data - Array of region data with individual city GeoJSON features
  * @returns Array of GeoJSON features representing NRE boundaries
  */
@@ -110,9 +112,10 @@ const computeNREBoundaries = (
 ): Feature<Polygon | MultiPolygon>[] => {
   const groups = new Map<string, RegionData[]>();
   data.forEach((region) => {
-    const existing = groups.get(region.name) ?? [];
+    const groupKey = region.groupName ?? region.name;
+    const existing = groups.get(groupKey) ?? [];
     existing.push(region);
-    groups.set(region.name, existing);
+    groups.set(groupKey, existing);
   });
 
   const boundaries: Feature<Polygon | MultiPolygon>[] = [];
@@ -458,14 +461,15 @@ const ChoroplethMap = ({
       }
     });
 
-    // Build NRE feature index for O(1) lookup by region name
-    const nreFeatureIndex = new Map<string, google.maps.Data.Feature[]>();
+    // Build per-city feature index for O(1) lookup by region id.
+    // Hover highlight and click-zoom operate per municipality (not per NRE).
+    const cityFeatureIndex = new Map<string, google.maps.Data.Feature[]>();
     map.data.forEach((f) => {
-      const name = f.getProperty('regionName') as string;
-      if (name) {
-        const list = nreFeatureIndex.get(name) ?? [];
+      const id = f.getProperty('regionId') as string;
+      if (id) {
+        const list = cityFeatureIndex.get(id) ?? [];
         list.push(f);
-        nreFeatureIndex.set(name, list);
+        cityFeatureIndex.set(id, list);
       }
     });
 
@@ -574,32 +578,31 @@ const ChoroplethMap = ({
       hoverAnimationsRef.current.set(groupKey, requestAnimationFrame(animate));
     };
 
-    // Handle hover events - highlight all cities in the same NRE
-    let currentNRE: string | null = null;
+    // Handle hover events - highlight only the hovered city
+    let currentCityId: string | null = null;
     let revertTimeout: ReturnType<typeof setTimeout> | null = null;
 
     /**
-     * Collect all features belonging to a given NRE name (O(1) index lookup)
-     * @param nreName - NRE region name to match
+     * Collect all features belonging to a given city id (O(1) index lookup)
+     * @param cityId - Region (city) id to match
      * @returns Array of matching features
      */
-    const collectNREFeatures = (
-      nreName: string
+    const collectCityFeatures = (
+      cityId: string
     ): google.maps.Data.Feature[] => {
-      return nreFeatureIndex.get(nreName) ?? [];
+      return cityFeatureIndex.get(cityId) ?? [];
     };
 
     const mouseoverListener = map.data.addListener(
       'mouseover',
       (event: google.maps.Data.MouseEvent) => {
-        // Cancel pending revert (when moving between cities in same NRE)
+        // Cancel pending revert (when moving between adjacent cities)
         if (revertTimeout) {
           clearTimeout(revertTimeout);
           revertTimeout = null;
         }
 
         const regionId = event.feature.getProperty('regionId') as string;
-        const regionName = event.feature.getProperty('regionName') as string;
         const region = stableData.find((r) => r.id === regionId);
         if (region) {
           setHoveredRegion(region);
@@ -611,28 +614,35 @@ const ChoroplethMap = ({
           }
         }
 
-        // Animate highlight for all features in the same NRE group
-        if (currentNRE !== regionName) {
-          if (currentNRE) {
-            const prevFeatures = collectNREFeatures(currentNRE);
-            animateHover(currentNRE, prevFeatures, 1, TARGET_OPACITY, 1, 0.5);
+        // Animate highlight for the hovered city only
+        if (currentCityId !== regionId) {
+          if (currentCityId) {
+            const prevFeatures = collectCityFeatures(currentCityId);
+            animateHover(
+              currentCityId,
+              prevFeatures,
+              1,
+              TARGET_OPACITY,
+              1,
+              0.5
+            );
           }
-          currentNRE = regionName;
-          const nreFeatures = collectNREFeatures(regionName);
-          animateHover(regionName, nreFeatures, TARGET_OPACITY, 1, 0.5, 1);
+          currentCityId = regionId;
+          const cityFeatures = collectCityFeatures(regionId);
+          animateHover(regionId, cityFeatures, TARGET_OPACITY, 1, 0.5, 1);
         }
       }
     );
 
     const mouseoutListener = map.data.addListener('mouseout', () => {
-      // Defer revert to avoid flicker when moving between cities in same NRE
+      // Defer revert to avoid flicker when moving between adjacent cities
       revertTimeout = setTimeout(() => {
         setHoveredRegion(null);
         setInfoPosition(null);
-        if (currentNRE) {
-          const prevFeatures = collectNREFeatures(currentNRE);
-          animateHover(currentNRE, prevFeatures, 1, TARGET_OPACITY, 1, 0.5);
-          currentNRE = null;
+        if (currentCityId) {
+          const prevFeatures = collectCityFeatures(currentCityId);
+          animateHover(currentCityId, prevFeatures, 1, TARGET_OPACITY, 1, 0.5);
+          currentCityId = null;
         }
       }, 50);
     });
@@ -650,34 +660,33 @@ const ChoroplethMap = ({
     );
 
     /**
-     * Compute bounds for all features matching a given NRE name
-     * @param nreName - NRE region name to match
+     * Compute bounds for all features matching a given city id
+     * @param cityId - Region (city) id to match
      * @returns LatLngBounds encompassing all matching features
      */
-    const computeNREBounds = (nreName: string): google.maps.LatLngBounds => {
-      const nreBounds = new google.maps.LatLngBounds();
-      for (const f of collectNREFeatures(nreName)) {
-        f.getGeometry()?.forEachLatLng((latLng) => {
-          nreBounds.extend(latLng);
+    const computeCityBounds = (cityId: string): google.maps.LatLngBounds => {
+      const cityBounds = new google.maps.LatLngBounds();
+      for (const f of collectCityFeatures(cityId)) {
+        f.getGeometry()?.forEachLatLng((latLng: google.maps.LatLng) => {
+          cityBounds.extend(latLng);
         });
       }
-      return nreBounds;
+      return cityBounds;
     };
 
-    // Handle click events - zoom to NRE region
+    // Handle click events - zoom to the clicked city
     const clickListener = map.data.addListener(
       'click',
       (event: google.maps.Data.MouseEvent) => {
         const regionId = event.feature.getProperty('regionId') as string;
-        const regionName = event.feature.getProperty('regionName') as string;
         const region = stableData.find((r) => r.id === regionId);
         if (region && region.isManagedRegion !== false) {
           onRegionClickRef.current?.(region);
         }
 
-        const nreBounds = computeNREBounds(regionName);
-        if (!nreBounds.isEmpty()) {
-          map.fitBounds(nreBounds, 20);
+        const cityBounds = computeCityBounds(regionId);
+        if (!cityBounds.isEmpty()) {
+          map.fitBounds(cityBounds, 20);
         }
       }
     );

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -4,10 +4,17 @@ import type { Feature, MultiPolygon, Polygon } from 'geojson';
  * Region data interface for choropleth map
  */
 export interface RegionData {
-  /** Unique identifier for the region */
+  /** Unique identifier for the region (per-city) */
   id: string;
-  /** Display name of the region */
+  /** Display name of the region — the municipality (city) name */
   name: string;
+  /**
+   * Grouping label used only to draw the NRE outline that visually groups the
+   * cities of the same NRE. When omitted, the region's own `name` is used as the
+   * group (each region is its own group). Coloring, tooltip, hover and zoom are
+   * per-city (keyed on `id`/`name`), independent of this field.
+   */
+  groupName?: string;
   /** Code identifier for the region */
   code?: string | null;
   /** Normalized value between 0 and 1 for color classification */

--- a/src/hooks/useMapData.test.ts
+++ b/src/hooks/useMapData.test.ts
@@ -104,7 +104,9 @@ describe('useMapData', () => {
 
       expect(result.current.data).toHaveLength(1);
       expect(result.current.data[0].id).toBe('4106902');
-      expect(result.current.data[0].name).toBe('NRE Curitiba');
+      // name is the city; the NRE goes to groupName (outline grouping only)
+      expect(result.current.data[0].name).toBe('Curitiba');
+      expect(result.current.data[0].groupName).toBe('NRE Curitiba');
       expect(result.current.data[0].value).toBe(85);
       expect(result.current.data[0].accessCount).toBe(1200);
       expect(result.current.data[0].isManagedRegion).toBe(true);
@@ -187,6 +189,7 @@ describe('useMapData', () => {
       });
 
       expect(result.current.data[0].name).toBe('Curitiba');
+      expect(result.current.data[0].groupName).toBeUndefined();
     });
 
     it('should use empty string when GEOCODIGO and NOME are missing', async () => {

--- a/src/hooks/useMapData.ts
+++ b/src/hooks/useMapData.ts
@@ -27,8 +27,12 @@ export interface UseMapDataReturn {
 }
 
 /**
- * Transform enriched GeoJSON features to ChoroplethMap region data
- * Each city feature has NRE, value, totalAccess from backend enrichment
+ * Transform enriched GeoJSON features to ChoroplethMap region data.
+ *
+ * Each feature is one municipality: `name` is the city and `value`/`accessCount`
+ * are its own per-city metric (colored individually). `groupName` carries the
+ * NRE label used only to draw the grouping outline.
+ *
  * @param geoJSON - Enriched GeoJSON FeatureCollection from backend
  * @returns Array of region data for ChoroplethMap
  */
@@ -37,9 +41,10 @@ function transformGeoJSONFeatures(
 ): ChoroplethRegionData[] {
   return geoJSON.features.map((feature) => ({
     id: feature.properties?.GEOCODIGO || feature.properties?.NOME || '',
-    name: feature.properties?.NRE
+    name: feature.properties?.NOME || '',
+    groupName: feature.properties?.NRE
       ? `NRE ${feature.properties.NRE}`
-      : feature.properties?.NOME || '',
+      : undefined,
     value: feature.properties?.value ?? 0,
     accessCount: feature.properties?.totalAccess ?? 0,
     geoJson: feature,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Map interactions now focus on individual municipalities, with clearer hover highlighting and smoother visual transitions.
  * Clicking a municipality zooms directly to its boundaries.
  * Municipality names are displayed separately from regional grouping labels for clearer map information.
  * Regional outlines continue to group areas appropriately, including locations without a grouping label.

* **Bug Fixes**
  * Improved map feature selection and highlighting when municipalities contain multiple geographic areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->