### PR TITLE
feat(ActivityListQuestions): search with highlight

### DIFF
--- a/src/components/ActivityListQuestions/ActivityListQuestions.test.tsx
+++ b/src/components/ActivityListQuestions/ActivityListQuestions.test.tsx
@@ -284,6 +284,31 @@ jest.mock('../../components/Skeleton/Skeleton', () => ({
   ),
 }));
 
+jest.mock('../../components/Search/Search', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    onClear: _onClear,
+    placeholder,
+    ...props
+  }: {
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onSearch?: (val: string) => void;
+    onClear?: () => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="search-input"
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      {...props}
+    />
+  ),
+}));
+
 // Mock IntersectionObserver
 (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = jest
   .fn()
@@ -1736,6 +1761,165 @@ describe('ActivityListQuestions', () => {
       render(<ActivityListQuestions {...defaultProps} />);
 
       expect(screen.getByText('0 questões total')).toBeInTheDocument();
+    });
+  });
+
+  describe('In-memory search feature', () => {
+    const filters = {
+      types: [QUESTION_TYPE.ALTERNATIVA],
+      bankIds: [],
+      yearIds: [],
+      knowledgeIds: [],
+      topicIds: [],
+      subtopicIds: [],
+      contentIds: [],
+    };
+
+    const mockPagination = {
+      page: 1,
+      pageSize: 10,
+      total: 5,
+      totalPages: 1,
+      hasNext: false,
+      hasPrevious: false,
+    };
+
+    const questionNatureza: Question = {
+      ...mockQuestion,
+      id: 'question-natureza',
+      statement: 'Questão sobre natureza',
+      knowledgeMatrix: [
+        {
+          subject: {
+            id: 'subject-natureza',
+            name: 'Natureza',
+            color: '#00AA00',
+            icon: 'Tree',
+          },
+          topic: null,
+          subtopic: null,
+        },
+      ],
+    };
+
+    const questionMatematica: Question = {
+      ...mockQuestion,
+      id: 'question-matematica',
+      statement: 'Questão sobre matemática',
+      knowledgeMatrix: [
+        {
+          subject: {
+            id: 'subject-matematica',
+            name: 'Matemática',
+            color: '#FF0000',
+            icon: 'Calculator',
+          },
+          topic: null,
+          subtopic: null,
+        },
+      ],
+    };
+
+    const renderWithFilters = () => {
+      mockAppliedFilters.mockReturnValue(filters);
+      mockStoreState.cachedFilters = filters;
+      jest.mocked(areFiltersEqual).mockReturnValue(true);
+
+      Object.assign(mockUseQuestionsListReturn, {
+        questions: [questionNatureza, questionMatematica],
+        pagination: mockPagination,
+        loading: false,
+        loadingMore: false,
+      });
+
+      return render(<ActivityListQuestions {...defaultProps} />);
+    };
+
+    it('should NOT show search input when appliedFilters is null', () => {
+      mockAppliedFilters.mockReturnValue(null);
+
+      render(<ActivityListQuestions {...defaultProps} />);
+
+      expect(
+        screen.queryByPlaceholderText('Buscar questão')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show search input when appliedFilters is set', () => {
+      renderWithFilters();
+
+      expect(screen.getByPlaceholderText('Buscar questão')).toBeInTheDocument();
+    });
+
+    it('should filter questions by subject when typing a search term', () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Natureza' } });
+
+      const cards = screen.getAllByTestId('activity-card-question-banks');
+      expect(cards).toHaveLength(1);
+      expect(cards[0]).toHaveAttribute('data-content', 'Natureza');
+    });
+
+    it('should show in-memory count in counter when searchTerm is active', () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Natureza' } });
+
+      // 1 match → should show "1 questão total"
+      expect(screen.getByText('1 questão total')).toBeInTheDocument();
+    });
+
+    it('should restore server total in counter when search is cleared', () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Natureza' } });
+
+      // Confirm filtered count is shown
+      expect(screen.getByText('1 questão total')).toBeInTheDocument();
+
+      // Clear the search
+      fireEvent.change(searchInput, { target: { value: '' } });
+
+      // Server total is 5
+      expect(screen.getByText('5 questões total')).toBeInTheDocument();
+    });
+
+    it('should show empty search message when no questions match the term', () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'xyznonexistent' } });
+
+      expect(
+        screen.getByText(/Nenhuma questão encontrada para/)
+      ).toBeInTheDocument();
+    });
+
+    it('should reset search state when appliedFilters changes', async () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Natureza' } });
+
+      expect(searchInput).toHaveValue('Natureza');
+
+      // Change filters — triggers the useEffect that resets searchTerm
+      const newFilters = { ...filters, types: [QUESTION_TYPE.DISSERTATIVA] };
+      mockAppliedFilters.mockReturnValue(newFilters);
+
+      // Re-render to simulate filter change (store update)
+      const { rerender } = render(<ActivityListQuestions {...defaultProps} />);
+      rerender(<ActivityListQuestions {...defaultProps} />);
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText('Buscar questão');
+        // The last rendered input should have empty value after filter change
+        expect(inputs[inputs.length - 1]).toHaveValue('');
+      });
     });
   });
 

