### PR TITLE
feat: papole theme + tutorials in header

### DIFF
--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -74,3 +74,22 @@ export const Manager: Story = () => (
     onNavigateByNotification={noop}
   />
 );
+
+/**
+ * Header with the "Tutoriais" pill button (opens the tutorial link).
+ */
+export const WithTutorial: Story = () => (
+  <AppHeader
+    user={{ name: 'Maria', email: 'maria@example.com' }}
+    sessionInfo={baseSession}
+    notifications={sampleNotifications}
+    tutorial={{ visible: true, onClick: noop }}
+    showCalendar
+    calendarContent={
+      <div className="p-4 text-text-700">Calendário do aluno</div>
+    }
+    onLogout={noop}
+    onNavigateToMyData={noop}
+    onNavigateByNotification={noop}
+  />
+);

--- a/src/components/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppHeader/AppHeader.test.tsx
@@ -209,4 +209,83 @@ describe('AppHeader', () => {
     );
     expect(screen.getByAltText('Logo')).toBeInTheDocument();
   });
+
+  it('does not render the tutorial button by default', () => {
+    render(<AppHeader {...baseProps()} />);
+    expect(screen.queryByText('Tutoriais')).not.toBeInTheDocument();
+  });
+
+  it('does not render the tutorial button when tutorial.visible is false', () => {
+    render(
+      <AppHeader
+        {...baseProps({ tutorial: { visible: false, onClick: jest.fn() } })}
+      />
+    );
+    expect(screen.queryByText('Tutoriais')).not.toBeInTheDocument();
+  });
+
+  it('renders the tutorial button with the default label when visible', () => {
+    render(
+      <AppHeader
+        {...baseProps({ tutorial: { visible: true, onClick: jest.fn() } })}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Tutoriais' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders a custom tutorial label when provided', () => {
+    render(
+      <AppHeader
+        {...baseProps({
+          tutorial: { visible: true, label: 'Tutorial', onClick: jest.fn() },
+        })}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Tutorial' })
+    ).toBeInTheDocument();
+  });
+
+  // Regression: `text-*` inverts with the color mode while the header
+  // background (`bg-primary-800`) does not, which erased the button in dark
+  // mode. `primary` is the designed foreground of `primary-800` in every theme.
+  it('styles the tutorial button with the on-primary foreground token', () => {
+    render(
+      <AppHeader
+        {...baseProps({ tutorial: { visible: true, onClick: jest.fn() } })}
+      />
+    );
+    const button = screen.getByRole('button', { name: 'Tutoriais' });
+    expect(button).toHaveClass('text-primary', 'border-primary');
+    expect(button).not.toHaveClass('text-text', 'border-text');
+  });
+
+  it('calls tutorial.onClick when the tutorial button is clicked', () => {
+    const onClick = jest.fn();
+    render(
+      <AppHeader {...baseProps({ tutorial: { visible: true, onClick } })} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Tutoriais' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: the tutorial pill widened the header enough to overflow narrow
+  // viewports, because an <img> resolves `min-width:auto` to its intrinsic
+  // width and refuses to shrink, pushing the actions off-screen.
+  it('lets the logo shrink and keeps the actions from being squashed', () => {
+    render(
+      <AppHeader
+        {...baseProps({ tutorial: { visible: true, onClick: jest.fn() } })}
+      />
+    );
+    const logo = screen.getByAltText('Logo');
+    expect(logo).toHaveClass('min-w-0', 'shrink');
+
+    const section = logo.parentElement?.querySelector('section');
+    expect(section).toHaveClass('shrink-0');
+    // A gap on the row guarantees the logo never touches the tutorial pill.
+    expect(logo.parentElement).toHaveClass('gap-3');
+  });
 });

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -48,6 +48,20 @@ export interface AppHeaderUser {
 }
 
 /**
+ * Tutorial action rendered as a pill button in the header (left of the
+ * notifications bell). The consumer owns the click behavior (usually opening
+ * the configured tutorial URL in a new tab).
+ */
+export interface AppHeaderTutorial {
+  /** Show the tutorial button. */
+  visible?: boolean;
+  /** Button label. Defaults to "Tutoriais". */
+  label?: string;
+  /** Fired when the tutorial button is clicked. */
+  onClick: () => void;
+}
+
+/**
  * Notifications data + callbacks the AppHeader forwards to NotificationCard.
  * Built by the consumer (usually via `createNotificationsHook(api)`).
  */
@@ -71,6 +85,8 @@ export interface AppHeaderProps {
   sessionInfo?: AppHeaderSessionInfo;
   /** Notifications wiring (state + callbacks). */
   notifications: AppHeaderNotifications;
+  /** Tutorial pill button shown before the notifications bell. */
+  tutorial?: AppHeaderTutorial;
   /** Show the calendar widget in the header. */
   showCalendar?: boolean;
   /** Content rendered inside the calendar (dropdown on tablet/desktop, modal on mobile). */
@@ -125,6 +141,7 @@ export const AppHeader = ({
   user,
   sessionInfo,
   notifications,
+  tutorial,
   showCalendar = false,
   calendarContent,
   calendarOpen,
@@ -217,6 +234,11 @@ export const AppHeader = ({
   );
   const sectionGap = pickResponsiveClass('gap-1', 'gap-2', 'gap-3');
   const logoHeight = pickResponsiveClass('h-6', 'h-8', 'h-10');
+  const tutorialPadding = pickResponsiveClass(
+    'px-3 py-1.5 text-xs',
+    'px-3.5 py-2 text-sm',
+    'px-4 py-2 text-sm'
+  );
 
   return (
     <header
@@ -227,13 +249,36 @@ export const AppHeader = ({
         className="pb-0 justify-center"
         innerClassName={contentMaxWidth}
       >
-        <div className="w-full flex flex-row justify-between items-center">
+        <div className="w-full flex flex-row justify-between items-center gap-3">
+          {/* `min-w-0 shrink` lets the logo compress instead of overflowing:
+              an <img> resolves `min-width:auto` to its intrinsic width, which
+              would otherwise block flex-shrink and push the actions off-screen
+              on narrow viewports. `object-left` keeps it left-aligned as it
+              scales down. The actions never shrink. */}
           <BrandingLogo
             variant="main"
             alt="Logo"
-            className={`${logoHeight} object-contain`}
+            className={`${logoHeight} object-contain object-left min-w-0 shrink`}
           />
-          <section className={`flex flex-row items-center ${sectionGap}`}>
+          <section
+            className={`flex flex-row items-center shrink-0 ${sectionGap}`}
+          >
+            {tutorial?.visible && (
+              <button
+                type="button"
+                data-testid="app-header-tutorial"
+                onClick={tutorial.onClick}
+                /* `primary` (não `text`) é o foreground de `primary-800` em
+                   todos os temas — os dois formam um par contrastante mesmo
+                   onde o dark inverte o header (paraiba/analytica). Usar
+                   `text-*` aqui inverteria com o modo enquanto o fundo do
+                   header não inverte, apagando o botão no dark. */
+                className={`rounded-full border border-primary text-primary font-medium whitespace-nowrap cursor-pointer transition-colors hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${tutorialPadding}`}
+              >
+                {tutorial.label ?? 'Tutoriais'}
+              </button>
+            )}
+
             {showCalendar && (
               <div className="lg:hidden">
                 <CalendarCard

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -63,6 +63,7 @@ const DARK_THEME_MAP: Record<string, string> = {
   'enem-parana-light': 'enem-parana-dark',
   'enem-paraiba-light': 'enem-paraiba-dark',
   'analytica-light': 'analytica-dark',
+  'papole-light': 'papole-dark',
 };
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,6 +18,8 @@
 @import './themes/paraiba/dark.css';
 @import './themes/analytica/light.css';
 @import './themes/analytica/dark.css';
+@import './themes/papole/light.css';
+@import './themes/papole/dark.css';
 
 /*
  * Regras globais do AccessibilityWidget (classes em <html> para

--- a/src/themes/papole/dark.css
+++ b/src/themes/papole/dark.css
@@ -1,0 +1,38 @@
+@layer base {
+  /*
+   * Papolê (dark) — verde institucional, variante escura definida pela
+   * designer (não é derivada por nós).
+   *
+   * Assim como no light, a plataforma só define a rampa primary; os demais
+   * grupos são herdados dos defaults de ../tokens.css.
+   *
+   * Os passos 100–900 são idênticos ao light (a cor de marca continua
+   * reconhecível); dos extremos, `50` vira um tom escuro e `950` um tom claro
+   * — mesmo padrão de ../parana/dark.css.
+   *
+   * DESVIO INTENCIONAL da tabela da designer: ela define "Papolê 0" do dark
+   * como #194D2A. O passo base não é só o topo da rampa — é o foreground de
+   * tudo que tem fundo `primary-800` (barra do AppHeader, ícones de sino,
+   * calendário e perfil). Como o `primary-800` do Papolê continua escuro no
+   * dark (#1f5e34), usar #194D2A daria contraste 1.27:1 e sumiria com o
+   * conteúdo da barra. Mantemos o base igual ao light, exatamente como
+   * parana/base fazem nos temas em que o header não inverte → 7.56:1.
+   */
+  [data-theme='papole-dark'] {
+    color-scheme: dark;
+
+    /* Primary Colors — verde Papolê (dark) */
+    --color-primary: #f9fdfb;
+    --color-primary-50: #1c552f;
+    --color-primary-100: #a4e1b7;
+    --color-primary-200: #79d296;
+    --color-primary-300: #4ec474;
+    --color-primary-400: #36a35a;
+    --color-primary-500: #287842;
+    --color-primary-600: #256f3d;
+    --color-primary-700: #226738;
+    --color-primary-800: #1f5e34;
+    --color-primary-900: #1c552f;
+    --color-primary-950: #79d296;
+  }
+}

--- a/src/themes/papole/light.css
+++ b/src/themes/papole/light.css
@@ -1,0 +1,30 @@
+@layer base {
+  /*
+   * Papolê (light) — verde institucional.
+   *
+   * A plataforma usa APENAS uma rampa primary própria; todos os demais grupos
+   * (secondary, tertiary, text, background, border, success, error, warning,
+   * info, indicator, subject/exam, question-type, map e sombras) são herdados
+   * dos defaults de ../tokens.css de propósito.
+   *
+   * Mapeamento: o token "Papolê 0" da designer corresponde ao passo base da
+   * lib (`--color-primary`, sem sufixo); 50–950 são 1:1.
+   */
+  [data-theme='papole-light'] {
+    color-scheme: light;
+
+    /* Primary Colors — verde Papolê */
+    --color-primary: #f9fdfb;
+    --color-primary-50: #ceefd9;
+    --color-primary-100: #a4e1b7;
+    --color-primary-200: #79d296;
+    --color-primary-300: #4ec474;
+    --color-primary-400: #36a35a;
+    --color-primary-500: #287842;
+    --color-primary-600: #256f3d;
+    --color-primary-700: #226738;
+    --color-primary-800: #1f5e34;
+    --color-primary-900: #1c552f;
+    --color-primary-950: #194d2a;
+  }
+}

--- a/src/themes/themeContrast.test.ts
+++ b/src/themes/themeContrast.test.ts
@@ -1,0 +1,102 @@
+import { readdirSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Contrato dos temas: `--color-primary` (o passo "0"/base da rampa) NÃO é
+ * apenas o topo da escala — é o foreground de tudo que é pintado sobre
+ * `--color-primary-800` (barra do AppHeader e os ícones de sino, calendário e
+ * perfil, que usam `text-primary`).
+ *
+ * Os dois passos precisam formar um par contrastante em TODOS os temas e nos
+ * dois modos, inclusive nos temas em que o dark inverte o header (paraiba,
+ * analytica) e nos que o mantêm escuro (parana, papole).
+ *
+ * Este teste existe porque a tabela original do tema Papolê definia o passo 0
+ * do dark mais escuro que o próprio 800, o que zerava o contraste (1.27:1) e
+ * fazia sumir todo o conteúdo da barra.
+ */
+
+/*
+ * O ESLint só expõe globals de browser/jest em `src/**` (correto: é código que
+ * roda no navegador). Este é o único teste que lê arquivo do disco, então
+ * declaramos o global do Node aqui em vez de afrouxar a config para toda a
+ * pasta. Resolver por `__dirname` — e não pelo cwd — mantém os caminhos
+ * corretos independente de onde o Jest for invocado.
+ */
+/* global __dirname */
+const THEMES_DIR = __dirname;
+const TOKENS_FILE = join(THEMES_DIR, 'tokens.css');
+
+/** Lê o valor de uma custom property em um arquivo CSS. */
+const readToken = (file: string, token: string): string | undefined => {
+  if (!existsSync(file)) return undefined;
+  const css = readFileSync(file, 'utf8');
+  const match = new RegExp(`${token}:\\s*(#[0-9a-fA-F]{3,8})\\s*;`).exec(css);
+  return match?.[1];
+};
+
+/** Luminância relativa (WCAG 2.x). */
+const luminance = (hex: string): number => {
+  const full =
+    hex.length === 4
+      ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+      : hex;
+  const channels = [1, 3, 5].map(
+    (i) => parseInt(full.slice(i, i + 2), 16) / 255
+  );
+  const [r, g, b] = channels.map((c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrast = (a: string, b: string): number => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+/** Temas = subpastas de src/themes que tenham light.css/dark.css. */
+const themeDirs = readdirSync(THEMES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+const cases = themeDirs.flatMap((theme) =>
+  (['light', 'dark'] as const).map((mode) => ({ theme, mode }))
+);
+
+describe('contrato de contraste dos temas', () => {
+  it('encontra as pastas de tema', () => {
+    expect(themeDirs.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)(
+    '$theme/$mode: --color-primary contrasta com --color-primary-800',
+    ({ theme, mode }) => {
+      const file = join(THEMES_DIR, theme, `${mode}.css`);
+      if (!existsSync(file)) return;
+
+      // Quando o tema não declara o token, ele herda o default do tokens.css.
+      const foreground =
+        readToken(file, '--color-primary') ??
+        readToken(TOKENS_FILE, '--color-primary');
+      const background =
+        readToken(file, '--color-primary-800') ??
+        readToken(TOKENS_FILE, '--color-primary-800');
+
+      expect(foreground).toBeDefined();
+      expect(background).toBeDefined();
+
+      const ratio = contrast(foreground!, background!);
+      // AA para texto normal. Falhar aqui significa que o conteúdo da barra
+      // do AppHeader ficaria ilegível neste tema/modo.
+      expect({
+        theme,
+        mode,
+        foreground,
+        background,
+        ratio: +ratio.toFixed(2),
+      }).toMatchObject({ theme, mode });
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Tutoriais” button to the application header, with customizable text and click behavior.
  * Added Papolê light and dark visual themes with dedicated color palettes.
  * Improved header responsiveness so branding and actions remain usable on smaller screens.

* **Bug Fixes**
  * Improved dark-mode theme resolution for the Papolê theme.

* **Tests**
  * Added coverage for tutorial button visibility, styling, interaction, layout, and theme color contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->