### PR TITLE
AE-2895 - feat(Table): searchable column filter, and fix the access report modal

### DIFF
--- a/src/components/AccessReportModal/AccessReportModal.test.tsx
+++ b/src/components/AccessReportModal/AccessReportModal.test.tsx
@@ -220,9 +220,45 @@ describe('AccessReportModal', () => {
         />
       );
       // Professional variant shows simplified metrics without activity breakdown
-      expect(screen.getByText('Tempo na plataforma')).toBeInTheDocument();
-      expect(screen.getByText('Quantidade de acessos')).toBeInTheDocument();
+      expect(screen.getByText('Dados de acesso')).toBeInTheDocument();
+      expect(screen.getByText('Tempo total')).toBeInTheDocument();
+      expect(screen.getByText('Acessos')).toBeInTheDocument();
       expect(screen.getByText('Último acesso')).toBeInTheDocument();
+    });
+
+    it('shows the platform time in the legend, not the percentage', () => {
+      // The pie is sized by percentage, but the legend reads the time, per the
+      // design. The percentage number must not appear.
+      render(
+        <AccessReportModal
+          isOpen={true}
+          onClose={() => {}}
+          variant={AccessReportModalVariant.PROFESSIONAL}
+          data={mockProfessionalData}
+        />
+      );
+
+      expect(screen.getByText('14h50min')).toBeInTheDocument();
+      expect(screen.getByText('3h40min')).toBeInTheDocument();
+    });
+
+    it('omits the class segment for a user without one (no orphan bullet)', () => {
+      render(
+        <AccessReportModal
+          isOpen={true}
+          onClose={() => {}}
+          variant={AccessReportModalVariant.PROFESSIONAL}
+          data={{
+            ...mockProfessionalData,
+            user: { ...mockProfessionalData.user, class: null },
+          }}
+        />
+      );
+
+      // "Escola • • 2026" would have a doubled bullet; "Escola • 2026" doesn't.
+      expect(
+        screen.getByText('Escola Estadual Paraná • 2026')
+      ).toBeInTheDocument();
     });
 
     it('should render metric values from data', () => {

--- a/src/components/AccessReportModal/AccessReportModal.tsx
+++ b/src/components/AccessReportModal/AccessReportModal.tsx
@@ -124,16 +124,20 @@ export type AccessReportModalProps = AccessReportModalBaseProps &
 // ─── Pie slice builders ───────────────────────────────────────
 
 function buildPlatformSlices(platform: AccessReportByPlatform): PieSlice[] {
+  // The pie is sized by the percentage; the legend reads the time next to each
+  // platform (as in the design), not the percentage.
   return [
     {
       label: 'Web',
       value: platform.web.percentage,
+      displayValue: platform.web.time,
       colorClass: 'bg-success-700',
       color: 'var(--Success-success700, #206F3E)',
     },
     {
       label: 'Celular',
       value: platform.mobile.percentage,
+      displayValue: platform.mobile.time,
       colorClass: 'bg-success-300',
       color: 'var(--Success-success300, #66B584)',
     },
@@ -269,19 +273,16 @@ const ProfessionalModalContent = ({
       year={data.user.year}
     />
 
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-      <MetricBox
-        label="Tempo na plataforma"
-        value={data.accessData.totalTime}
-      />
-      <MetricBox
-        label="Quantidade de acessos"
-        value={data.accessData.accessCount}
-      />
-      <MetricBox
-        label="Último acesso"
-        value={data.accessData.lastAccess ?? '—'}
-      />
+    <div className="flex flex-col gap-3">
+      <SectionTitle>Dados de acesso</SectionTitle>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <MetricBox label="Tempo total" value={data.accessData.totalTime} />
+        <MetricBox label="Acessos" value={data.accessData.accessCount} />
+        <MetricBox
+          label="Último acesso"
+          value={data.accessData.lastAccess ?? '—'}
+        />
+      </div>
     </div>
 
     {accessCountByPeriod && accessCountByPeriod.length > 0 && (

--- a/src/components/Table/ColumnFilterMenu.test.tsx
+++ b/src/components/Table/ColumnFilterMenu.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ColumnFilterMenu from './ColumnFilterMenu';
 import type { ColumnFilterConfig } from './useColumnFilters';
 
@@ -133,6 +133,157 @@ describe('ColumnFilterMenu', () => {
     fireEvent.click(screen.getByText('DESTAQUE'));
 
     expect(onChange).toHaveBeenCalledWith(['SEM_ACESSO']);
+  });
+
+  describe('searchable', () => {
+    const schools = {
+      paramKey: 'schoolIds',
+      searchable: true,
+      searchPlaceholder: 'Buscar escola...',
+      options: [
+        {
+          value: 's1',
+          label: 'Colégio Estadual do Paraná',
+          searchText: 'Colégio Estadual do Paraná',
+        },
+        {
+          value: 's2',
+          label: 'Escola Municipal São José',
+          searchText: 'Escola Municipal São José',
+        },
+      ],
+    } satisfies ColumnFilterConfig;
+
+    const openSchools = () =>
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Filtrar por Escola' })
+      );
+
+    it('has no search box unless asked for one', () => {
+      render(
+        <ColumnFilterMenu
+          columnLabel="Status"
+          config={config}
+          value={[]}
+          onChange={jest.fn()}
+        />
+      );
+      openMenu();
+
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('filters the given options locally when there is no onSearch', () => {
+      render(
+        <ColumnFilterMenu
+          columnLabel="Escola"
+          config={schools}
+          value={[]}
+          onChange={jest.fn()}
+        />
+      );
+      openSchools();
+
+      expect(screen.getByText('Escola Municipal São José')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'paraná' },
+      });
+
+      expect(
+        screen.getByText('Colégio Estadual do Paraná')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Escola Municipal São José')
+      ).not.toBeInTheDocument();
+    });
+
+    it('matches on searchText, since the label can be a node and the value an id', () => {
+      render(
+        <ColumnFilterMenu
+          columnLabel="Escola"
+          config={schools}
+          value={[]}
+          onChange={jest.fn()}
+        />
+      );
+      openSchools();
+
+      // 's1' is the value; searching for it must not match by accident.
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'municipal' },
+      });
+
+      expect(screen.getByText('Escola Municipal São José')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Colégio Estadual do Paraná')
+      ).not.toBeInTheDocument();
+    });
+
+    it('hands the query to onSearch and stops filtering locally', async () => {
+      // With a server-side search the consumer owns the list — the options that
+      // come back are already the answer, so filtering them again would drop rows.
+      const onSearch = jest.fn();
+
+      render(
+        <ColumnFilterMenu
+          columnLabel="Escola"
+          config={{ ...schools, onSearch }}
+          value={[]}
+          onChange={jest.fn()}
+        />
+      );
+      openSchools();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'nada casa com isto' },
+      });
+
+      await waitFor(() =>
+        expect(onSearch).toHaveBeenCalledWith('nada casa com isto')
+      );
+
+      // Both options are still listed: the server decides, not us.
+      expect(
+        screen.getByText('Colégio Estadual do Paraná')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Escola Municipal São José')).toBeInTheDocument();
+    });
+
+    it('shows a loading state while the search is in flight', () => {
+      render(
+        <ColumnFilterMenu
+          columnLabel="Escola"
+          config={{ ...schools, onSearch: jest.fn(), loading: true }}
+          value={[]}
+          onChange={jest.fn()}
+        />
+      );
+      openSchools();
+
+      expect(screen.getByText('Carregando...')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Colégio Estadual do Paraná')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows an empty state when nothing matches', () => {
+      render(
+        <ColumnFilterMenu
+          columnLabel="Escola"
+          config={{ ...schools, options: [] }}
+          value={[]}
+          onChange={jest.fn()}
+        />
+      );
+      openSchools();
+
+      expect(
+        screen.getByText('Nenhum resultado encontrado')
+      ).toBeInTheDocument();
+      // "Todos" stays reachable so the filter can always be cleared.
+      expect(screen.getByText('Todos')).toBeInTheDocument();
+    });
   });
 
   it('does not trigger an enclosing sort handler', () => {

--- a/src/components/Table/ColumnFilterMenu.tsx
+++ b/src/components/Table/ColumnFilterMenu.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { CaretDownIcon } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CheckIcon } from '@phosphor-icons/react/dist/csr/Check';
 import DropdownMenu, {
@@ -6,6 +6,8 @@ import DropdownMenu, {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../DropdownMenu/DropdownMenu';
+import Search from '../Search/Search';
+import Text from '../Text/Text';
 import { cn } from '../../utils/utils';
 import type { ColumnFilterConfig } from './useColumnFilters';
 
@@ -32,9 +34,32 @@ const ColumnFilterMenu = ({
   onChange,
 }: ColumnFilterMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const { options, multiple = false, allLabel = 'Todos' } = config;
+  const {
+    options,
+    multiple = false,
+    allLabel = 'Todos',
+    searchable = false,
+    searchPlaceholder = 'Buscar...',
+    onSearch,
+    loading = false,
+  } = config;
+
+  const [query, setQuery] = useState('');
 
   const hasFilter = value.length > 0;
+
+  // With `onSearch` the consumer owns the list (it re-fetches per query), so the
+  // options arrive already filtered. Without it, filter what we were given.
+  const visibleOptions = useMemo(() => {
+    if (!searchable || onSearch || !query) return options;
+
+    const term = query.toLowerCase();
+    return options.filter((option) =>
+      String(option.searchText ?? option.value)
+        .toLowerCase()
+        .includes(term)
+    );
+  }, [searchable, onSearch, query, options]);
 
   const toggle = (optionValue: string) => {
     if (!multiple) {
@@ -81,8 +106,32 @@ const ColumnFilterMenu = ({
           portal
           triggerRef={triggerRef}
           align="start"
+          className="max-h-80 overflow-y-auto"
           onClick={(event) => event.stopPropagation()}
         >
+          {searchable && (
+            <div className="p-2">
+              {/*
+               * Two callbacks on purpose: `onChange` fires on every keystroke and
+               * drives the local filtering (debouncing that would make typing feel
+               * broken), while `onSearch` is debounced and is what hits the server.
+               */}
+              <Search
+                options={[]}
+                value={query}
+                placeholder={searchPlaceholder}
+                debounceMs={300}
+                onChange={(event) => setQuery(event.target.value)}
+                onSearch={onSearch}
+                onClear={() => {
+                  setQuery('');
+                  onSearch?.('');
+                }}
+                aria-label={`Buscar ${columnLabel}`}
+              />
+            </div>
+          )}
+
           <DropdownMenuItem
             onClick={() => onChange([])}
             className={cn(!hasFilter && 'font-bold')}
@@ -90,25 +139,42 @@ const ColumnFilterMenu = ({
             {allLabel}
           </DropdownMenuItem>
 
-          {options.map((option) => {
-            const selected = value.includes(option.value);
+          {loading && (
+            <div className="px-3 py-2">
+              <Text size="sm" className="text-text-600">
+                Carregando...
+              </Text>
+            </div>
+          )}
 
-            return (
-              <DropdownMenuItem
-                key={option.value}
-                preventClose={multiple}
-                onClick={() => toggle(option.value)}
-                iconRight={
-                  selected ? (
-                    <CheckIcon size={16} weight="bold" aria-hidden="true" />
-                  ) : undefined
-                }
-                className={cn(selected && 'font-bold')}
-              >
-                {option.label}
-              </DropdownMenuItem>
-            );
-          })}
+          {!loading && visibleOptions.length === 0 && (
+            <div className="px-3 py-2">
+              <Text size="sm" className="text-text-600">
+                Nenhum resultado encontrado
+              </Text>
+            </div>
+          )}
+
+          {!loading &&
+            visibleOptions.map((option) => {
+              const selected = value.includes(option.value);
+
+              return (
+                <DropdownMenuItem
+                  key={option.value}
+                  preventClose={multiple}
+                  onClick={() => toggle(option.value)}
+                  iconRight={
+                    selected ? (
+                      <CheckIcon size={16} weight="bold" aria-hidden="true" />
+                    ) : undefined
+                  }
+                  className={cn(selected && 'font-bold')}
+                >
+                  {option.label}
+                </DropdownMenuItem>
+              );
+            })}
         </DropdownMenuContent>
       </DropdownMenu>
     </span>

--- a/src/components/Table/useColumnFilters.ts
+++ b/src/components/Table/useColumnFilters.ts
@@ -10,6 +10,13 @@ import {
 export interface ColumnFilterOption {
   value: string;
   label: ReactNode;
+  /**
+   * Text a local search matches against. Needed because `label` is a ReactNode
+   * (a badge, an icon + text) and `value` is often an opaque id — neither is
+   * searchable. Ignored when the config supplies `onSearch`, since the server
+   * does the matching then.
+   */
+  searchText?: string;
 }
 
 export interface ColumnFilterConfig {
@@ -24,6 +31,24 @@ export interface ColumnFilterConfig {
    * the API expects. Defaults to the column's `key`.
    */
   paramKey?: string;
+  /**
+   * Show a search box at the top of the menu.
+   *
+   * Needed whenever the option list is too long to scan — a school manager sees
+   * over a thousand schools, and a plain list of those is unusable.
+   */
+  searchable?: boolean;
+  /** Placeholder of the search box (default: "Buscar..."). */
+  searchPlaceholder?: string;
+  /**
+   * Called (debounced) as the user types, for options fetched from a server.
+   *
+   * The consumer keeps owning `options`: it refreshes them as results arrive.
+   * When omitted, a `searchable` menu filters the given `options` in place.
+   */
+  onSearch?: (query: string) => void;
+  /** Show a loading state in the menu while the search is in flight. */
+  loading?: boolean;
 }
 
 /** Minimum shape `useColumnFilters` needs out of a column definition. */

--- a/src/components/TableProvider/TableProvider.stories.tsx
+++ b/src/components/TableProvider/TableProvider.stories.tsx
@@ -365,7 +365,24 @@ const STATUS_LABELS: Record<School['status'], string> = {
 
 export const ServerSortWithHeaderFilter: Story = () => {
   const schoolColumns: ColumnConfig<School>[] = [
-    { key: 'schoolName', label: 'Escola' },
+    {
+      key: 'schoolName',
+      label: 'Escola',
+      // A searchable header filter: the option list is fetched as the user
+      // types (here, filtered client-side over the mock), for lists too long
+      // to scan — a manager sees over a thousand schools.
+      filter: {
+        paramKey: 'schoolIds',
+        allLabel: 'Todas as escolas',
+        searchable: true,
+        searchPlaceholder: 'Buscar escola...',
+        options: mockSchools.map((s) => ({
+          value: s.schoolId,
+          label: s.schoolName,
+          searchText: s.schoolName,
+        })),
+      },
+    },
     { key: 'municipalityName', label: 'Município' },
     {
       key: 'status',

--- a/src/components/TableProvider/TableProvider.tsx
+++ b/src/components/TableProvider/TableProvider.tsx
@@ -23,6 +23,13 @@ import {
   type ColumnFilterConfig,
 } from '../Table/useColumnFilters';
 import { useTableFilter, FilterConfig } from '../Filter/useTableFilter';
+
+// Re-exported here (not only from the barrel) because the `table-provider`
+// subpath maps to this file, and consumers set `ColumnConfig.filter` with it.
+export type {
+  ColumnFilterConfig,
+  ColumnFilterOption,
+} from '../Table/useColumnFilters';
 import Search from '../Search/Search';
 import { FilterModal } from '../Filter/FilterModal';
 import Button from '../Button/Button';

--- a/src/components/shared/ChartComponents.tsx
+++ b/src/components/shared/ChartComponents.tsx
@@ -157,10 +157,18 @@ export interface PieSlice {
   /** Unique key for the slice (uses label if not provided) */
   key?: string;
   label: string;
+  /** Drives the slice's angle. Always the number — never a formatted string. */
   value: number;
   colorClass: string;
   /** Direct CSS color value — takes precedence over colorClass when provided */
   color?: string;
+  /**
+   * What the legend shows, when it differs from `value`.
+   *
+   * The pie is sized by the percentage, but the legend often needs to read as
+   * something else — "1h 20min" rather than "45". Falls back to `value`.
+   */
+  displayValue?: string | number;
 }
 
 /** Default radius ratio (44% of size) */
@@ -378,11 +386,13 @@ export const LegendRow = ({
   color,
   label,
   value,
+  displayValue,
 }: {
   colorClass: string;
   color?: string;
   label: string;
   value: number;
+  displayValue?: string | number;
 }) => (
   <div className="flex items-center gap-2">
     <div
@@ -393,7 +403,7 @@ export const LegendRow = ({
       {label}
     </Text>
     <Text size="sm" weight="medium" className="text-text-600 ml-3">
-      {value}
+      {displayValue ?? value}
     </Text>
   </div>
 );
@@ -411,6 +421,7 @@ export const LegendPieCard = ({ slices }: { slices: PieSlice[] }) => (
           color={s.color}
           label={s.label}
           value={s.value}
+          displayValue={s.displayValue}
         />
       ))}
     </div>

--- a/src/components/shared/ModalComponents.tsx
+++ b/src/components/shared/ModalComponents.tsx
@@ -50,7 +50,13 @@ export const UserHeader = ({
       {statusBadge}
     </div>
     <Text size="xs" className="text-text-600">
-      {school} • {className} • {year}
+      {/*
+       * Only the parts that exist. A director or pedagogue has no class, and
+       * interpolating it blindly left an orphan bullet: "Escola Municipal •  • 2026".
+       */}
+      {[school, className, year]
+        .filter((part) => part !== undefined && part !== null && part !== '')
+        .join(' • ')}
     </Text>
   </div>
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added searchable table column filters with local filtering or server-backed search.
  - Added loading and no-results states while searching, while retaining the “Todos” option.
  - Enabled school filtering with searchable options.
  - Access reports now display platform usage times in chart legends.

- **Bug Fixes**
  - Updated professional access report labels and layout for clearer metrics.
  - Prevented doubled or orphaned separators in user headers when class information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->