### PR TITLE
fix(activities): remapeia filtros do histórico para o contrato do backend

### DIFF
--- a/src/hooks/useActivitiesHistory.test.ts
+++ b/src/hooks/useActivitiesHistory.test.ts
@@ -3,6 +3,7 @@ import {
   createUseActivitiesHistory,
   createActivitiesHistoryHook,
   transformActivityToTableItem,
+  buildActivityHistoryQueryParams,
   DEFAULT_ACTIVITIES_PAGINATION,
 } from './useActivitiesHistory';
 import {
@@ -539,5 +540,127 @@ describe('useActivitiesHistory', () => {
       expect(result.current.fetchActivities).toBeInstanceOf(Function);
       expect(result.current.activities).toEqual([]);
     });
+  });
+});
+
+describe('buildActivityHistoryQueryParams', () => {
+  it('adds type from activityCategory', () => {
+    const params = buildActivityHistoryQueryParams({}, 'ATIVIDADE');
+    expect(params.type).toBe('ATIVIDADE');
+  });
+
+  it('maps school[] to comma-separated schoolIds', () => {
+    const params = buildActivityHistoryQueryParams({
+      school: ['school-1', 'school-2'],
+    });
+    expect(params.schoolIds).toBe('school-1,school-2');
+    expect(params.school).toBeUndefined();
+  });
+
+  it('maps class[] to classIds and schoolYear[] to schoolYearIds (CSV)', () => {
+    const params = buildActivityHistoryQueryParams({
+      class: ['c1', 'c2'],
+      schoolYear: ['y1'],
+    });
+    expect(params.classIds).toBe('c1,c2');
+    expect(params.schoolYearIds).toBe('y1');
+  });
+
+  it('collapses single-select filters to the first value', () => {
+    const params = buildActivityHistoryQueryParams({
+      status: ['A_VENCER', 'VENCIDA'],
+      subject: ['subj-1', 'subj-2'],
+      creatorType: ['own'],
+    });
+    expect(params.status).toBe('A_VENCER');
+    expect(params.subjectId).toBe('subj-1');
+    expect(params.creatorType).toBe('own');
+    expect(params.subject).toBeUndefined();
+  });
+
+  it('forwards pagination, search and sorting untouched', () => {
+    const params = buildActivityHistoryQueryParams({
+      page: 2,
+      limit: 20,
+      search: 'prova',
+      sortBy: 'finalDate',
+      sortOrder: 'asc',
+    });
+    expect(params).toMatchObject({
+      page: 2,
+      limit: 20,
+      search: 'prova',
+      sortBy: 'finalDate',
+      sortOrder: 'asc',
+    });
+  });
+
+  it('omits empty filter arrays', () => {
+    const params = buildActivityHistoryQueryParams({
+      school: [],
+      status: [],
+      subject: [],
+    });
+    expect(params.schoolIds).toBeUndefined();
+    expect(params.status).toBeUndefined();
+    expect(params.subjectId).toBeUndefined();
+  });
+
+  it('honors legacy singular subjectId as a fallback', () => {
+    const params = buildActivityHistoryQueryParams({ subjectId: 'subj-1' });
+    expect(params.subjectId).toBe('subj-1');
+  });
+
+  it('honors legacy singular schoolId as a fallback', () => {
+    const params = buildActivityHistoryQueryParams({ schoolId: 'school-1' });
+    expect(params.schoolId).toBe('school-1');
+    expect(params.schoolIds).toBeUndefined();
+  });
+
+  it('honors legacy singular classId as a fallback', () => {
+    const params = buildActivityHistoryQueryParams({ classId: 'class-1' });
+    expect(params.classId).toBe('class-1');
+    expect(params.classIds).toBeUndefined();
+  });
+
+  it('prefers raw subject[] over legacy subjectId', () => {
+    const params = buildActivityHistoryQueryParams({
+      subject: ['a'],
+      subjectId: 'b',
+    });
+    expect(params.subjectId).toBe('a');
+  });
+
+  it('prefers raw school[] over legacy schoolId', () => {
+    const params = buildActivityHistoryQueryParams({
+      school: ['a', 'b'],
+      schoolId: 'c',
+    });
+    expect(params.schoolIds).toBe('a,b');
+    expect(params.schoolId).toBeUndefined();
+  });
+
+  it('prefers raw class[] over legacy classId', () => {
+    const params = buildActivityHistoryQueryParams({
+      class: ['a', 'b'],
+      classId: 'c',
+    });
+    expect(params.classIds).toBe('a,b');
+    expect(params.classId).toBeUndefined();
+  });
+
+  it('accepts a bare-string status', () => {
+    expect(buildActivityHistoryQueryParams({ status: 'A_VENCER' }).status).toBe(
+      'A_VENCER'
+    );
+  });
+
+  it('forwards startDate and finalDate', () => {
+    const params = buildActivityHistoryQueryParams({
+      startDate: '01/01/2026',
+      finalDate: '31/01/2026',
+    });
+    expect(params.startDate).toBe('01/01/2026');
+    expect(params.finalDate).toBe('31/01/2026');
   });
 });

