### PR TITLE
AE-2895 - feat(table): offer a clear-filters action in the empty state

### DIFF
--- a/src/components/TableProvider/TableProvider.test.tsx
+++ b/src/components/TableProvider/TableProvider.test.tsx
@@ -760,6 +760,80 @@ describe('TableProvider', () => {
         expect.objectContaining({ page: 1, statusFilter: 'active' })
       );
     });
+
+    it('offers a clear-filters action when a column filter empties the table', () => {
+      const onParamsChange = jest.fn();
+      const { rerender } = render(
+        <TableProvider
+          data={testData}
+          headers={filterHeaders}
+          onParamsChange={onParamsChange}
+        />
+      );
+
+      // Activate the filter while rows are present — the caret lives in the
+      // header row, which the empty state hides once the filter returns nothing.
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Filtrar por Status' })
+      );
+      fireEvent.click(screen.getByText('Ativo'));
+
+      // The consumer refetches and the filter now matches no rows.
+      rerender(
+        <TableProvider
+          data={[]}
+          headers={filterHeaders}
+          onParamsChange={onParamsChange}
+        />
+      );
+
+      const clearButton = screen.getByRole('button', {
+        name: 'Limpar filtros',
+      });
+      expect(clearButton).toBeInTheDocument();
+
+      fireEvent.click(clearButton);
+
+      const lastParams = onParamsChange.mock.calls.at(-1)?.[0];
+      expect(lastParams).not.toHaveProperty('statusFilter');
+    });
+
+    it('does not offer a clear-filters action when empty without an active filter', () => {
+      render(<TableProvider data={[]} headers={filterHeaders} />);
+
+      expect(
+        screen.queryByRole('button', { name: 'Limpar filtros' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('keeps a consumer-provided empty-state action instead of overriding it', () => {
+      const onButtonClick = jest.fn();
+      const { rerender } = render(
+        <TableProvider
+          data={testData}
+          headers={filterHeaders}
+          emptyState={{ buttonText: 'Criar', onButtonClick }}
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Filtrar por Status' })
+      );
+      fireEvent.click(screen.getByText('Ativo'));
+
+      rerender(
+        <TableProvider
+          data={[]}
+          headers={filterHeaders}
+          emptyState={{ buttonText: 'Criar', onButtonClick }}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Criar' })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Limpar filtros' })
+      ).not.toBeInTheDocument();
+    });
   });
 
   // ======================

--- a/src/components/TableProvider/TableProvider.tsx
+++ b/src/components/TableProvider/TableProvider.tsx
@@ -552,6 +552,31 @@ export function TableProvider<T extends Record<string, unknown>>({
     !loading && data.length === 0 && searchQuery.trim() !== '';
   const showEmpty = !loading && data.length === 0 && searchQuery.trim() === '';
 
+  // A header filter that returns nothing replaces the whole header row — carets
+  // included — with the empty state, leaving no way to undo it. When the table is
+  // empty *because* of an active column filter, surface a one-click reset in the
+  // empty state itself.
+  const hasActiveColumnFilters = Object.keys(columnFilterParams).length > 0;
+
+  const clearAllColumnFilters = useCallback(() => {
+    for (const paramKey of Object.keys(columnFilters)) {
+      setColumnFilter(paramKey, []);
+    }
+  }, [columnFilters, setColumnFilter]);
+
+  const effectiveEmptyState = useMemo<EmptyStateConfig | undefined>(() => {
+    if (!hasActiveColumnFilters) return emptyState;
+    // Don't override a consumer that already defined its own action or body.
+    if (emptyState?.component || emptyState?.buttonText) return emptyState;
+    return {
+      ...emptyState,
+      buttonText: 'Limpar filtros',
+      buttonVariant: 'outline',
+      buttonAction: 'primary',
+      onButtonClick: clearAllColumnFilters,
+    };
+  }, [emptyState, hasActiveColumnFilters, clearAllColumnFilters]);
+
   // Extract components for render prop pattern
   const controls = (enableSearch || enableFilters) && (
     <div className="flex items-center gap-4">
@@ -614,7 +639,7 @@ export function TableProvider<T extends Record<string, unknown>>({
         showNoSearchResult={showNoSearchResult}
         noSearchResultState={noSearchResultState}
         showEmpty={showEmpty}
-        emptyState={emptyState}
+        emptyState={effectiveEmptyState}
       >
         {/* Table Header */}
         <thead>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Limpar filtros” action when column filters produce no results, allowing users to clear them in one click.

* **Bug Fixes**
  * Preserved custom empty states and their actions.
  * Prevented the filter-clearing action from appearing when no column filter is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->