### PR TITLE
AE-2899: fix alert form validation

### DIFF
--- a/src/components/AlertManager/AlertSteps/tests/DateStep.test.tsx
+++ b/src/components/AlertManager/AlertSteps/tests/DateStep.test.tsx
@@ -381,9 +381,11 @@ describe('DateStep', () => {
       jest.setSystemTime(mockDate);
 
       useAlertFormStore.getState().resetForm();
+      // sendToday primeiro: desmarcá-lo limpa data/hora, então a escolha
+      // manual precisa vir depois para não ser apagada.
+      useAlertFormStore.getState().setSendToday(false);
       useAlertFormStore.getState().setDate('2024-10-15');
       useAlertFormStore.getState().setTime('14:30');
-      useAlertFormStore.getState().setSendToday(false);
 
       render(<DateStep />);
 

--- a/src/components/AlertManager/tests/useAlertForm.test.ts
+++ b/src/components/AlertManager/tests/useAlertForm.test.ts
@@ -118,10 +118,9 @@ describe('useAlertFormStore', () => {
       jest.useRealTimers();
     });
 
-    it('should set sendToday to false and still update date and time', () => {
+    it('should clear date and time when sendToday is unchecked', () => {
       const { result } = renderHook(() => useAlertFormStore());
 
-      // Mock current date using Jest fake timers
       const mockDate = new Date('2024-10-15T14:30:00');
       jest.useFakeTimers();
       jest.setSystemTime(mockDate);
@@ -134,14 +133,15 @@ describe('useAlertFormStore', () => {
         result.current.setSendToday(false);
       });
 
+      // Campos voltam a ser editáveis e ficam vazios para o usuário escolher
       expect(result.current.sendToday).toBe(false);
-      expect(result.current.date).toBe('2024-10-15');
-      expect(result.current.time).toBe('14:30');
+      expect(result.current.date).toBe('');
+      expect(result.current.time).toBe('');
 
       jest.useRealTimers();
     });
 
-    it('should always update date and time regardless of sendToday value', () => {
+    it('should overwrite date and time with "now" only when sendToday is checked', () => {
       const { result } = renderHook(() => useAlertFormStore());
 
       act(() => {
@@ -161,15 +161,6 @@ describe('useAlertFormStore', () => {
       });
 
       expect(result.current.sendToday).toBe(true);
-      expect(result.current.date).toBe('2024-10-15');
-      expect(result.current.time).toBe('14:30');
-
-      // Test with false as well
-      act(() => {
-        result.current.setSendToday(false);
-      });
-
-      expect(result.current.sendToday).toBe(false);
       expect(result.current.date).toBe('2024-10-15');
       expect(result.current.time).toBe('14:30');
 
@@ -409,9 +400,11 @@ describe('useAlertFormStore', () => {
         result.current.setTitle('Test Title');
         result.current.setMessage('Test Message');
         result.current.setImage(mockFile);
+        // sendToday primeiro: desmarcá-lo limpa data/hora, então a escolha
+        // manual precisa vir depois para não ser apagada.
+        result.current.setSendToday(false);
         result.current.setDate('2024-10-15');
         result.current.setTime('14:30');
-        result.current.setSendToday(false);
         result.current.initializeCategory(mockCategory);
       });
 

--- a/src/components/AlertManager/tests/validation.test.ts
+++ b/src/components/AlertManager/tests/validation.test.ts
@@ -139,6 +139,28 @@ describe('AlertsManager Validation Functions', () => {
       expect(result).toBe(true);
     });
 
+    it('should return error when date is provided but time is missing', () => {
+      const formData = {
+        ...mockFormData,
+        sendToday: false,
+        date: '2024-01-01',
+        time: '',
+      };
+      const result = validateDateStep(formData);
+      expect(result).toBe('Hora é obrigatória');
+    });
+
+    it('should ignore a missing time when sendToday is true', () => {
+      const formData = {
+        ...mockFormData,
+        sendToday: true,
+        date: '',
+        time: '',
+      };
+      const result = validateDateStep(formData);
+      expect(result).toBe(true);
+    });
+
     it('should return error when neither sendToday nor date is provided', () => {
       const formData = { ...mockFormData, sendToday: false, date: '' };
       const result = validateDateStep(formData);

--- a/src/components/AlertManager/useAlertForm.ts
+++ b/src/components/AlertManager/useAlertForm.ts
@@ -149,7 +149,14 @@ export const useAlertFormStore = create<AlertFormStore>((set) => ({
   setTime: (time) => set({ time }),
 
   setSendToday: (sendToday: boolean) => {
-    // Define data e hora atuais quando sendToday é true
+    // Ao desmarcar, o campo volta a ser editável e deve ficar vazio para o
+    // usuário escolher — sobrescrever com "agora" apagaria a escolha dele.
+    if (!sendToday) {
+      set({ sendToday, date: '', time: '' });
+      return;
+    }
+
+    // Marcado: preenche com data e hora atuais (envio imediato)
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
@@ -158,7 +165,7 @@ export const useAlertFormStore = create<AlertFormStore>((set) => ({
     const minutes = String(now.getMinutes()).padStart(2, '0');
 
     set({
-      sendToday: sendToday,
+      sendToday,
       date: `${year}-${month}-${day}`,
       time: `${hours}:${minutes}`,
     });

--- a/src/components/AlertManager/validation.ts
+++ b/src/components/AlertManager/validation.ts
@@ -43,7 +43,10 @@ export const validateRecipientsStep = (
  * Valida o step de data
  */
 export const validateDateStep = (formData: AlertData): boolean | string => {
-  if (!formData.sendToday && !formData.date) return 'Data é obrigatória';
+  if (formData.sendToday) return true;
+  if (!formData.date) return 'Data é obrigatória';
+  // Sem hora não há como agendar um instante exato de envio
+  if (!formData.time) return 'Hora é obrigatória';
   return true;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated “Send today” behavior to clear the selected date and time when disabled.
  * Automatically fills the current date and time when enabled.
  * Improved date-step validation to require both date and time when scheduling for later.
  * Allows date-step completion without date or time when “Send today” is enabled.

* **Tests**
  * Expanded coverage for date/time clearing and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->