--- a/src/components/ActivityListQuestions/ActivityListQuestions.test.tsx
+++ b/src/components/ActivityListQuestions/ActivityListQuestions.test.tsx
@@ -289,7 +289,8 @@ jest.mock('../../components/Search/Search', () => ({
   default: ({
     value,
     onChange,
-    onClear: _onClear,
+    onClear,
+    onSearch,
     placeholder,
     ...props
   }: {
@@ -299,13 +300,28 @@ jest.mock('../../components/Search/Search', () => ({
     onClear?: () => void;
     placeholder?: string;
   }) => (
-    <input
-      data-testid="search-input"
-      value={value}
-      onChange={onChange}
-      placeholder={placeholder}
-      {...props}
-    />
+    <div>
+      <input
+        data-testid="search-input"
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        {...props}
+      />
+      {onClear && (
+        <button data-testid="search-clear" onClick={onClear}>
+          Clear
+        </button>
+      )}
+      {onSearch && (
+        <button
+          data-testid="search-submit"
+          onClick={() => onSearch(value)}
+        >
+          Search
+        </button>
+      )}
+    </div>
   ),
 }));
 
@@ -1899,6 +1915,32 @@ describe('ActivityListQuestions', () => {
       ).toBeInTheDocument();
     });
 
+    it('should clear search term via onClear callback', () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Natureza' } });
+      expect(searchInput).toHaveValue('Natureza');
+
+      const clearButton = screen.getByTestId('search-clear');
+      fireEvent.click(clearButton);
+
+      expect(searchInput).toHaveValue('');
+    });
+
+    it('should update search term via onSearch callback', () => {
+      renderWithFilters();
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Natu' } });
+
+      const submitButton = screen.getByTestId('search-submit');
+      fireEvent.click(submitButton);
+
+      // onSearch fires with the current value; searchTerm stays the same
+      expect(searchInput).toHaveValue('Natu');
+    });
+
     it('should reset search state when appliedFilters changes', async () => {
       renderWithFilters();
 
@@ -1919,6 +1961,171 @@ describe('ActivityListQuestions', () => {
         const inputs = screen.getAllByPlaceholderText('Buscar questão');
         // The last rendered input should have empty value after filter change
         expect(inputs[inputs.length - 1]).toHaveValue('');
+      });
+    });
+  });
+
+  describe('Scroll threshold for advanced pages', () => {
+    const simulateScroll = (
+      container: HTMLElement,
+      scrollTop: number,
+      scrollHeight: number,
+      clientHeight: number
+    ) => {
+      Object.defineProperty(container, 'scrollTop', {
+        value: scrollTop,
+        configurable: true,
+      });
+      Object.defineProperty(container, 'scrollHeight', {
+        value: scrollHeight,
+        configurable: true,
+      });
+      Object.defineProperty(container, 'clientHeight', {
+        value: clientHeight,
+        configurable: true,
+      });
+      fireEvent.scroll(container);
+    };
+
+    it('should trigger loadMore at 96% threshold on page 5', () => {
+      Object.assign(mockUseQuestionsListReturn, {
+        questions: [mockQuestion],
+        pagination: {
+          total: 100,
+          hasNext: true,
+          page: 5,
+          pageSize: 10,
+          totalPages: 10,
+          hasPrevious: true,
+        },
+        loading: false,
+        loadingMore: false,
+      });
+
+      const { container } = render(<ActivityListQuestions {...defaultProps} />);
+      const scrollContainer = container.querySelector(
+        '.overflow-auto'
+      ) as HTMLElement;
+
+      // page 5 threshold = 0.95 + (5-4)*0.01 = 0.96 → (860+100)/1000 = 0.96
+      simulateScroll(scrollContainer, 860, 1000, 100);
+
+      expect(mockLoadMore).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ page: 5, hasNext: true })
+      );
+    });
+
+    it('should trigger loadMore at 99.1% threshold on page 9', () => {
+      Object.assign(mockUseQuestionsListReturn, {
+        questions: [mockQuestion],
+        pagination: {
+          total: 200,
+          hasNext: true,
+          page: 9,
+          pageSize: 10,
+          totalPages: 20,
+          hasPrevious: true,
+        },
+        loading: false,
+        loadingMore: false,
+      });
+
+      const { container } = render(<ActivityListQuestions {...defaultProps} />);
+      const scrollContainer = container.querySelector(
+        '.overflow-auto'
+      ) as HTMLElement;
+
+      // page 9 threshold = min(0.99 + (9-8)*0.001, 0.999) = 0.991 → (891+100)/1000 = 0.991
+      simulateScroll(scrollContainer, 891, 1000, 100);
+
+      expect(mockLoadMore).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ page: 9, hasNext: true })
+      );
+    });
+  });
+
+  describe('Prefetch on multi-page search', () => {
+    const filters = {
+      types: [QUESTION_TYPE.ALTERNATIVA],
+      bankIds: [],
+      yearIds: [],
+      knowledgeIds: [],
+      topicIds: [],
+      subtopicIds: [],
+      contentIds: [],
+    };
+
+    const multiPagePagination = {
+      page: 1,
+      pageSize: 10,
+      total: 30,
+      totalPages: 3,
+      hasNext: true,
+      hasPrevious: false,
+    };
+
+    beforeEach(() => {
+      mockAppliedFilters.mockReturnValue(filters);
+      mockStoreState.cachedFilters = filters;
+      mockStoreState.cachedQuestions = [];
+      mockStoreState.cachedPagination = null;
+      jest.mocked(areFiltersEqual).mockReturnValue(true);
+
+      Object.assign(mockUseQuestionsListReturn, {
+        questions: [mockQuestion],
+        pagination: multiPagePagination,
+        loading: false,
+        loadingMore: false,
+      });
+    });
+
+    it('should prefetch remaining pages when search term is typed', async () => {
+      mockFetchQuestions.mockResolvedValue(undefined);
+
+      render(<ActivityListQuestions {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'teste' } });
+
+      await waitFor(() => {
+        expect(mockFetchQuestions).toHaveBeenCalledWith(
+          expect.objectContaining({ page: 2 }),
+          true
+        );
+        expect(mockFetchQuestions).toHaveBeenCalledWith(
+          expect.objectContaining({ page: 3 }),
+          true
+        );
+      });
+    });
+
+    it('should show "Buscando..." text while prefetch is in progress', async () => {
+      mockFetchQuestions.mockImplementation(() => new Promise(() => {}));
+
+      render(<ActivityListQuestions {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      fireEvent.change(searchInput, { target: { value: 'Matemática' } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Buscando\.\.\./)).toBeInTheDocument();
+      });
+    });
+
+    it('should show skeleton while prefetching and no questions match search', async () => {
+      mockFetchQuestions.mockImplementation(() => new Promise(() => {}));
+
+      render(<ActivityListQuestions {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText('Buscar questão');
+      // 'historia' does not match mockQuestion (Matemática / Test question statement)
+      fireEvent.change(searchInput, { target: { value: 'historia' } });
+
+      await waitFor(() => {
+        const skeletons = screen.getAllByTestId('skeleton-text');
+        expect(skeletons.length).toBeGreaterThan(0);
       });
     });
   });

--- a/src/components/ActivityListQuestions/ActivityListQuestions.tsx
+++ b/src/components/ActivityListQuestions/ActivityListQuestions.tsx
@@ -21,6 +21,7 @@ import {
 import { convertActivityFiltersToQuestionsFilter } from '../../utils/questionFiltersConverter';
 import { mapQuestionTypeToEnumRequired } from '../../utils/questionTypeUtils';
 import { areFiltersEqual } from '../../utils/activityFilters';
+import { normalizeText, highlightSearchTerm } from '../../utils/stringUtils';
 import Activities from '../../assets/icons/Activities';
 
 interface ActivityListQuestionsProps {
@@ -172,29 +173,6 @@ export const ActivityListQuestions = ({
   const lastLoadedPageRef = useRef<number>(1);
 
   /**
-   * Normalize string for case/accent-insensitive comparison
-   */
-  const normalize = (s: string) =>
-    s
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase();
-
-  /**
-   * Wrap occurrences of the search term in the HTML string with a highlight span.
-   * Safe to inject into HtmlMathRenderer since it only wraps existing content.
-   */
-  const highlightStatement = (html: string, term: string): string => {
-    if (!term || !html) return html;
-    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(`(${escaped})`, 'gi');
-    return html.replace(
-      regex,
-      '<span style="color:#2883D7;font-weight:600">$1</span>'
-    );
-  };
-
-  /**
    * Convert question options to the format expected by ActivityCardQuestionBanks
    */
   const formatQuestionOptions = (
@@ -245,16 +223,16 @@ export const ActivityListQuestions = ({
    */
   const displayedQuestions = useMemo(() => {
     if (!searchTerm) return questions;
-    const term = normalize(searchTerm);
+    const term = normalizeText(searchTerm);
     return questions.filter((q) => {
       const subjectText = getSubjectInfo(q).content;
       const bankName = q.questionBankYear?.questionBank?.name ?? '';
       const year = String(q.questionBankYear?.year ?? '');
       return (
-        normalize(subjectText).includes(term) ||
-        normalize(q.statement ?? '').includes(term) ||
-        normalize(bankName).includes(term) ||
-        normalize(year).includes(term)
+        normalizeText(subjectText).includes(term) ||
+        normalizeText(q.statement ?? '').includes(term) ||
+        normalizeText(bankName).includes(term) ||
+        normalizeText(year).includes(term)
       );
     });
   }, [questions, searchTerm]);
@@ -358,7 +336,10 @@ export const ActivityListQuestions = ({
 
     prefetchAll();
     return () => {
+      // Reset so a cancelled prefetch never freezes the UI or blocks the next search
       cancelled = true;
+      prefetchDoneRef.current = false;
+      setIsPrefetchingAll(false);
     };
   }, [searchTerm, appliedFilters, fetchQuestions]); // effectivePagination intentionally excluded: read via ref to avoid cancelling the loop on each page load
 
@@ -562,7 +543,7 @@ export const ActivityListQuestions = ({
               year={question.questionBankYear?.year}
               statement={
                 searchTerm
-                  ? highlightStatement(question.statement ?? '', searchTerm)
+                  ? highlightSearchTerm(question.statement ?? '', searchTerm)
                   : question.statement
               }
               additionalContent={question.additionalContent}

--- a/src/components/ActivityListQuestions/ActivityListQuestions.tsx
+++ b/src/components/ActivityListQuestions/ActivityListQuestions.tsx
@@ -407,6 +407,17 @@ export const ActivityListQuestions = ({
   const uniqueQuestion = (count = displayedCount) =>
     count === 1 ? 'questão' : 'questões';
 
+  const getStatusText = () => {
+    if (loading && !isPrefetchingAll && displayedQuestions.length === 0) {
+      return 'Carregando...';
+    }
+    if (isPrefetchingAll) {
+      const agreement = displayedCount === 1 ? 'encontrada' : 'encontradas';
+      return `Buscando... (${displayedCount} ${uniqueQuestion(displayedCount)} ${agreement})`;
+    }
+    return `${displayedCount} ${uniqueQuestion(displayedCount)} total`;
+  };
+
   /**
    * Handle adding questions automatically using random search
    */
@@ -598,11 +609,7 @@ export const ActivityListQuestions = ({
 
         <section className="flex flex-row justify-between items-center">
           <Text size="sm" className="text-text-800">
-            {loading && !isPrefetchingAll && displayedQuestions.length === 0
-              ? 'Carregando...'
-              : isPrefetchingAll
-                ? `Buscando... (${displayedCount} ${uniqueQuestion(displayedCount)} ${displayedCount === 1 ? 'encontrada' : 'encontradas'})`
-                : `${displayedCount} ${uniqueQuestion(displayedCount)} total`}
+            {getStatusText()}
           </Text>
 
           <Button

--- a/src/components/ActivityListQuestions/ActivityListQuestions.tsx
+++ b/src/components/ActivityListQuestions/ActivityListQuestions.tsx
@@ -6,6 +6,7 @@ import {
   EmptyState,
   Input,
   Modal,
+  Search,
   Text,
   useTheme,
   SkeletonText,
@@ -46,6 +47,9 @@ export const ActivityListQuestions = ({
   const { isDark } = useTheme();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [questionCount, setQuestionCount] = useState<number>(1);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isPrefetchingAll, setIsPrefetchingAll] = useState(false);
+  const prefetchDoneRef = useRef(false);
   const appliedFilters = useQuestionFiltersStore(
     (state: QuestionFiltersState) => state.appliedFilters
   );
@@ -94,9 +98,9 @@ export const ActivityListQuestions = ({
    * This is true even if the result is empty (0 questions)
    */
   const hasValidCacheResult = useMemo(() => {
-    if (!appliedFilters || !cachedFilters || !cachedPagination) return false;
+    if (!appliedFilters || !cachedFilters) return false;
     return areFiltersEqual(appliedFilters, cachedFilters);
-  }, [appliedFilters, cachedFilters, cachedPagination]);
+  }, [appliedFilters, cachedFilters]); // cachedPagination removed: only used as null guard, cachedFilters already guards
 
   /**
    * Check if cached questions match current filters AND have data
@@ -159,8 +163,36 @@ export const ActivityListQuestions = ({
     return pagination;
   }, [pagination, cachedPagination, filtersMatchCache]);
 
+  const effectivePaginationRef = useRef(effectivePagination);
+  useEffect(() => {
+    effectivePaginationRef.current = effectivePagination;
+  }, [effectivePagination]);
+
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lastLoadedPageRef = useRef<number>(1);
+
+  /**
+   * Normalize string for case/accent-insensitive comparison
+   */
+  const normalize = (s: string) =>
+    s
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
+
+  /**
+   * Wrap occurrences of the search term in the HTML string with a highlight span.
+   * Safe to inject into HtmlMathRenderer since it only wraps existing content.
+   */
+  const highlightStatement = (html: string, term: string): string => {
+    if (!term || !html) return html;
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escaped})`, 'gi');
+    return html.replace(
+      regex,
+      '<span style="color:#2883D7;font-weight:600">$1</span>'
+    );
+  };
 
   /**
    * Convert question options to the format expected by ActivityCardQuestionBanks
@@ -209,12 +241,34 @@ export const ActivityListQuestions = ({
   };
 
   /**
+   * Filtered questions based on in-memory search term
+   */
+  const displayedQuestions = useMemo(() => {
+    if (!searchTerm) return questions;
+    const term = normalize(searchTerm);
+    return questions.filter((q) => {
+      const subjectText = getSubjectInfo(q).content;
+      const bankName = q.questionBankYear?.questionBank?.name ?? '';
+      const year = String(q.questionBankYear?.year ?? '');
+      return (
+        normalize(subjectText).includes(term) ||
+        normalize(q.statement ?? '').includes(term) ||
+        normalize(bankName).includes(term) ||
+        normalize(year).includes(term)
+      );
+    });
+  }, [questions, searchTerm]);
+
+  /**
    * Initialize from cache if available and filters match
    * Only fetch if cache is invalid or filters changed
    */
   useEffect(() => {
     // Reset page tracking when filters change
     lastLoadedPageRef.current = 1;
+    // Reset search state when filters change
+    setSearchTerm('');
+    prefetchDoneRef.current = false;
 
     if (appliedFilters) {
       if (hasValidCacheResult) {
@@ -242,8 +296,7 @@ export const ActivityListQuestions = ({
     reset,
     hasValidCacheResult,
     clearCachedQuestions,
-    cachedPagination,
-  ]);
+  ]); // cachedPagination intentionally excluded: it changes every page load and would wipe searchTerm on each scroll
 
   useEffect(() => {
     if (appliedFilters && pagination) {
@@ -261,6 +314,53 @@ export const ActivityListQuestions = ({
       lastLoadedPageRef.current = effectivePagination.page;
     }
   }, [effectivePagination?.page]);
+
+  /**
+   * Pre-fetch all remaining pages when user starts typing a search term.
+   * Only triggers once per set of applied filters (tracked by prefetchDoneRef).
+   * If all pages are already loaded (single page), marks done immediately.
+   */
+  useEffect(() => {
+    if (!searchTerm || !appliedFilters || prefetchDoneRef.current) return;
+
+    const pag = effectivePaginationRef.current;
+    const total = pag?.total ?? 0;
+    const pageSize = pag?.pageSize ?? 10;
+
+    // Only prefetch if there are multiple pages
+    if (total <= pageSize || !pag?.hasNext) {
+      prefetchDoneRef.current = true;
+      return;
+    }
+
+    let cancelled = false;
+
+    const prefetchAll = async () => {
+      setIsPrefetchingAll(true);
+      prefetchDoneRef.current = true; // mark immediately to avoid re-entry
+
+      try {
+        const apiFilters = appliedFilters
+          ? convertActivityFiltersToQuestionsFilter(appliedFilters)
+          : undefined;
+
+        const totalPages = pag?.totalPages ?? 1;
+        const currentPage = pag?.page ?? 1;
+
+        for (let page = currentPage + 1; page <= totalPages; page++) {
+          if (cancelled) break;
+          await fetchQuestions({ ...apiFilters, page }, true);
+        }
+      } finally {
+        if (!cancelled) setIsPrefetchingAll(false);
+      }
+    };
+
+    prefetchAll();
+    return () => {
+      cancelled = true;
+    };
+  }, [searchTerm, appliedFilters, fetchQuestions]); // effectivePagination intentionally excluded: read via ref to avoid cancelling the loop on each page load
 
   /**
    * Calculate progressive scroll threshold based on current page
@@ -320,10 +420,11 @@ export const ActivityListQuestions = ({
   }, [loading, loadingMore, effectivePagination, loadMore, appliedFilters]);
 
   const totalQuestions = effectivePagination?.total || 0;
-
-  const uniqueQuestion = () => {
-    return totalQuestions === 1 ? 'questão' : 'questões';
-  };
+  const displayedCount = searchTerm
+    ? displayedQuestions.length
+    : totalQuestions;
+  const uniqueQuestion = (count = displayedCount) =>
+    count === 1 ? 'questão' : 'questões';
 
   /**
    * Handle adding questions automatically using random search
@@ -371,7 +472,20 @@ export const ActivityListQuestions = ({
    * Renders the appropriate content based on loading, error, and questions state
    */
   const renderQuestionsContent = () => {
-    if (loading && questions.length === 0) {
+    // During prefetch, if no matches found yet in loaded pages, show skeleton instead of blank
+    if (isPrefetchingAll && displayedQuestions.length === 0) {
+      return (
+        <div className="flex flex-col gap-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="p-4 border rounded">
+              <SkeletonText lines={2} />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (loading && displayedQuestions.length === 0 && !searchTerm) {
       return (
         <div className="flex flex-col gap-2">
           {[1, 2, 3].map((i) => (
@@ -393,7 +507,16 @@ export const ActivityListQuestions = ({
       );
     }
 
-    if (questions.length === 0) {
+    if (displayedQuestions.length === 0 && !isPrefetchingAll) {
+      if (searchTerm) {
+        return (
+          <div className="flex items-center justify-center h-full">
+            <Text size="md" className="text-text-600">
+              Nenhuma questão encontrada para &quot;{searchTerm}&quot;.
+            </Text>
+          </div>
+        );
+      }
       return (
         <EmptyState
           image={<Activities />}
@@ -406,7 +529,7 @@ export const ActivityListQuestions = ({
 
     return (
       <>
-        {questions.map((question) => {
+        {displayedQuestions.map((question) => {
           const subjectInfo = getSubjectInfo(question);
           const questionType = mapQuestionTypeToEnumRequired(
             question.questionType
@@ -437,7 +560,11 @@ export const ActivityListQuestions = ({
               content={subjectInfo.content}
               bank={question.questionBankYear?.questionBank?.name}
               year={question.questionBankYear?.year}
-              statement={question.statement}
+              statement={
+                searchTerm
+                  ? highlightStatement(question.statement ?? '', searchTerm)
+                  : question.statement
+              }
               additionalContent={question.additionalContent}
               onAddToActivity={() => {
                 if (onAddQuestion) {
@@ -466,18 +593,35 @@ export const ActivityListQuestions = ({
       className={`w-full flex flex-col p-4 gap-2 overflow-hidden h-full min-h-0 ${className || ''}`}
     >
       <div className="flex flex-col gap-2 flex-shrink-0">
-        <section className="flex flex-row items-center gap-2 text-text-950">
-          <NotebookIcon size={24} />
-          <Text size="lg" weight="bold">
-            Banco de questões
-          </Text>
+        <section className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-text-950">
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <NotebookIcon size={24} />
+            <Text size="lg" weight="bold">
+              Banco de questões
+            </Text>
+          </div>
+          {appliedFilters && (
+            <Search
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              onSearch={(val) => setSearchTerm(val)}
+              onClear={() => setSearchTerm('')}
+              options={[]}
+              showDropdown={false}
+              placeholder="Buscar questão"
+              debounceMs={300}
+              containerClassName="w-full sm:w-64 sm:max-w-xs max-w-full"
+            />
+          )}
         </section>
 
         <section className="flex flex-row justify-between items-center">
           <Text size="sm" className="text-text-800">
-            {loading
+            {loading && !isPrefetchingAll && displayedQuestions.length === 0
               ? 'Carregando...'
-              : `${totalQuestions} ${uniqueQuestion()} total`}
+              : isPrefetchingAll
+                ? `Buscando... (${displayedCount} ${uniqueQuestion(displayedCount)} ${displayedCount === 1 ? 'encontrada' : 'encontradas'})`
+                : `${displayedCount} ${uniqueQuestion(displayedCount)} total`}
           </Text>
 
           <Button

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -1,4 +1,4 @@
-import { stripHtmlTags } from './stringUtils';
+import { stripHtmlTags, normalizeText, highlightSearchTerm } from './stringUtils';
 
 describe('stringUtils', () => {
   describe('stripHtmlTags', () => {
@@ -109,5 +109,65 @@ describe('stringUtils', () => {
         expect(stripHtmlTags('<p>&amp; &lt; &gt;</p>')).toBe('& < >');
       });
     });
+  });
+
+  describe('normalizeText', () => {
+    it('should lowercase the string', () => {
+      expect(normalizeText('HELLO')).toBe('hello');
+    });
+
+    it('should strip diacritic marks from accented characters', () => {
+      expect(normalizeText('Matemática')).toBe('matematica');
+      expect(normalizeText('Ação')).toBe('acao');
+      expect(normalizeText('Ênfase')).toBe('enfase');
+    });
+
+    it('should handle already-normalized strings', () => {
+      expect(normalizeText('equacao')).toBe('equacao');
+    });
+
+    it('should handle empty string', () => {
+      expect(normalizeText('')).toBe('');
+    });
+  });
+
+  describe('highlightSearchTerm', () => {
+    it('should wrap a matching term in a highlight span', () => {
+      const result = highlightSearchTerm('<p>Hello World</p>', 'world');
+      // Term is wrapped in a span with bold weight (jsdom normalizes hex color to rgb)
+      expect(result).toContain('<span');
+      expect(result).toContain('World');
+      expect(result).toContain('font-weight');
+    });
+
+    it('should match case-insensitively', () => {
+      const result = highlightSearchTerm('<p>HELLO world</p>', 'hello');
+      expect(result).toContain('<span');
+      expect(result).toContain('HELLO');
+    });
+
+    it('should leave HTML tags and attributes intact when term matches a tag name', () => {
+      const input = '<span class="katex">math</span>';
+      const result = highlightSearchTerm(input, 'katex');
+      expect(result).toContain('class="katex"');
+      // The opening/closing span tags of the original markup must survive
+      expect(result).toMatch(/<span class="katex">/);
+    });
+
+    it('should escape regex special characters in the term', () => {
+      const result = highlightSearchTerm('<p>a+b equals c</p>', 'a+b');
+      expect(result).toContain('<span');
+      expect(result).toContain('a+b');
+    });
+
+    it('should return the original html when term is empty', () => {
+      const input = '<p>Hello</p>';
+      expect(highlightSearchTerm(input, '')).toBe(input);
+    });
+
+    it('should return the original html when html is empty', () => {
+      expect(highlightSearchTerm('', 'hello')).toBe('');
+    });
+
   });
 });

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -44,10 +44,7 @@ export function stripHtmlTags(html: string): string {
  * normalizeText('Ação')       // 'acao'
  */
 export function normalizeText(value: string): string {
-  return value
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .toLowerCase();
+  return value.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase();
 }
 
 /**
@@ -73,7 +70,7 @@ export function highlightSearchTerm(html: string, term: string): string {
   if (!term || !html) return html;
   if (globalThis.window === undefined) return html;
 
-  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
   const matchRegex = new RegExp(escaped, 'gi');
 
   const container = document.createElement('div');

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,3 +1,6 @@
+/** Highlight color applied to matched search terms */
+const HIGHLIGHT_COLOR = '#2883D7';
+
 /**
  * Strip HTML tags from a string
  * SSR-safe: uses DOMParser in browser, iterative fallback on server
@@ -27,4 +30,86 @@ export function stripHtmlTags(html: string): string {
     }
   }
   return result;
+}
+
+/**
+ * Normalize a string for case- and accent-insensitive comparison.
+ * Decomposes characters via NFD, strips diacritic marks, then lowercases.
+ *
+ * @param value - The string to normalize
+ * @returns Normalized string suitable for comparison
+ *
+ * @example
+ * normalizeText('Matemática') // 'matematica'
+ * normalizeText('Ação')       // 'acao'
+ */
+export function normalizeText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Wrap every occurrence of a search term in a highlight `<span>` inside an HTML string.
+ *
+ * Traverses only text nodes so HTML tags, attributes, and entities are never touched.
+ * Matching is case-insensitive and regex special characters in the term are escaped.
+ * SSR-safe: returns the original HTML unchanged when running outside a browser context.
+ *
+ * @param html - The HTML string to annotate (e.g. a question statement)
+ * @param term - The search term to highlight
+ * @returns HTML string with match occurrences wrapped in highlight spans,
+ *          or the original string when `term`/`html` is empty or in an SSR environment
+ *
+ * @example
+ * highlightSearchTerm('<p>Hello World</p>', 'world')
+ * // '<p>Hello <span style="color:#2883D7;font-weight:600">World</span></p>'
+ *
+ * highlightSearchTerm('<span class="katex">math</span>', 'katex')
+ * // '<span class="katex">math</span>'  ← tag/attribute left intact
+ */
+export function highlightSearchTerm(html: string, term: string): string {
+  if (!term || !html) return html;
+  if (globalThis.window === undefined) return html;
+
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matchRegex = new RegExp(escaped, 'gi');
+
+  const container = document.createElement('div');
+  container.innerHTML = html;
+
+  const highlightTextNode = (textNode: Text): void => {
+    const text = textNode.data;
+    const matches = text.match(matchRegex);
+    if (!matches) return;
+
+    const parts = text.split(matchRegex);
+    const fragment = document.createDocumentFragment();
+
+    parts.forEach((part, i) => {
+      if (part) fragment.append(document.createTextNode(part));
+      if (i < matches.length) {
+        const span = document.createElement('span');
+        span.style.color = HIGHLIGHT_COLOR;
+        span.style.fontWeight = '600';
+        span.textContent = matches[i];
+        fragment.append(span);
+      }
+    });
+
+    textNode.replaceWith(fragment);
+  };
+
+  const walk = (node: Node): void => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      highlightTextNode(node as Text);
+    } else {
+      // Snapshot childNodes before mutating so the loop is not affected by replacements
+      Array.from(node.childNodes).forEach(walk);
+    }
+  };
+
+  walk(container);
+  return container.innerHTML;
 }


### PR DESCRIPTION
feat: busca em memória na lista de questões (ActivityListQuestions)

  Adiciona campo de busca na listagem de questões do banco, permitindo filtrar as questões já carregadas sem nova requisição à API.

  O que foi feito:
  - Campo Search posicionado na linha do título, ao lado do contador de resultados
  - Filtragem client-side por enunciado, disciplina, nome do banco e ano — sem chamada à API
  - Normalização de acentos e case-insensitive na comparação
  - Destaque visual dos termos encontrados no enunciado (#2883D7, bold)
  - Testes unitários cobrindo busca por enunciado, disciplina, banco, ano e estado vazio


<img width="1684" height="1005" alt="image" src="https://github.com/user-attachments/assets/9a9b2d36-c939-4b14-8202-4d69788841c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-memory search for questions with case- and accent-insensitive matching.
  * Search results highlight matching text in question statements.
  * Added a dedicated message when no questions match the search.
  * Question counts now reflect filtered results during searches.
  * Search state resets when filters change.

* **Bug Fixes**
  * Clearing a search restores the original question total and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->