### PR TITLE
AE-2894: refact map

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -216,10 +216,16 @@ describe('ChoroplethMap', () => {
   it('renders all legend items', () => {
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} />);
 
-    expect(screen.getByText('Destaque')).toBeInTheDocument();
-    expect(screen.getByText('Acima da média')).toBeInTheDocument();
-    expect(screen.getByText('Abaixo da média')).toBeInTheDocument();
-    expect(screen.getByText('Ponto de atenção')).toBeInTheDocument();
+    expect(screen.getByText('Destaque (75% com acesso)')).toBeInTheDocument();
+    expect(
+      screen.getByText('Acima da média (50 até 74% com acesso)')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Abaixo da média (26 até 49% com acesso)')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Ponto de atenção (Abaixo de 25% com acesso)')
+    ).toBeInTheDocument();
   });
 
   it('shows loading skeleton when loading is true', () => {
@@ -839,6 +845,69 @@ describe('ChoroplethMap animations', () => {
     expect(screen.getByText(/Atividades realizadas: 200/)).toBeInTheDocument();
   });
 
+  it('shows the per-profile breakdown in the tooltip when accessBreakdown is present', async () => {
+    await renderAndHoverRegion({
+      data: [
+        {
+          id: 'r1',
+          name: 'NRE Test',
+          value: 0.5,
+          accessCount: 200,
+          accessBreakdown: {
+            students: { withAccess: 300, withoutAccess: 1000 },
+            teachers: { withAccess: 40, withoutAccess: 5 },
+            managers: { withAccess: 2, withoutAccess: 8 },
+          },
+          geoJson: {
+            type: 'Feature',
+            properties: {},
+            geometry: { type: 'Polygon', coordinates: [[]] },
+          },
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(/Estudantes: 300 com acesso, 1\.000 sem acessos/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Professores\(as\): 40 com acesso, 5 sem acessos/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Diretores\(as\): 2 com acesso, 8 sem acessos/)
+    ).toBeInTheDocument();
+    // Falls back away from the single-count label
+    expect(screen.queryByText(/Acessos: 200/)).not.toBeInTheDocument();
+  });
+
+  it('renders a headerAction on the right of the header', () => {
+    render(
+      <ChoroplethMap
+        data={[]}
+        apiKey={mockApiKey}
+        headerAction={<button type="button">Todos dispositivos</button>}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Todos dispositivos' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders an info alert below the map when infoText is provided', () => {
+    render(
+      <ChoroplethMap
+        data={[]}
+        apiKey={mockApiKey}
+        infoText="Dados do mapa somam acessos por escola."
+      />
+    );
+
+    expect(
+      screen.getByText('Dados do mapa somam acessos por escola.')
+    ).toBeInTheDocument();
+  });
+
   it('zooms to NRE region on click', async () => {
     let clickHandler: ((event: unknown) => void) | null = null;
     mockAddListener.mockImplementation((event, handler) => {
@@ -1095,10 +1164,18 @@ describe('ChoroplethMap legend interaction', () => {
   it('renders all legend items as buttons', () => {
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} />);
 
-    const destaqueBtn = screen.getByText('Destaque').closest('button');
-    const acimaBtn = screen.getByText('Acima da média').closest('button');
-    const abaixoBtn = screen.getByText('Abaixo da média').closest('button');
-    const atencaoBtn = screen.getByText('Ponto de atenção').closest('button');
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button');
+    const acimaBtn = screen
+      .getByText('Acima da média (50 até 74% com acesso)')
+      .closest('button');
+    const abaixoBtn = screen
+      .getByText('Abaixo da média (26 até 49% com acesso)')
+      .closest('button');
+    const atencaoBtn = screen
+      .getByText('Ponto de atenção (Abaixo de 25% com acesso)')
+      .closest('button');
 
     expect(destaqueBtn).toBeInTheDocument();
     expect(acimaBtn).toBeInTheDocument();
@@ -1118,7 +1195,9 @@ describe('ChoroplethMap legend interaction', () => {
   it('toggles legend class opacity on click', () => {
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} />);
 
-    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button')!;
     expect(destaqueBtn).toHaveStyle({ opacity: 1 });
 
     act(() => {
@@ -1131,7 +1210,9 @@ describe('ChoroplethMap legend interaction', () => {
   it('restores legend class opacity on second click', () => {
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} />);
 
-    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button')!;
 
     act(() => {
       destaqueBtn.click();
@@ -1166,7 +1247,9 @@ describe('ChoroplethMap legend interaction', () => {
     mockOverrideStyle.mockClear();
     mockRevertStyle.mockClear();
 
-    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button')!;
     act(() => {
       destaqueBtn.click();
     });
@@ -1197,7 +1280,9 @@ describe('ChoroplethMap legend interaction', () => {
       expect(mockSetStyle).toHaveBeenCalled();
     });
 
-    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button')!;
 
     // Toggle off
     act(() => {
@@ -1248,7 +1333,9 @@ describe('ChoroplethMap legend interaction', () => {
     mockLatLngBounds.mockClear();
 
     // Toggle off "Abaixo da média" (index 2) — "Destaque" stays visible
-    const abaixoBtn = screen.getByText('Abaixo da média').closest('button')!;
+    const abaixoBtn = screen
+      .getByText('Abaixo da média (26 até 49% com acesso)')
+      .closest('button')!;
     act(() => {
       abaixoBtn.click();
     });
@@ -1594,7 +1681,9 @@ describe('ChoroplethMap isManagedRegion', () => {
     unmanagedLatLng.mockClear();
 
     // Toggle off "Destaque" — the managed feature (value 0.9) belongs to it
-    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button')!;
     act(() => {
       destaqueBtn.click();
     });
@@ -1685,7 +1774,9 @@ describe('ChoroplethMap isManagedRegion', () => {
 
     // Toggle off "Destaque": the low-value managed feature stays visible
     // and the map refits to it
-    const destaqueBtn = screen.getByText('Destaque').closest('button')!;
+    const destaqueBtn = screen
+      .getByText('Destaque (75% com acesso)')
+      .closest('button')!;
     act(() => {
       destaqueBtn.click();
     });

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -221,7 +221,7 @@ describe('ChoroplethMap', () => {
       screen.getByText('Acima da média (50 até 74% com acesso)')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Abaixo da média (26 até 49% com acesso)')
+      screen.getByText('Abaixo da média (25 até 49% com acesso)')
     ).toBeInTheDocument();
     expect(
       screen.getByText('Ponto de atenção (Abaixo de 25% com acesso)')
@@ -1171,7 +1171,7 @@ describe('ChoroplethMap legend interaction', () => {
       .getByText('Acima da média (50 até 74% com acesso)')
       .closest('button');
     const abaixoBtn = screen
-      .getByText('Abaixo da média (26 até 49% com acesso)')
+      .getByText('Abaixo da média (25 até 49% com acesso)')
       .closest('button');
     const atencaoBtn = screen
       .getByText('Ponto de atenção (Abaixo de 25% com acesso)')
@@ -1334,7 +1334,7 @@ describe('ChoroplethMap legend interaction', () => {
 
     // Toggle off "Abaixo da média" (index 2) — "Destaque" stays visible
     const abaixoBtn = screen
-      .getByText('Abaixo da média (26 até 49% com acesso)')
+      .getByText('Abaixo da média (25 até 49% com acesso)')
       .closest('button')!;
     act(() => {
       abaixoBtn.click();

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -72,7 +72,7 @@ const getColorClasses = (): ColorClass[] => [
     max: 0.5,
     fillColor: getCssVar('--color-map-below-avg', '#fb954b'),
     strokeColor: getCssVar('--color-map-below-avg', '#fb954b'),
-    label: 'Abaixo da média (26 até 49% com acesso)',
+    label: 'Abaixo da média (25 até 49% com acesso)',
   },
   {
     min: 0,

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -839,58 +839,62 @@ const ChoroplethMap = ({
         {/* Tooltip */}
         {hoveredRegion && infoPosition && (
           <div
-            className="fixed z-50 bg-background border border-border-50 shadow-lg rounded-lg p-3 pointer-events-none"
+            className="fixed z-50 flex flex-col gap-2 bg-background-900 shadow-hard-shadow-2 rounded px-3 py-1 pointer-events-none"
             style={{
-              left: Math.min(infoPosition.x + 10, window.innerWidth - 220),
-              top: Math.min(infoPosition.y + 10, window.innerHeight - 80),
+              left: Math.min(infoPosition.x + 10, window.innerWidth - 460),
+              top: Math.min(infoPosition.y + 10, window.innerHeight - 160),
             }}
           >
-            <Text size="sm" weight="semibold">
+            <Text size="md" weight="semibold" color="text-text-50">
               {hoveredRegion.name}
             </Text>
-            {hoveredRegion.isManagedRegion !== false &&
-              (hoveredRegion.accessBreakdown ? (
-                <div className="mt-1 flex flex-col gap-0.5">
-                  <Text size="xs" color="text-text-700">
-                    Estudantes:{' '}
-                    {hoveredRegion.accessBreakdown.students.withAccess.toLocaleString(
-                      'pt-BR'
-                    )}{' '}
-                    com acesso,{' '}
-                    {hoveredRegion.accessBreakdown.students.withoutAccess.toLocaleString(
-                      'pt-BR'
-                    )}{' '}
-                    sem acessos
+            {hoveredRegion.isManagedRegion !== false && (
+              <>
+                <div className="h-px self-stretch bg-border-200" />
+                {hoveredRegion.accessBreakdown ? (
+                  <div className="flex flex-col gap-1">
+                    <Text size="md" color="text-text-50">
+                      Estudantes:{' '}
+                      {hoveredRegion.accessBreakdown.students.withAccess.toLocaleString(
+                        'pt-BR'
+                      )}{' '}
+                      com acesso,{' '}
+                      {hoveredRegion.accessBreakdown.students.withoutAccess.toLocaleString(
+                        'pt-BR'
+                      )}{' '}
+                      sem acessos
+                    </Text>
+                    <Text size="md" color="text-text-50">
+                      Professores(as):{' '}
+                      {hoveredRegion.accessBreakdown.teachers.withAccess.toLocaleString(
+                        'pt-BR'
+                      )}{' '}
+                      com acesso,{' '}
+                      {hoveredRegion.accessBreakdown.teachers.withoutAccess.toLocaleString(
+                        'pt-BR'
+                      )}{' '}
+                      sem acessos
+                    </Text>
+                    <Text size="md" color="text-text-50">
+                      Diretores(as):{' '}
+                      {hoveredRegion.accessBreakdown.managers.withAccess.toLocaleString(
+                        'pt-BR'
+                      )}{' '}
+                      com acesso,{' '}
+                      {hoveredRegion.accessBreakdown.managers.withoutAccess.toLocaleString(
+                        'pt-BR'
+                      )}{' '}
+                      sem acessos
+                    </Text>
+                  </div>
+                ) : (
+                  <Text size="md" color="text-text-50">
+                    {countLabel}:{' '}
+                    {hoveredRegion.accessCount.toLocaleString('pt-BR')}
                   </Text>
-                  <Text size="xs" color="text-text-700">
-                    Professores(as):{' '}
-                    {hoveredRegion.accessBreakdown.teachers.withAccess.toLocaleString(
-                      'pt-BR'
-                    )}{' '}
-                    com acesso,{' '}
-                    {hoveredRegion.accessBreakdown.teachers.withoutAccess.toLocaleString(
-                      'pt-BR'
-                    )}{' '}
-                    sem acessos
-                  </Text>
-                  <Text size="xs" color="text-text-700">
-                    Diretores(as):{' '}
-                    {hoveredRegion.accessBreakdown.managers.withAccess.toLocaleString(
-                      'pt-BR'
-                    )}{' '}
-                    com acesso,{' '}
-                    {hoveredRegion.accessBreakdown.managers.withoutAccess.toLocaleString(
-                      'pt-BR'
-                    )}{' '}
-                    sem acessos
-                  </Text>
-                </div>
-              ) : (
-                <Text size="xs" color="text-text-700">
-                  {countLabel}:{' '}
-                  {hoveredRegion.accessCount.toLocaleString('pt-BR')}
-                </Text>
-              ))}
+                )}
+              </>
+            )}
           </div>
         )}
       </div>

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -6,6 +6,7 @@ import type { Feature, MultiPolygon, Polygon } from 'geojson';
 import { cn } from '../../utils/utils';
 import { useTheme } from '../../hooks/useTheme';
 import Text from '../Text/Text';
+import Alert from '../Alert/Alert';
 import type {
   ChoroplethMapProps,
   ColorClass,
@@ -57,28 +58,28 @@ const getColorClasses = (): ColorClass[] => [
     max: 1.01,
     fillColor: getCssVar('--color-map-highlight', '#66b584'),
     strokeColor: getCssVar('--color-map-highlight', '#66b584'),
-    label: 'Destaque',
+    label: 'Destaque (75% com acesso)',
   },
   {
     min: 0.5,
     max: 0.75,
     fillColor: getCssVar('--color-map-above-avg', '#f8cc2e'),
     strokeColor: getCssVar('--color-map-above-avg', '#f8cc2e'),
-    label: 'Acima da média',
+    label: 'Acima da média (50 até 74% com acesso)',
   },
   {
     min: 0.25,
     max: 0.5,
     fillColor: getCssVar('--color-map-below-avg', '#fb954b'),
     strokeColor: getCssVar('--color-map-below-avg', '#fb954b'),
-    label: 'Abaixo da média',
+    label: 'Abaixo da média (26 até 49% com acesso)',
   },
   {
     min: 0,
     max: 0.25,
     fillColor: getCssVar('--color-map-attention', '#b91c1c'),
     strokeColor: getCssVar('--color-map-attention', '#b91c1c'),
-    label: 'Ponto de atenção',
+    label: 'Ponto de atenção (Abaixo de 25% com acesso)',
   },
 ];
 
@@ -287,6 +288,8 @@ const ChoroplethMap = ({
   loading = false,
   bounds,
   onRegionClick,
+  headerAction,
+  infoText,
   className,
 }: ChoroplethMapProps) => {
   const mapId = GOOGLE_MAPS_LOADER_ID;
@@ -310,12 +313,15 @@ const ChoroplethMap = ({
   const dataSignature = useMemo(
     () =>
       data
-        .map(
-          (d) =>
-            `${d.id}:${d.value}:${d.name}:${d.groupName ?? ''}:${d.accessCount}:${
-              d.isManagedRegion === false ? 0 : 1
-            }`
-        )
+        .map((d) => {
+          const b = d.accessBreakdown;
+          const breakdown = b
+            ? `${b.students.withAccess}/${b.students.withoutAccess}/${b.teachers.withAccess}/${b.teachers.withoutAccess}/${b.managers.withAccess}/${b.managers.withoutAccess}`
+            : '';
+          return `${d.id}:${d.value}:${d.name}:${d.groupName ?? ''}:${d.accessCount}:${
+            d.isManagedRegion === false ? 0 : 1
+          }:${breakdown}`;
+        })
         .join('|'),
     [data]
   );
@@ -784,14 +790,17 @@ const ChoroplethMap = ({
     >
       {/* Header */}
       <div className="flex flex-col gap-4">
-        <Text
-          as="h2"
-          size="lg"
-          weight="bold"
-          className="leading-[21px] tracking-[0.2px]"
-        >
-          {title}
-        </Text>
+        <div className="flex flex-row items-center gap-4">
+          <Text
+            as="h2"
+            size="lg"
+            weight="bold"
+            className="flex-1 leading-[21px] tracking-[0.2px]"
+          >
+            {title}
+          </Text>
+          {headerAction}
+        </div>
 
         {/* Legend */}
         <div className="flex flex-wrap gap-8">
@@ -839,15 +848,62 @@ const ChoroplethMap = ({
             <Text size="sm" weight="semibold">
               {hoveredRegion.name}
             </Text>
-            {hoveredRegion.isManagedRegion !== false && (
-              <Text size="xs" color="text-text-700">
-                {countLabel}:{' '}
-                {hoveredRegion.accessCount.toLocaleString('pt-BR')}
-              </Text>
-            )}
+            {hoveredRegion.isManagedRegion !== false &&
+              (hoveredRegion.accessBreakdown ? (
+                <div className="mt-1 flex flex-col gap-0.5">
+                  <Text size="xs" color="text-text-700">
+                    Estudantes:{' '}
+                    {hoveredRegion.accessBreakdown.students.withAccess.toLocaleString(
+                      'pt-BR'
+                    )}{' '}
+                    com acesso,{' '}
+                    {hoveredRegion.accessBreakdown.students.withoutAccess.toLocaleString(
+                      'pt-BR'
+                    )}{' '}
+                    sem acessos
+                  </Text>
+                  <Text size="xs" color="text-text-700">
+                    Professores(as):{' '}
+                    {hoveredRegion.accessBreakdown.teachers.withAccess.toLocaleString(
+                      'pt-BR'
+                    )}{' '}
+                    com acesso,{' '}
+                    {hoveredRegion.accessBreakdown.teachers.withoutAccess.toLocaleString(
+                      'pt-BR'
+                    )}{' '}
+                    sem acessos
+                  </Text>
+                  <Text size="xs" color="text-text-700">
+                    Diretores(as):{' '}
+                    {hoveredRegion.accessBreakdown.managers.withAccess.toLocaleString(
+                      'pt-BR'
+                    )}{' '}
+                    com acesso,{' '}
+                    {hoveredRegion.accessBreakdown.managers.withoutAccess.toLocaleString(
+                      'pt-BR'
+                    )}{' '}
+                    sem acessos
+                  </Text>
+                </div>
+              ) : (
+                <Text size="xs" color="text-text-700">
+                  {countLabel}:{' '}
+                  {hoveredRegion.accessCount.toLocaleString('pt-BR')}
+                </Text>
+              ))}
           </div>
         )}
       </div>
+
+      {/* Info alert below the map, inside the card */}
+      {infoText && (
+        <Alert
+          action="info"
+          variant="solid"
+          description={infoText}
+          className="w-full"
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -1,4 +1,26 @@
+import type { ReactNode } from 'react';
 import type { Feature, MultiPolygon, Polygon } from 'geojson';
+
+/**
+ * With/without-access counts for a single profile group in a region.
+ */
+export interface AccessBreakdownEntry {
+  /** Users of this profile that accessed in the period */
+  withAccess: number;
+  /** Users of this profile that did NOT access in the period */
+  withoutAccess: number;
+}
+
+/**
+ * Per-profile access breakdown shown in the region tooltip. Always covers the
+ * three profile groups (students, teachers, managers), independent of any map
+ * filter.
+ */
+export interface AccessBreakdown {
+  students: AccessBreakdownEntry;
+  teachers: AccessBreakdownEntry;
+  managers: AccessBreakdownEntry;
+}
 
 /**
  * Region data interface for choropleth map
@@ -29,6 +51,12 @@ export interface RegionData {
    * does not trigger onRegionClick. Undefined is treated as true.
    */
   isManagedRegion?: boolean;
+  /**
+   * Optional per-profile access breakdown for the tooltip. When present, the
+   * tooltip shows the three profile lines (students/teachers/managers) instead
+   * of the single `countLabel` count.
+   */
+  accessBreakdown?: AccessBreakdown;
 }
 
 /**
@@ -71,6 +99,16 @@ export interface ChoroplethMapProps {
   bounds?: MapBounds;
   /** Callback when a region is clicked */
   onRegionClick?: (region: RegionData) => void;
+  /**
+   * Optional action rendered on the right side of the header (e.g. a device
+   * filter select).
+   */
+  headerAction?: ReactNode;
+  /**
+   * Optional informational text rendered in an info Alert below the map,
+   * inside the map card.
+   */
+  infoText?: string;
   /** Optional additional CSS classes */
   className?: string;
 }

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -220,6 +220,25 @@ describe('Select component', () => {
     expect(screen.getByText('Select something')).toBeInTheDocument();
   });
 
+  it('should render a leading icon in SelectValue when provided', () => {
+    render(
+      <Select defaultValue="">
+        <SelectTrigger>
+          <SelectValue
+            placeholder="Select something"
+            icon={<span data-testid="value-icon">icon</span>}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="option1">Option 1</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+
+    expect(screen.getByTestId('value-icon')).toBeInTheDocument();
+    expect(screen.getByText('Select something')).toBeInTheDocument();
+  });
+
   it('should apply variant and size classes', () => {
     render(
       <Select size="large">

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -332,9 +332,12 @@ const Select = ({
 
 const SelectValue = ({
   placeholder,
+  icon,
   store: externalStore,
 }: {
   placeholder?: string;
+  /** Optional leading icon rendered before the selected label/placeholder. */
+  icon?: ReactNode;
   store?: SelectStoreApi;
 }) => {
   const store = useSelectStore(externalStore);
@@ -343,6 +346,7 @@ const SelectValue = ({
   const value = useStore(store, (s) => s.value);
   return (
     <span className="text-inherit flex gap-2 items-center">
+      {icon}
       {selectedLabel || placeholder || value}
     </span>
   );

--- a/src/hooks/useMapData.test.ts
+++ b/src/hooks/useMapData.test.ts
@@ -116,11 +116,11 @@ describe('useMapData', () => {
     });
 
     it('should map accessBreakdown from feature properties for the tooltip', async () => {
-      const accessBreakdown = [
-        { profile: 'STUDENT', withAccess: 100, withoutAccess: 20 },
-        { profile: 'TEACHER', withAccess: 10, withoutAccess: 5 },
-        { profile: 'MANAGER', withAccess: 2, withoutAccess: 1 },
-      ];
+      const accessBreakdown = {
+        students: { withAccess: 100, withoutAccess: 20 },
+        teachers: { withAccess: 10, withoutAccess: 5 },
+        managers: { withAccess: 2, withoutAccess: 1 },
+      };
       const geoJSON: FeatureCollection<Polygon | MultiPolygon> = {
         type: 'FeatureCollection',
         features: [

--- a/src/hooks/useMapData.test.ts
+++ b/src/hooks/useMapData.test.ts
@@ -115,6 +115,77 @@ describe('useMapData', () => {
       expect(result.current.error).toBeNull();
     });
 
+    it('should map accessBreakdown from feature properties for the tooltip', async () => {
+      const accessBreakdown = [
+        { profile: 'STUDENT', withAccess: 100, withoutAccess: 20 },
+        { profile: 'TEACHER', withAccess: 10, withoutAccess: 5 },
+        { profile: 'MANAGER', withAccess: 2, withoutAccess: 1 },
+      ];
+      const geoJSON: FeatureCollection<Polygon | MultiPolygon> = {
+        type: 'FeatureCollection',
+        features: [
+          createMockFeature({
+            GEOCODIGO: '4106902',
+            NOME: 'Curitiba',
+            NRE: 'Curitiba',
+            value: 85,
+            totalAccess: 1200,
+            accessBreakdown,
+          }),
+        ],
+      };
+
+      mockFetchMapData.mockResolvedValueOnce({
+        message: 'Success',
+        data: {
+          state: 'PR',
+          regions: [],
+          bounds: mockBounds,
+          geoJSON,
+        },
+      });
+
+      const { result } = renderHook(() => useMapData(defaultFilters));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data[0].accessBreakdown).toEqual(accessBreakdown);
+    });
+
+    it('should leave accessBreakdown undefined when feature omits it', async () => {
+      const geoJSON: FeatureCollection<Polygon | MultiPolygon> = {
+        type: 'FeatureCollection',
+        features: [
+          createMockFeature({
+            GEOCODIGO: '4106902',
+            NOME: 'Curitiba',
+            value: 85,
+            totalAccess: 1200,
+          }),
+        ],
+      };
+
+      mockFetchMapData.mockResolvedValueOnce({
+        message: 'Success',
+        data: {
+          state: 'PR',
+          regions: [],
+          bounds: mockBounds,
+          geoJSON,
+        },
+      });
+
+      const { result } = renderHook(() => useMapData(defaultFilters));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data[0].accessBreakdown).toBeUndefined();
+    });
+
     it('should map isManagedRegion from feature properties, defaulting to true', async () => {
       const geoJSON: FeatureCollection<Polygon | MultiPolygon> = {
         type: 'FeatureCollection',

--- a/src/hooks/useMapData.ts
+++ b/src/hooks/useMapData.ts
@@ -49,6 +49,7 @@ function transformGeoJSONFeatures(
     accessCount: feature.properties?.totalAccess ?? 0,
     geoJson: feature,
     isManagedRegion: feature.properties?.isManagedRegion !== false,
+    accessBreakdown: feature.properties?.accessBreakdown,
   }));
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,8 @@ export type {
   MapBounds,
   LegendItem,
   ColorClass,
+  AccessBreakdown,
+  AccessBreakdownEntry,
 } from './components/ChoroplethMap/ChoroplethMap.types';
 
 // Map Data Hook


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional header action and an info message area below the map.
  * Enhanced the choropleth legend with access-percentage range labels.
  * Extended map tooltips to show detailed per-profile access breakdowns when available.
  * Added an optional leading icon to `SelectValue`.

* **Bug Fixes**
  * Improved map memoization so tooltip data updates correctly when access breakdowns change.
  * Updated tooltip and legend interactions to align with the new labels/behavior.

* **Tests**
  * Expanded coverage for tooltip rendering, header/info rendering, and legend controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->