--- a/src/hooks/useActivitiesHistory.ts
+++ b/src/hooks/useActivitiesHistory.ts
@@ -135,6 +135,34 @@ const toSingle = (value: unknown): string | undefined => {
 };
 
 /**
+ * Assign a resolved string value onto the params object only when it is present.
+ * Keeps the builder free of repetitive `if (value) params[key] = value` blocks.
+ */
+const assignIf = (
+  params: Record<string, unknown>,
+  key: string,
+  value: string | undefined
+): void => {
+  if (value) {
+    params[key] = value;
+  }
+};
+
+/**
+ * Raw scalar keys forwarded to the backend untouched (pagination, text search,
+ * date range and sorting). Copied verbatim when present and non-empty.
+ */
+const PASSTHROUGH_KEYS = [
+  'page',
+  'limit',
+  'search',
+  'startDate',
+  'finalDate',
+  'sortBy',
+  'sortOrder',
+] as const;
+
+/**
  * Build the `/activities/history` query params from the raw TableProvider filter
  * keys. TableProvider emits UI-category keys (`subject`, `school`, `class`,
  * `schoolYear`, `status`, `creatorType`) as arrays; the backend expects a
@@ -150,67 +178,39 @@ export const buildActivityHistoryQueryParams = (
   activityCategory?: string
 ): Record<string, unknown> => {
   const params: Record<string, unknown> = {};
-
-  if (activityCategory) {
-    params.type = activityCategory;
-  }
+  assignIf(params, 'type', activityCategory);
 
   if (!filters) {
     return params;
   }
 
-  if (filters.page !== undefined && filters.page !== null) {
-    params.page = filters.page;
-  }
-  if (filters.limit !== undefined && filters.limit !== null) {
-    params.limit = filters.limit;
-  }
-  if (typeof filters.search === 'string' && filters.search) {
-    params.search = filters.search;
-  }
-  if (typeof filters.startDate === 'string' && filters.startDate) {
-    params.startDate = filters.startDate;
-  }
-  if (typeof filters.finalDate === 'string' && filters.finalDate) {
-    params.finalDate = filters.finalDate;
-  }
-  if (filters.sortBy) {
-    params.sortBy = filters.sortBy;
-  }
-  if (filters.sortOrder) {
-    params.sortOrder = filters.sortOrder;
+  for (const key of PASSTHROUGH_KEYS) {
+    const value = filters[key];
+    if (value !== undefined && value !== null && value !== '') {
+      params[key] = value;
+    }
   }
 
-  // School: prefer raw multi-select (CSV); fall back to legacy singular.
-  const schoolIds = toCsv(filters.school);
-  if (schoolIds) {
-    params.schoolIds = schoolIds;
-  } else {
-    const schoolId = toSingle(filters.schoolId);
-    if (schoolId) params.schoolId = schoolId;
+  // Multi-select filters serialized as comma-separated ids. School and class each
+  // fall back to their legacy singular key when the raw multi-select key is absent.
+  assignIf(params, 'schoolIds', toCsv(filters.school));
+  assignIf(params, 'classIds', toCsv(filters.class));
+  assignIf(params, 'schoolYearIds', toCsv(filters.schoolYear));
+  if (!params.schoolIds) {
+    assignIf(params, 'schoolId', toSingle(filters.schoolId));
+  }
+  if (!params.classIds) {
+    assignIf(params, 'classId', toSingle(filters.classId));
   }
 
-  // Class: prefer raw multi-select (CSV); fall back to legacy singular.
-  const classIds = toCsv(filters.class);
-  if (classIds) {
-    params.classIds = classIds;
-  } else {
-    const classId = toSingle(filters.classId);
-    if (classId) params.classId = classId;
-  }
-
-  const schoolYearIds = toCsv(filters.schoolYear);
-  if (schoolYearIds) params.schoolYearIds = schoolYearIds;
-
-  const status = toSingle(filters.status);
-  if (status) params.status = status;
-
-  // Subject: prefer raw multi-select; fall back to legacy singular.
-  const subjectId = toSingle(filters.subject) ?? toSingle(filters.subjectId);
-  if (subjectId) params.subjectId = subjectId;
-
-  const creatorType = toSingle(filters.creatorType);
-  if (creatorType) params.creatorType = creatorType;
+  // Single-select filters (subject also honors the legacy singular key).
+  assignIf(params, 'status', toSingle(filters.status));
+  assignIf(
+    params,
+    'subjectId',
+    toSingle(filters.subject) ?? toSingle(filters.subjectId)
+  );
+  assignIf(params, 'creatorType', toSingle(filters.creatorType));
 
   return params;
 };

--- a/src/hooks/useActivitiesHistory.ts
+++ b/src/hooks/useActivitiesHistory.ts
@@ -109,30 +109,108 @@ export const extractActivityFilterOptions = (
 ): ActivityApiFilterOptions => extractBreakdownFilterOptions(activities);
 
 /**
- * Build query params from filters
- * @param filters - User filters
- * @param activityCategory - Optional activity category filter
- * @returns Query params object
+ * Join an array of selected ids into the backend's comma-separated convention
+ * (e.g. `schoolIds=a,b,c`). Returns undefined for empty / non-array input so the
+ * query param is omitted entirely.
  */
