### PR TITLE
AE-2925 - feat(modules): add readingFluency flag

### DIFF
--- a/src/components/ModuleProtectedRoute.test.tsx
+++ b/src/components/ModuleProtectedRoute.test.tsx
@@ -57,6 +57,7 @@ const createMockModulesReturn = (
   hasLessons: true,
   hasTutorial: false,
   tutorialUrl: '',
+  hasReadingFluency: false,
   hasExams: true,
   hasSimulations: true,
   simulations: DEFAULT_SIMULATIONS,

--- a/src/hooks/useModules.test.ts
+++ b/src/hooks/useModules.test.ts
@@ -784,4 +784,39 @@ describe('useModules', () => {
       expect(result.current.hasTutorial).toBe(false);
     });
   });
+
+  describe('reading fluency mode', () => {
+    it('hasReadingFluency is false by default (opt-in per institution)', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: defaultModules,
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasReadingFluency).toBe(false);
+    });
+
+    it('hasReadingFluency is true when enabled', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: { ...defaultModules, readingFluency: true },
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasReadingFluency).toBe(true);
+    });
+
+    it('hasReadingFluency defaults to false when the field is missing', () => {
+      mockUseModulesStore.mockReturnValue({
+        modules: {}, // no readingFluency key (old persisted state)
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useModules());
+
+      expect(result.current.hasReadingFluency).toBe(false);
+    });
+  });
 });

--- a/src/hooks/useModules.ts
+++ b/src/hooks/useModules.ts
@@ -33,6 +33,10 @@ export interface UseModulesReturn {
   hasTutorial: boolean;
   tutorialUrl: string;
 
+  // Reading-fluency mode (institution-wide; switches the app to the
+  // fluency-only experience). Off by default.
+  hasReadingFluency: boolean;
+
   // Exams
   hasExams: boolean;
 
@@ -122,6 +126,9 @@ export const useModules = (): UseModulesReturn => {
     // Tutorial: only show the menu link when enabled AND a url is configured
     hasTutorial: (modules.tutorial ?? false) && tutorialUrl.length > 0,
     tutorialUrl,
+
+    // Reading-fluency mode (opt-in per institution, defaults off)
+    hasReadingFluency: modules.readingFluency ?? false,
 
     // Exams (simple boolean, with backwards compatibility for old object format)
     hasExams:

--- a/src/types/modulesConfig.ts
+++ b/src/types/modulesConfig.ts
@@ -130,6 +130,14 @@ export interface ModulesConfig {
   tutorial: boolean;
   tutorialUrl: string;
 
+  /**
+   * Reading-fluency mode (opt-in per institution, off by default).
+   * When `true`, the platform switches to the reading-fluency-only experience:
+   * the professor app hides the navigation menu and exposes only the
+   * "Teste de fluência" page. Consumed via `useModules().hasReadingFluency`.
+   */
+  readingFluency: boolean;
+
   // Nested configurations
   exams: boolean;
   simulations: SimulationsConfig;
@@ -169,6 +177,9 @@ export const DEFAULT_MODULES: ModulesConfig = {
   // Tutorial off by default (opt-in per institution, requires a url)
   tutorial: false,
   tutorialUrl: '',
+
+  // Reading-fluency mode off by default (opt-in per institution)
+  readingFluency: false,
 
   // Nested configurations
   exams: DEFAULT_EXAMS,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an opt-in reading fluency mode.
  - Reading fluency mode is disabled by default and can be enabled through module configuration.
  - Existing configurations remain compatible when the new setting is absent.

- **Tests**
  - Added coverage confirming default, enabled, and legacy-configuration behavior.
  - Updated module-related test setup to account for the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->