### PR TITLE
AE-2902 - feat(time-report): add optional subtitle line to TimeCard

### DIFF
--- a/src/components/TimeReport/TimeReport.test.tsx
+++ b/src/components/TimeReport/TimeReport.test.tsx
@@ -100,6 +100,30 @@ describe('TimeCard', () => {
     expect(trend).toHaveClass('text-success-500');
   });
 
+  it('renders the subtitle when provided', () => {
+    render(
+      <TimeCard
+        data={{
+          id: 'total',
+          label: 'TOTAL DE DIRETORES(AS)/PEDAGOGOS(AS)',
+          value: '16.778',
+          icon: <MockIcon />,
+          subtitle: '1 município • 134 escolas',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('subtitle-total')).toHaveTextContent(
+      '1 município • 134 escolas'
+    );
+  });
+
+  it('does not render the subtitle when not provided', () => {
+    render(<TimeCard data={mockNoTrendCard} />);
+
+    expect(screen.queryByTestId('subtitle-no-trend')).not.toBeInTheDocument();
+  });
+
   it('does not render trend when not provided', () => {
     render(<TimeCard data={mockNoTrendCard} />);
 

--- a/src/components/TimeReport/TimeReport.tsx
+++ b/src/components/TimeReport/TimeReport.tsx
@@ -102,6 +102,12 @@ export interface TimeCardData {
   trendValue?: string;
   /** Trend direction - determines color */
   trendDirection?: TimeCardTrend;
+  /**
+   * Plain gray line under the value (e.g., "1 município • 134 escolas"), for
+   * cards whose context is a breakdown rather than a trend. Rendered alongside
+   * the trend when both are present.
+   */
+  subtitle?: string;
 }
 
 /**
@@ -158,7 +164,7 @@ const TREND_CONFIG = {
  * TimeCard component - displays a single time statistic
  */
 export const TimeCard = ({ data, className, ...props }: TimeCardProps) => {
-  const { label, value, icon, trendValue, trendDirection } = data;
+  const { label, value, icon, trendValue, trendDirection, subtitle } = data;
 
   return (
     <div
@@ -188,6 +194,17 @@ export const TimeCard = ({ data, className, ...props }: TimeCardProps) => {
       >
         {value}
       </Text>
+
+      {/* Context line (e.g., "1 município • 134 escolas") */}
+      {subtitle && (
+        <Text
+          size="sm"
+          className="text-text-600 leading-[100%]"
+          data-testid={`subtitle-${data.id}`}
+        >
+          {subtitle}
+        </Text>
+      )}
 
       {/* Trend indicator */}
       {trendValue && trendDirection && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time report cards can now display an optional secondary subtitle beneath the main value.
  * Subtitles provide additional context, such as coverage or breakdown details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->