-const buildQueryParams = (
-  filters?: ActivityHistoryFilters,
+const toCsv = (value: unknown): string | undefined => {
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map(String).join(',');
+  }
+  return undefined;
+};
+
+/**
+ * Collapse a single-select filter (emitted as an array by TableProvider) to its
+ * first value. Also tolerates a bare string. Returns undefined when empty.
+ */
+const toSingle = (value: unknown): string | undefined => {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? String(value[0]) : undefined;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  return undefined;
+};
+
+/**
+ * Build the `/activities/history` query params from the raw TableProvider filter
+ * keys. TableProvider emits UI-category keys (`subject`, `school`, `class`,
+ * `schoolYear`, `status`, `creatorType`) as arrays; the backend expects a
+ * different, mostly single-value contract. This adapter renames each key and
+ * collapses/serializes to what the backend actually reads. Mirrors
+ * `buildFiltersFromParams` in RecommendedLessonsHistory.
+ *
+ * @param filters - Raw table params (arrays under UI keys) plus page/limit/search/sort
+ * @param activityCategory - Optional value forwarded as the `type` param
+ */
+export const buildActivityHistoryQueryParams = (
+  filters?: Record<string, unknown>,
   activityCategory?: string
 ): Record<string, unknown> => {
   const params: Record<string, unknown> = {};
 
-  // Add activityCategory filter (type param for /activities/history)
   if (activityCategory) {
     params.type = activityCategory;
   }
 
-  if (filters) {
-    for (const key in filters) {
-      const value = filters[key as keyof ActivityHistoryFilters];
-      if (value !== undefined && value !== null) {
-        params[key] = value;
-      }
-    }
+  if (!filters) {
+    return params;
   }
+
+  if (filters.page !== undefined && filters.page !== null) {
+    params.page = filters.page;
+  }
+  if (filters.limit !== undefined && filters.limit !== null) {
+    params.limit = filters.limit;
+  }
+  if (typeof filters.search === 'string' && filters.search) {
+    params.search = filters.search;
+  }
+  if (typeof filters.startDate === 'string' && filters.startDate) {
+    params.startDate = filters.startDate;
+  }
+  if (typeof filters.finalDate === 'string' && filters.finalDate) {
+    params.finalDate = filters.finalDate;
+  }
+  if (filters.sortBy) {
+    params.sortBy = filters.sortBy;
+  }
+  if (filters.sortOrder) {
+    params.sortOrder = filters.sortOrder;
+  }
+
+  // School: prefer raw multi-select (CSV); fall back to legacy singular.
+  const schoolIds = toCsv(filters.school);
+  if (schoolIds) {
+    params.schoolIds = schoolIds;
+  } else {
+    const schoolId = toSingle(filters.schoolId);
+    if (schoolId) params.schoolId = schoolId;
+  }
+
+  // Class: prefer raw multi-select (CSV); fall back to legacy singular.
+  const classIds = toCsv(filters.class);
+  if (classIds) {
+    params.classIds = classIds;
+  } else {
+    const classId = toSingle(filters.classId);
+    if (classId) params.classId = classId;
+  }
+
+  const schoolYearIds = toCsv(filters.schoolYear);
+  if (schoolYearIds) params.schoolYearIds = schoolYearIds;
+
+  const status = toSingle(filters.status);
+  if (status) params.status = status;
+
+  // Subject: prefer raw multi-select; fall back to legacy singular.
+  const subjectId = toSingle(filters.subject) ?? toSingle(filters.subjectId);
+  if (subjectId) params.subjectId = subjectId;
+
+  const creatorType = toSingle(filters.creatorType);
+  if (creatorType) params.creatorType = creatorType;
 
   return params;
 };
@@ -157,7 +235,10 @@ const useActivitiesHistoryImpl = (
       setState((prev) => ({ ...prev, loading: true, error: null }));
 
       try {
-        const params = buildQueryParams(filters, options?.activityCategory);
+        const params = buildActivityHistoryQueryParams(
+          filters as Record<string, unknown>,
+          options?.activityCategory
+        );
         const response = await apiClient.get<ActivitiesHistoryApiResponse>(
           '/activities/history',
           { params }

--- a/src/types/activitiesHistory.ts
+++ b/src/types/activitiesHistory.ts
@@ -132,15 +132,26 @@ export interface ActivityHistoryFilters {
     | 'SIMULADO'
     | 'QUESTIONARIO'
     | 'AULA_RECOMENDADA';
-  status?: GenericApiStatus;
   search?: string;
+  sortBy?: 'finalDate' | 'title' | 'completionPercentage';
+  sortOrder?: 'asc' | 'desc';
+
+  // Raw TableProvider filter keys (arrays of selected ids/values).
+  // Remapped to the backend contract by buildActivityHistoryQueryParams.
+  status?: string[] | GenericApiStatus;
+  subject?: string[];
+  school?: string[];
+  class?: string[];
+  schoolYear?: string[];
+  creatorType?: string[];
+
+  // Legacy single-value fields, consumed by buildActivityHistoryQueryParams
+  // as fallbacks when the raw multi-select keys above are absent.
   startDate?: string;
   finalDate?: string;
   subjectId?: string;
   schoolId?: string;
   classId?: string;
-  sortBy?: 'finalDate' | 'title' | 'completionPercentage';
-  sortOrder?: 'asc' | 'desc';
 }
 
 /**


### PR DESCRIPTION
## O que
Corrige os filtros da lista de atividades (histórico), que não filtravam nada.

## Por quê
O hook enviava as chaves cruas do `TableProvider` (`subject`/`school`/`class`/
`schoolYear`/`status`/`creatorType`, como arrays) direto pra query string. O
backend espera nomes/formatos diferentes, então o Zod descartava tudo
silenciosamente. Faltava a camada de tradução que a lista de aulas recomendadas
já tem (`buildFiltersFromParams`).

## Como
Substitui o `buildQueryParams` "cópia cega" por `buildActivityHistoryQueryParams`,
espelhando o adaptador das aulas recomendadas (contrato híbrido):
- `school[]`/`class[]`/`schoolYear[]` → `schoolIds`/`classIds`/`schoolYearIds` (CSV)
- `status`/`subject`/`creatorType` → valor único (single-select, padrão do repo)
- encaminha `type` (de `activityCategory`), paginação, busca, datas e ordenação
- fallback para as chaves singulares legadas (`subjectId`/`schoolId`/`classId`),
  preservando o componente público `ActivitiesHistory`/`HistoryTab`
- corrige o tipo `ActivityHistoryFilters`, que declarava um shape que não batia
  com o runtime (a causa raiz de o bug ter passado despercebido)

Nenhuma página consumidora (gestor/professor) precisou mudar.

## Escopo / decisão
`status`/`matéria`/`criador` ficam single-select (mesmo comportamento das aulas
recomendadas). Multi-select real neles exigiria um padrão novo no backend —
adiado de propósito.

## Testes
- 12 casos em `useActivitiesHistory.test.ts` (mapeamento, colapso, precedência
  raw>legado, passthrough, arrays vazios)
- `yarn lint` e `yarn typecheck` limpos


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved activity history filtering with support for subjects, schools, classes, school years, creator types, and activity categories.
  * Added compatibility with existing single-value filter formats.
  * Preserved search, pagination, sorting, and date filters in activity history requests.

* **Tests**
  * Added coverage for filter conversion, fallback behavior, precedence rules, and empty filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->