### PR TITLE
AE-2939 imagens e url de imagens no editor de texto

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@tiptap/core": "^3.0.0",
     "@tiptap/extension-color": "^3.0.0",
     "@tiptap/extension-highlight": "^3.0.0",
+    "@tiptap/extension-image": "^3.0.0",
     "@tiptap/extension-link": "^3.0.0",
     "@tiptap/extension-placeholder": "^3.0.0",
     "@tiptap/extension-subscript": "^3.0.0",
@@ -96,6 +97,9 @@
       "optional": true
     },
     "@tiptap/extension-highlight": {
+      "optional": true
+    },
+    "@tiptap/extension-image": {
       "optional": true
     },
     "@tiptap/extension-link": {
@@ -166,6 +170,7 @@
     "@tiptap/core": "^3.24.0",
     "@tiptap/extension-color": "^3.24.0",
     "@tiptap/extension-highlight": "^3.24.0",
+    "@tiptap/extension-image": "3.24.0",
     "@tiptap/extension-link": "^3.24.0",
     "@tiptap/extension-placeholder": "^3.24.0",
     "@tiptap/extension-subscript": "^3.24.0",

--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.test.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.test.tsx
@@ -607,3 +607,82 @@ describe('utils', () => {
     });
   });
 });
+
+describe('quebras de linha em conteúdo de texto puro', () => {
+  // Pure text with no tags takes the Markdown path (which already handles
+  // blank lines); a single loose tag forces the HTML path, where the bug lives.
+  it('deve separar com <br> texto com linha em branco', () => {
+    const { container } = render(
+      <HtmlMathRenderer content={'Primeira.\n\n<b>Segunda</b>.'} testId="r" />
+    );
+
+    expect(container.querySelectorAll('br')).toHaveLength(2);
+    expect(container).toHaveTextContent('Primeira.');
+    expect(container).toHaveTextContent('Segunda.');
+  });
+
+  it('deve converter quebra simples em um único <br>', () => {
+    const { container } = render(
+      <HtmlMathRenderer content={'Linha um.\nLinha dois.'} testId="r" />
+    );
+
+    expect(container.querySelectorAll('br')).toHaveLength(1);
+  });
+
+  it('deve preservar tags inline soltas ao quebrar linhas', () => {
+    const { container } = render(
+      <HtmlMathRenderer
+        content={'A) <b>Correta</b>.Explicação.\n\nB) <b>Incorreta</b>.Outra.'}
+        testId="r"
+      />
+    );
+
+    expect(container.querySelectorAll('b')).toHaveLength(2);
+    expect(container.querySelectorAll('br').length).toBeGreaterThan(0);
+  });
+
+  it('nunca deve emitir <p>, que o fatiamento por partes quebraria', () => {
+    const { container } = render(
+      <HtmlMathRenderer content={'Primeira.\n\n<b>Segunda</b>.'} testId="r" />
+    );
+
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('não deve emitir <p> no modo inline', () => {
+    const { container } = render(
+      <HtmlMathRenderer content={'Primeira.\n\nSegunda.'} inline testId="r" />
+    );
+
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+    expect(container.querySelectorAll('br').length).toBeGreaterThan(0);
+  });
+
+  it('não deve alterar conteúdo que já é HTML estruturado', () => {
+    const { container } = render(
+      <HtmlMathRenderer
+        content={'<p>Primeira.</p>\n\n<p>Segunda.</p>'}
+        testId="r"
+      />
+    );
+
+    expect(container.querySelectorAll('p')).toHaveLength(2);
+    expect(container.querySelectorAll('br')).toHaveLength(0);
+  });
+
+  // Content with any HTML tag bypasses the Markdown path, so this hybrid shape
+  // (loose <b> + LaTeX + newlines) is exactly what reaches the HTML pipeline.
+  it('deve preservar quebras junto com LaTeX e tags inline', () => {
+    const { container } = render(
+      <HtmlMathRenderer
+        content={'A) <b>Correta</b>: $x = 1$.\n\nB) <b>Errada</b>: $y = 2$.'}
+        testId="r"
+      />
+    );
+
+    expect(screen.getAllByTestId('inline-math')).toHaveLength(2);
+    expect(container.querySelectorAll('b')).toHaveLength(2);
+    expect(container.querySelectorAll('br').length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+  });
+});

--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.tsx
@@ -2,6 +2,7 @@ import { CSSProperties, forwardRef, memo, ReactNode, Ref } from 'react';
 import 'katex/dist/katex.min.css';
 import { KatexMath } from './KatexMath';
 import { cn } from '../../utils/utils';
+import { normalizeLineBreaksInHtml } from '../../utils/htmlLineBreaks';
 import MarkdownMathRenderer from '../MarkdownMathRenderer/MarkdownMathRenderer';
 import {
   isLikelyMarkdown,
@@ -90,9 +91,23 @@ const HtmlMathRenderer = forwardRef<HTMLElement, HtmlMathRendererProps>(
     const renderContent = () => {
       if (!content) return null;
 
+      // Question content is stored as plain text with `\n` line breaks mixed
+      // with loose inline tags. Newlines are insignificant whitespace in HTML,
+      // so without this the whole thing renders as one collapsed run of text.
+      // Content that is already structured HTML passes through untouched.
+      //
+      // Breaks are always emitted as <br>, never <p>: the mixed text+math path
+      // below wraps each part in its own element, which would cut a paragraph
+      // in half across a math expression. <br> is inline and survives the split
+      // intact — and `[&_p]:mb-0` below means paragraphs carry no spacing here
+      // anyway, so there is nothing to gain from block elements.
+      const normalizedContent = normalizeLineBreaksInHtml(content, {
+        inline: true,
+      });
+
       const processedContent = sanitize
-        ? sanitizeHtmlForDisplay(content)
-        : content;
+        ? sanitizeHtmlForDisplay(normalizedContent)
+        : normalizedContent;
 
       const parts = processHtmlWithMath(processedContent);
 

--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -259,7 +259,9 @@ describe('ImageUpload Component', () => {
         <ImageUpload selectedFile={mockFile} onRemoveFile={onRemoveFile} />
       );
 
-      const removeButton = screen.getByRole('button', { name: '' });
+      const removeButton = screen.getByRole('button', {
+        name: 'Remover imagem',
+      });
       fireEvent.click(removeButton);
 
       expect(onRemoveFile).toHaveBeenCalled();

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -171,6 +171,8 @@ export default function ImageUpload({
               onClick={handleRemoveFile}
               disabled={disabled}
               className="hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Remover imagem"
+              title="Remover imagem"
             >
               <XIcon className="h-4 w-4 text-primary-950 cursor-pointer" />
             </button>

--- a/src/components/RichEditor/RichEditor.test.tsx
+++ b/src/components/RichEditor/RichEditor.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { RichEditor } from './RichEditorCore';
 import { useEditor } from '@tiptap/react';
@@ -29,6 +35,7 @@ interface MockChainResult {
   extendMarkRange: jest.Mock;
   setLink: jest.Mock;
   unsetLink: jest.Mock;
+  setImage: jest.Mock;
   insertContent: jest.Mock;
   setContent: jest.Mock;
   run: jest.Mock;
@@ -52,6 +59,7 @@ const createMockChain = (): MockChainResult => ({
   extendMarkRange: jest.fn(() => createMockChain()),
   setLink: jest.fn(() => createMockChain()),
   unsetLink: jest.fn(() => createMockChain()),
+  setImage: jest.fn(() => createMockChain()),
   insertContent: jest.fn(() => createMockChain()),
   setContent: jest.fn(() => createMockChain()),
   run: jest.fn(),
@@ -432,5 +440,122 @@ describe('RichEditor', () => {
 
       expect(container.firstChild).toBeNull();
     });
+  });
+});
+
+describe('Imagem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // An earlier test sets useEditor to null to cover the "no editor" branch,
+    // and mockReturnValue survives clearAllMocks.
+    (useEditor as jest.Mock).mockReturnValue(mockEditor);
+  });
+
+  it('deve abrir o ImageDialog ao clicar no botão de imagem', () => {
+    render(<RichEditor />);
+
+    fireEvent.click(screen.getByTitle('Inserir imagem'));
+
+    expect(
+      screen.getByRole('heading', { name: 'Inserir imagem' })
+    ).toBeInTheDocument();
+  });
+
+  it('deve fechar o ImageDialog ao cancelar', () => {
+    render(<RichEditor />);
+
+    fireEvent.click(screen.getByTitle('Inserir imagem'));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+
+    expect(
+      screen.queryByRole('heading', { name: 'Inserir imagem' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('deve inserir a imagem no editor ao confirmar uma URL', () => {
+    render(<RichEditor />);
+
+    fireEvent.click(screen.getByTitle('Inserir imagem'));
+    fireEvent.change(
+      screen.getByPlaceholderText('https://exemplo.com/imagem.png'),
+      { target: { value: 'https://cdn.exemplo.com/a.png' } }
+    );
+    // The toolbar button carries the same accessible name, so scope the query
+    // to the dialog.
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Inserir imagem',
+      })
+    );
+
+    expect(mockEditor.chain).toHaveBeenCalled();
+    expect(
+      screen.queryByRole('heading', { name: 'Inserir imagem' })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('Sincronização de conteúdo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useEditor as jest.Mock).mockReturnValue(mockEditor);
+  });
+
+  // The last call is the render from the current test; earlier entries belong
+  // to previous ones.
+  const getEditorConfig = () =>
+    (useEditor as jest.Mock).mock.calls.at(-1)![0] as {
+      onUpdate: (arg: { editor: typeof mockEditor }) => void;
+    };
+
+  it('deve notificar onChange ao editar', () => {
+    const onChange = jest.fn();
+    render(<RichEditor onChange={onChange} />);
+
+    getEditorConfig().onUpdate({ editor: mockEditor });
+
+    expect(onChange).toHaveBeenCalledWith({
+      json: { type: 'doc', content: [] },
+      html: '<p>Test content</p>',
+    });
+  });
+
+  it('não deve quebrar quando onChange não é informado', () => {
+    render(<RichEditor />);
+
+    expect(() =>
+      getEditorConfig().onUpdate({ editor: mockEditor })
+    ).not.toThrow();
+  });
+
+  it('deve aplicar conteúdo novo vindo de fora', () => {
+    const { rerender } = render(<RichEditor content="<p>Inicial</p>" />);
+
+    rerender(<RichEditor content="<p>Carregado da API</p>" />);
+
+    expect(mockEditor.commands.setContent).toHaveBeenCalledWith(
+      '<p>Carregado da API</p>',
+      { emitUpdate: false }
+    );
+  });
+
+  it('deve normalizar quebras de linha do conteúdo externo', () => {
+    const { rerender } = render(<RichEditor content="inicial" />);
+
+    rerender(<RichEditor content={'Linha um.\n\n<b>Linha dois.</b>'} />);
+
+    expect(mockEditor.commands.setContent).toHaveBeenCalledWith(
+      '<p>Linha um.</p><p><b>Linha dois.</b></p>',
+      { emitUpdate: false }
+    );
+  });
+
+  it('não deve reaplicar o mesmo conteúdo', () => {
+    const { rerender } = render(<RichEditor content="<p>Igual</p>" />);
+    (mockEditor.commands.setContent as jest.Mock).mockClear();
+
+    rerender(<RichEditor content="<p>Igual</p>" />);
+
+    expect(mockEditor.commands.setContent).not.toHaveBeenCalled();
   });
 });

--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -18,6 +18,13 @@ interface RichEditorProps {
    * @returns Promise resolving to the LaTeX string
    */
   readonly onGenerateLatexWithAI?: (description: string) => Promise<string>;
+  /**
+   * Optional callback to upload an image file and get back its public URL.
+   * If provided, the image insertion button is enabled in the toolbar.
+   * @param file - The image file selected by the user
+   * @returns Promise resolving to the public URL of the uploaded image
+   */
+  readonly onUploadImage?: (file: File) => Promise<string>;
 }
 
 interface ErrorBoundaryState {
@@ -64,6 +71,7 @@ const TIPTAP_DEPENDENCIES = [
   '@tiptap/extension-superscript',
   '@tiptap/extension-link',
   '@tiptap/extension-placeholder',
+  '@tiptap/extension-image',
 ];
 
 function MissingDependenciesError({ error }: { readonly error: Error }) {

--- a/src/components/RichEditor/RichEditor.tsx
+++ b/src/components/RichEditor/RichEditor.tsx
@@ -20,7 +20,8 @@ interface RichEditorProps {
   readonly onGenerateLatexWithAI?: (description: string) => Promise<string>;
   /**
    * Optional callback to upload an image file and get back its public URL.
-   * If provided, the image insertion button is enabled in the toolbar.
+   * If provided, the file upload tab is enabled in the image dialog; otherwise
+   * images can still be inserted by URL.
    * @param file - The image file selected by the user
    * @returns Promise resolving to the public URL of the uploaded image
    */

--- a/src/components/RichEditor/RichEditorCore.tsx
+++ b/src/components/RichEditor/RichEditorCore.tsx
@@ -1,6 +1,9 @@
 import { EditorContent, useEditor } from '@tiptap/react';
 import { createRichEditorExtensions } from './components/extensions';
-import { processLatexInHtml } from './components/utils';
+import {
+  normalizeLineBreaksInHtml,
+  processLatexInHtml,
+} from './components/utils';
 import 'katex/dist/katex.min.css';
 import { TextBolderIcon } from '@phosphor-icons/react/dist/csr/TextB';
 import { TextItalicIcon } from '@phosphor-icons/react/dist/csr/TextItalic';
@@ -50,6 +53,13 @@ const ToolbarBtn = ({ onClick, active, title, children }: ToolbarBtnProps) => (
 
 const Divider = () => <div className="w-px h-5 bg-border-200 mx-0.5" />;
 
+/**
+ * Prepares stored content for the TipTap parser. Line breaks are restored first
+ * so that LaTeX spans are injected into already-structured markup.
+ */
+const prepareContent = (content?: string) =>
+  processLatexInHtml(normalizeLineBreaksInHtml(content || ''));
+
 interface RichEditorProps {
   readonly content?: string;
   readonly onChange?: (data: { json: object; html: string }) => void;
@@ -84,7 +94,7 @@ export function RichEditor({
 
   const editor = useEditor({
     extensions: createRichEditorExtensions(placeholder),
-    content: processLatexInHtml(content || ''),
+    content: prepareContent(content),
     onUpdate: ({ editor }) => {
       // Skip onChange callback during external content updates
       if (isExternalUpdateRef.current) {
@@ -109,8 +119,9 @@ export function RichEditor({
   // Update editor content when prop changes externally (e.g., from loadQuestion)
   useEffect(() => {
     if (editor && content !== undefined && content !== lastContentRef.current) {
-      const processedContent = processLatexInHtml(content || '');
-      editor.commands.setContent(processedContent, { emitUpdate: false });
+      editor.commands.setContent(prepareContent(content), {
+        emitUpdate: false,
+      });
       lastContentRef.current = content;
     }
   }, [content, editor]);

--- a/src/components/RichEditor/RichEditorCore.tsx
+++ b/src/components/RichEditor/RichEditorCore.tsx
@@ -73,7 +73,8 @@ interface RichEditorProps {
   readonly onGenerateLatexWithAI?: (description: string) => Promise<string>;
   /**
    * Optional callback to upload an image file and get back its public URL.
-   * If provided, the image insertion button is enabled in the toolbar.
+   * If provided, the file upload tab is enabled in the image dialog; otherwise
+   * images can still be inserted by URL.
    * @param file - The image file selected by the user
    * @returns Promise resolving to the public URL of the uploaded image
    */

--- a/src/components/RichEditor/RichEditorCore.tsx
+++ b/src/components/RichEditor/RichEditorCore.tsx
@@ -89,18 +89,14 @@ export function RichEditor({
 }: RichEditorProps) {
   const [formulaOpen, setFormulaOpen] = useState(false);
   const [imageOpen, setImageOpen] = useState(false);
-  const isExternalUpdateRef = useRef(false);
   const lastContentRef = useRef(content);
 
   const editor = useEditor({
     extensions: createRichEditorExtensions(placeholder),
     content: prepareContent(content),
+    // External updates do not reach this callback: the sync effect below calls
+    // setContent with `emitUpdate: false`.
     onUpdate: ({ editor }) => {
-      // Skip onChange callback during external content updates
-      if (isExternalUpdateRef.current) {
-        isExternalUpdateRef.current = false;
-        return;
-      }
       const html = editor.getHTML();
       lastContentRef.current = html;
       onChange?.({

--- a/src/components/RichEditor/RichEditorCore.tsx
+++ b/src/components/RichEditor/RichEditorCore.tsx
@@ -1,15 +1,5 @@
 import { EditorContent, useEditor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Underline from '@tiptap/extension-underline';
-import TextAlign from '@tiptap/extension-text-align';
-import { Color } from '@tiptap/extension-color';
-import { TextStyle } from '@tiptap/extension-text-style';
-import Highlight from '@tiptap/extension-highlight';
-import Subscript from '@tiptap/extension-subscript';
-import Superscript from '@tiptap/extension-superscript';
-import Link from '@tiptap/extension-link';
-import Placeholder from '@tiptap/extension-placeholder';
-import { MathNode } from './components/MathNode';
+import { createRichEditorExtensions } from './components/extensions';
 import { processLatexInHtml } from './components/utils';
 import 'katex/dist/katex.min.css';
 import { TextBolderIcon } from '@phosphor-icons/react/dist/csr/TextB';
@@ -30,8 +20,10 @@ import { TextHOneIcon } from '@phosphor-icons/react/dist/csr/TextHOne';
 import { TextHTwoIcon } from '@phosphor-icons/react/dist/csr/TextHTwo';
 import { TextHThreeIcon } from '@phosphor-icons/react/dist/csr/TextHThree';
 import { MathOperationsIcon } from '@phosphor-icons/react/dist/csr/MathOperations';
+import { ImageIcon } from '@phosphor-icons/react/dist/csr/Image';
 import { useState, useRef, useEffect, ReactNode } from 'react';
 import { FormulaDialog } from './components/FormulaDialog';
+import { ImageDialog } from './components/ImageDialog';
 import Button from '../Button/Button';
 import Text from '../Text/Text';
 
@@ -69,6 +61,13 @@ interface RichEditorProps {
    * @returns Promise resolving to the LaTeX string
    */
   readonly onGenerateLatexWithAI?: (description: string) => Promise<string>;
+  /**
+   * Optional callback to upload an image file and get back its public URL.
+   * If provided, the image insertion button is enabled in the toolbar.
+   * @param file - The image file selected by the user
+   * @returns Promise resolving to the public URL of the uploaded image
+   */
+  readonly onUploadImage?: (file: File) => Promise<string>;
 }
 
 export function RichEditor({
@@ -76,25 +75,15 @@ export function RichEditor({
   onChange,
   placeholder = 'Digite aqui...',
   onGenerateLatexWithAI,
+  onUploadImage,
 }: RichEditorProps) {
   const [formulaOpen, setFormulaOpen] = useState(false);
+  const [imageOpen, setImageOpen] = useState(false);
   const isExternalUpdateRef = useRef(false);
   const lastContentRef = useRef(content);
 
   const editor = useEditor({
-    extensions: [
-      StarterKit,
-      Underline,
-      TextStyle,
-      Color,
-      Highlight.configure({ multicolor: true }),
-      Subscript,
-      Superscript,
-      TextAlign.configure({ types: ['heading', 'paragraph'] }),
-      Link.configure({ openOnClick: false }),
-      Placeholder.configure({ placeholder }),
-      MathNode,
-    ],
+    extensions: createRichEditorExtensions(placeholder),
     content: processLatexInHtml(content || ''),
     onUpdate: ({ editor }) => {
       // Skip onChange callback during external content updates
@@ -137,6 +126,12 @@ export function RichEditor({
       })
       .run();
     setFormulaOpen(false);
+  };
+
+  const insertImage = (src: string, alt: string) => {
+    if (!src || !editor) return;
+    editor.chain().focus().setImage({ src, alt }).run();
+    setImageOpen(false);
   };
 
   const setLink = () => {
@@ -316,6 +311,15 @@ export function RichEditor({
           <LinkIcon size={16} />
         </ToolbarBtn>
 
+        {/* Image */}
+        <ToolbarBtn
+          onClick={() => setImageOpen(true)}
+          active={editor.isActive('image')}
+          title="Inserir imagem"
+        >
+          <ImageIcon size={16} />
+        </ToolbarBtn>
+
         {/* Formula */}
         <Button
           type="button"
@@ -346,6 +350,13 @@ export function RichEditor({
         onClose={() => setFormulaOpen(false)}
         onInsert={insertFormula}
         onGenerateWithAI={onGenerateLatexWithAI}
+      />
+
+      <ImageDialog
+        open={imageOpen}
+        onClose={() => setImageOpen(false)}
+        onInsert={insertImage}
+        onUploadImage={onUploadImage}
       />
     </div>
   );

--- a/src/components/RichEditor/components/ImageDialog.test.tsx
+++ b/src/components/RichEditor/components/ImageDialog.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ImageDialog, MAX_IMAGE_SIZE } from './ImageDialog';
+
+const setup = (props: Partial<Parameters<typeof ImageDialog>[0]> = {}) => {
+  const onInsert = jest.fn();
+  const onClose = jest.fn();
+  render(<ImageDialog open onClose={onClose} onInsert={onInsert} {...props} />);
+  return { onInsert, onClose };
+};
+
+const selectFile = (file: File) => {
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+};
+
+const imageFile = (name = 'foto.png', size = 1024) => {
+  const file = new File(['x'], name, { type: 'image/png' });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+};
+
+describe('ImageDialog', () => {
+  it('deve expor o limite de 5MB alinhado ao backend', () => {
+    expect(MAX_IMAGE_SIZE).toBe(5 * 1024 * 1024);
+  });
+
+  describe('sem onUploadImage', () => {
+    it('deve mostrar apenas o modo URL', () => {
+      setup();
+
+      expect(screen.getByText('URL da imagem')).toBeInTheDocument();
+      expect(screen.queryByText('Enviar arquivo')).not.toBeInTheDocument();
+    });
+
+    it('deve inserir a URL digitada', () => {
+      const { onInsert } = setup();
+
+      fireEvent.change(
+        screen.getByPlaceholderText('https://exemplo.com/imagem.png'),
+        { target: { value: 'https://cdn.exemplo.com/foto.png' } }
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      expect(onInsert).toHaveBeenCalledWith(
+        'https://cdn.exemplo.com/foto.png',
+        ''
+      );
+    });
+
+    it('não deve inserir quando a URL está vazia', () => {
+      const { onInsert } = setup();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      expect(onInsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('com onUploadImage', () => {
+    it('deve fazer upload e inserir a URL pública retornada', async () => {
+      const onUploadImage = jest
+        .fn()
+        .mockResolvedValue('https://cdn.exemplo.com/enviada.png');
+      const { onInsert } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/enviada.png',
+          ''
+        )
+      );
+      expect(onUploadImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('deve exibir erro e não inserir quando o upload falha', async () => {
+      const onUploadImage = jest
+        .fn()
+        .mockRejectedValue(new Error('Falha na rede'));
+      const { onInsert } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      await waitFor(() =>
+        expect(screen.getByText('Falha na rede')).toBeInTheDocument()
+      );
+      expect(onInsert).not.toHaveBeenCalled();
+    });
+
+    it('deve rejeitar arquivo acima de 5MB', async () => {
+      const onUploadImage = jest.fn();
+      setup({ onUploadImage });
+
+      selectFile(imageFile('grande.png', MAX_IMAGE_SIZE + 1));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText('A imagem deve ter no máximo 5MB.')
+        ).toBeInTheDocument()
+      );
+      expect(onUploadImage).not.toHaveBeenCalled();
+    });
+
+    it('deve permitir alternar para o modo URL', () => {
+      const onUploadImage = jest.fn();
+      const { onInsert } = setup({ onUploadImage });
+
+      fireEvent.click(screen.getByRole('button', { name: /Usar URL/ }));
+      fireEvent.change(
+        screen.getByPlaceholderText('https://exemplo.com/imagem.png'),
+        { target: { value: 'https://cdn.exemplo.com/url.png' } }
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      expect(onInsert).toHaveBeenCalledWith(
+        'https://cdn.exemplo.com/url.png',
+        ''
+      );
+      expect(onUploadImage).not.toHaveBeenCalled();
+    });
+
+    it('deve enviar o texto alternativo informado', async () => {
+      const onUploadImage = jest
+        .fn()
+        .mockResolvedValue('https://cdn.exemplo.com/enviada.png');
+      const { onInsert } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      fireEvent.change(
+        screen.getByPlaceholderText('Descreva a imagem para leitores de tela'),
+        { target: { value: 'Gráfico de barras' } }
+      );
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/enviada.png',
+          'Gráfico de barras'
+        )
+      );
+    });
+  });
+});

--- a/src/components/RichEditor/components/ImageDialog.test.tsx
+++ b/src/components/RichEditor/components/ImageDialog.test.tsx
@@ -216,4 +216,60 @@ describe('ImageDialog', () => {
       ).toBeDisabled();
     });
   });
+
+  describe('cancelamento durante o upload', () => {
+    it('não deve inserir a imagem se o diálogo for fechado antes do upload terminar', async () => {
+      let resolveUpload: (url: string) => void = () => {};
+      const onUploadImage = jest.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUpload = resolve;
+          })
+      );
+      const { onInsert, onClose } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      // O botão Cancelar fica desabilitado durante o upload, mas o Modal ainda
+      // fecha no Escape — que é o caminho real do problema.
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalled();
+
+      resolveUpload('https://cdn.exemplo.com/tardia.png');
+      await waitFor(() => expect(onUploadImage).toHaveBeenCalled());
+
+      expect(onInsert).not.toHaveBeenCalled();
+    });
+
+    it('não deve exibir erro de upload após o fechamento', async () => {
+      let rejectUpload: (e: Error) => void = () => {};
+      const onUploadImage = jest.fn(
+        () =>
+          new Promise<string>((_, reject) => {
+            rejectUpload = reject;
+          })
+      );
+      setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      rejectUpload(new Error('Falha tardia'));
+      await waitFor(() => expect(onUploadImage).toHaveBeenCalled());
+
+      expect(screen.queryByText('Falha tardia')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/RichEditor/components/ImageDialog.test.tsx
+++ b/src/components/RichEditor/components/ImageDialog.test.tsx
@@ -97,9 +97,7 @@ describe('ImageDialog', () => {
       );
       fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
 
-      await waitFor(() =>
-        expect(screen.getByText('Falha na rede')).toBeInTheDocument()
-      );
+      expect(await screen.findByText('Falha na rede')).toBeInTheDocument();
       expect(onInsert).not.toHaveBeenCalled();
     });
 
@@ -109,11 +107,9 @@ describe('ImageDialog', () => {
 
       selectFile(imageFile('grande.png', MAX_IMAGE_SIZE + 1));
 
-      await waitFor(() =>
-        expect(
-          screen.getByText('A imagem deve ter no máximo 5MB.')
-        ).toBeInTheDocument()
-      );
+      expect(
+        await screen.findByText('A imagem deve ter no máximo 5MB.')
+      ).toBeInTheDocument();
       expect(onUploadImage).not.toHaveBeenCalled();
     });
 
@@ -159,6 +155,65 @@ describe('ImageDialog', () => {
           'Gráfico de barras'
         )
       );
+    });
+  });
+
+  describe('interações auxiliares', () => {
+    it('deve fechar e limpar o estado ao cancelar', () => {
+      const onUploadImage = jest.fn();
+      const { onClose } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('deve rejeitar arquivo que não é imagem', async () => {
+      const onUploadImage = jest.fn();
+      setup({ onUploadImage });
+
+      const naoImagem = new File(['x'], 'documento.pdf', {
+        type: 'application/pdf',
+      });
+      selectFile(naoImagem);
+
+      expect(
+        await screen.findByText('Selecione um arquivo de imagem válido.')
+      ).toBeInTheDocument();
+      expect(onUploadImage).not.toHaveBeenCalled();
+    });
+
+    it('deve permitir voltar do modo URL para o modo arquivo', () => {
+      const onUploadImage = jest.fn();
+      setup({ onUploadImage });
+
+      fireEvent.click(screen.getByRole('button', { name: /Usar URL/ }));
+      expect(screen.getByText('URL da imagem')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /Enviar arquivo/ }));
+
+      expect(screen.queryByText('URL da imagem')).not.toBeInTheDocument();
+      expect(document.querySelector('input[type="file"]')).toBeInTheDocument();
+    });
+
+    it('deve limpar o arquivo selecionado ao removê-lo', async () => {
+      const onUploadImage = jest.fn();
+      setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+
+      const remover = screen.getByRole('button', { name: /remover/i });
+      fireEvent.click(remover);
+
+      expect(
+        screen.getByRole('button', { name: 'Inserir imagem' })
+      ).toBeDisabled();
     });
   });
 });

--- a/src/components/RichEditor/components/ImageDialog.tsx
+++ b/src/components/RichEditor/components/ImageDialog.tsx
@@ -1,0 +1,217 @@
+import { useState, ChangeEvent } from 'react';
+import Button from '../../Button/Button';
+import Input from '../../Input/Input';
+import ImageUpload from '../../ImageUpload/ImageUpload';
+import Modal from '../../Modal/Modal';
+import Text from '../../Text/Text';
+import { LinkIcon } from '@phosphor-icons/react/dist/csr/Link';
+import { UploadSimpleIcon } from '@phosphor-icons/react/dist/csr/UploadSimple';
+
+/**
+ * Matches the 5MB cap enforced by the backend pre-signed URL schema.
+ * Keeping it here avoids the client accepting files the server will reject.
+ */
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+
+type InputMode = 'file' | 'url';
+
+interface ImageDialogProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onInsert: (src: string, alt: string) => void;
+  /**
+   * Optional callback to upload an image file and get back its public URL.
+   * If provided, the file upload tab is enabled; otherwise only URL input is
+   * available. The library stays agnostic of how the consumer uploads.
+   * @param file - The image file selected by the user
+   * @returns Promise resolving to the public URL of the uploaded image
+   */
+  readonly onUploadImage?: (file: File) => Promise<string>;
+}
+
+export function ImageDialog({
+  open,
+  onClose,
+  onInsert,
+  onUploadImage,
+}: ImageDialogProps) {
+  const [inputMode, setInputMode] = useState<InputMode>(
+    onUploadImage ? 'file' : 'url'
+  );
+  const [file, setFile] = useState<File | null>(null);
+  const [url, setUrl] = useState('');
+  const [alt, setAlt] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState('');
+
+  const resetState = () => {
+    setInputMode(onUploadImage ? 'file' : 'url');
+    setFile(null);
+    setUrl('');
+    setAlt('');
+    setIsUploading(false);
+    setError('');
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleFileSelect = (selected: File) => {
+    setFile(selected);
+    setError('');
+  };
+
+  const handleSizeError = () => {
+    setFile(null);
+    setError('A imagem deve ter no máximo 5MB.');
+  };
+
+  const handleTypeError = () => {
+    setFile(null);
+    setError('Selecione um arquivo de imagem válido.');
+  };
+
+  const switchMode = (mode: InputMode) => {
+    setInputMode(mode);
+    setError('');
+  };
+
+  const handleInsert = async () => {
+    if (inputMode === 'url') {
+      if (!url.trim()) return;
+      onInsert(url.trim(), alt.trim());
+      resetState();
+      return;
+    }
+
+    if (!file || !onUploadImage) return;
+
+    setIsUploading(true);
+    setError('');
+
+    try {
+      // Upload before inserting so the saved HTML never holds a blob: URL,
+      // which would break as soon as the page unloads.
+      const uploadedUrl = await onUploadImage(file);
+      onInsert(uploadedUrl, alt.trim());
+      resetState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao enviar a imagem.');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const canInsert = inputMode === 'url' ? !!url.trim() : !!file;
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={handleClose}
+      title="Inserir imagem"
+      size="md"
+      footer={
+        <>
+          <Button
+            variant="outline"
+            onClick={handleClose}
+            disabled={isUploading}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="solid"
+            action="primary"
+            onClick={handleInsert}
+            disabled={!canInsert || isUploading}
+          >
+            {isUploading ? 'Enviando...' : 'Inserir imagem'}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        {onUploadImage && (
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant={inputMode === 'file' ? 'solid' : 'outline'}
+              action="primary"
+              size="small"
+              onClick={() => switchMode('file')}
+              className="flex items-center gap-1"
+            >
+              <UploadSimpleIcon size={14} />
+              Enviar arquivo
+            </Button>
+            <Button
+              type="button"
+              variant={inputMode === 'url' ? 'solid' : 'outline'}
+              action="primary"
+              size="small"
+              onClick={() => switchMode('url')}
+              className="flex items-center gap-1"
+            >
+              <LinkIcon size={14} />
+              Usar URL
+            </Button>
+          </div>
+        )}
+
+        {inputMode === 'file' && onUploadImage ? (
+          <div>
+            <ImageUpload
+              selectedFile={file}
+              onFileSelect={handleFileSelect}
+              onRemoveFile={() => setFile(null)}
+              maxSize={MAX_IMAGE_SIZE}
+              onSizeError={handleSizeError}
+              onTypeError={handleTypeError}
+              disabled={isUploading}
+            />
+            <Text size="xs" className="text-text-400 mt-1">
+              Formatos aceitos: PNG, JPG, GIF, WEBP (máx. 5MB)
+            </Text>
+          </div>
+        ) : (
+          <div>
+            <Text weight="medium" className="text-xs text-text-600 mb-2 block">
+              URL da imagem
+            </Text>
+            <Input
+              type="text"
+              value={url}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setUrl(e.target.value)
+              }
+              placeholder="https://exemplo.com/imagem.png"
+            />
+          </div>
+        )}
+
+        <div>
+          <Text weight="medium" className="text-xs text-text-600 mb-2 block">
+            Texto alternativo (opcional)
+          </Text>
+          <Input
+            type="text"
+            value={alt}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setAlt(e.target.value)
+            }
+            placeholder="Descreva a imagem para leitores de tela"
+            disabled={isUploading}
+          />
+        </div>
+
+        {error && (
+          <Text size="xs" className="text-error-600">
+            {error}
+          </Text>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/RichEditor/components/ImageDialog.tsx
+++ b/src/components/RichEditor/components/ImageDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent } from 'react';
+import { useState, useRef, ChangeEvent } from 'react';
 import Button from '../../Button/Button';
 import Input from '../../Input/Input';
 import ImageUpload from '../../ImageUpload/ImageUpload';
@@ -43,6 +43,8 @@ export function ImageDialog({
   const [alt, setAlt] = useState('');
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState('');
+  /** Bumped on close so a resolving upload can tell it has been superseded. */
+  const uploadTokenRef = useRef(0);
 
   const resetState = () => {
     setInputMode(onUploadImage ? 'file' : 'url');
@@ -54,6 +56,10 @@ export function ImageDialog({
   };
 
   const handleClose = () => {
+    // Invalidates any upload still in flight. The Modal closes on Escape and on
+    // its X button, so the user can dismiss the dialog mid-upload; without this
+    // the promise would resolve afterwards and insert an image they cancelled.
+    uploadTokenRef.current += 1;
     resetState();
     onClose();
   };
@@ -90,14 +96,17 @@ export function ImageDialog({
 
     setIsUploading(true);
     setError('');
+    const token = uploadTokenRef.current;
 
     try {
       // Upload before inserting so the saved HTML never holds a blob: URL,
       // which would break as soon as the page unloads.
       const uploadedUrl = await onUploadImage(file);
+      if (token !== uploadTokenRef.current) return;
       onInsert(uploadedUrl, alt.trim());
       resetState();
     } catch (err) {
+      if (token !== uploadTokenRef.current) return;
       setError(err instanceof Error ? err.message : 'Erro ao enviar a imagem.');
     } finally {
       setIsUploading(false);

--- a/src/components/RichEditor/components/ImageDialog.tsx
+++ b/src/components/RichEditor/components/ImageDialog.tsx
@@ -166,6 +166,9 @@ export function ImageDialog({
               selectedFile={file}
               onFileSelect={handleFileSelect}
               onRemoveFile={() => setFile(null)}
+              // Defaults to "Inserir imagem", which would collide with the
+              // dialog's confirm button — same name, different action.
+              buttonText="Selecionar arquivo"
               maxSize={MAX_IMAGE_SIZE}
               onSizeError={handleSizeError}
               onTypeError={handleTypeError}

--- a/src/components/RichEditor/components/extensions.test.ts
+++ b/src/components/RichEditor/components/extensions.test.ts
@@ -1,5 +1,6 @@
 import { generateHTML, generateJSON } from '@tiptap/core';
 import { createRichEditorExtensions } from './extensions';
+import { normalizeLineBreaksInHtml, processLatexInHtml } from './utils';
 
 /**
  * These tests exercise the real Tiptap schema (not a mock) because the bug they
@@ -72,5 +73,82 @@ describe('createRichEditorExtensions', () => {
       expect(html).toContain('um');
       expect(html).toContain('dois');
     });
+  });
+});
+
+describe('normalizeLineBreaksInHtml + schema', () => {
+  const prepare = (content: string) =>
+    generateHTML(
+      generateJSON(
+        processLatexInHtml(normalizeLineBreaksInHtml(content)),
+        extensions
+      ),
+      extensions
+    );
+
+  it('deve separar em parágrafos texto puro com linha em branco', () => {
+    const html = prepare('Linha um.\n\nLinha dois.\n\nLinha três.');
+
+    expect(html).toContain('<p>Linha um.</p>');
+    expect(html).toContain('<p>Linha dois.</p>');
+    expect(html).toContain('<p>Linha três.</p>');
+  });
+
+  it('deve tratar quebra simples como <br> dentro do mesmo parágrafo', () => {
+    const html = prepare('Linha um.\nLinha dois.');
+
+    expect(html).toContain('<br>');
+    expect(html.match(/<p>/g)).toHaveLength(1);
+  });
+
+  it('deve preservar tags inline soltas ao separar parágrafos', () => {
+    const html = prepare('A) <b>Correta</b>.\n\nB) <b>Incorreta</b>.');
+
+    expect(html).toContain('<p>A) <strong>Correta</strong>.</p>');
+    expect(html).toContain('<p>B) <strong>Incorreta</strong>.</p>');
+  });
+
+  it('não deve duplicar parágrafos em conteúdo que já é HTML estruturado', () => {
+    const html = prepare('<p>Linha um.</p>\n\n<p>Linha dois.</p>');
+
+    expect(html).toEqual('<p>Linha um.</p><p>Linha dois.</p>');
+  });
+
+  it('deve manter LaTeX e quebras de linha juntos', () => {
+    const html = prepare('Item (I): $x = 1$.\n\nItem (II): $y = 2$.');
+
+    expect(html.match(/<p>/g)).toHaveLength(2);
+    expect(html).toContain('data-latex="x = 1"');
+    expect(html).toContain('data-latex="y = 2"');
+  });
+
+  it('deve estabilizar após o primeiro salvamento', () => {
+    const primeiraAbertura = prepare('Linha um.\n\nLinha dois.');
+    // O conteúdo salvo já vem estruturado na próxima abertura.
+    const segundaAbertura = prepare(primeiraAbertura);
+
+    expect(segundaAbertura).toEqual(primeiraAbertura);
+  });
+});
+
+describe('quebras de linha com imagens', () => {
+  const prepare = (content: string) =>
+    generateHTML(
+      generateJSON(
+        processLatexInHtml(normalizeLineBreaksInHtml(content)),
+        extensions
+      ),
+      extensions
+    );
+
+  it('não deve deixar parágrafo vazio ao redor de imagem isolada', () => {
+    const html = prepare(
+      'Veja a figura:\n\n<img src="https://cdn.exemplo.com/a.png">\n\nAnalise.'
+    );
+
+    expect(html).not.toContain('<p></p>');
+    expect(html).toContain('<p>Veja a figura:</p>');
+    expect(html).toContain('https://cdn.exemplo.com/a.png');
+    expect(html).toContain('<p>Analise.</p>');
   });
 });

--- a/src/components/RichEditor/components/extensions.test.ts
+++ b/src/components/RichEditor/components/extensions.test.ts
@@ -1,0 +1,76 @@
+import { generateHTML, generateJSON } from '@tiptap/core';
+import { createRichEditorExtensions } from './extensions';
+
+/**
+ * These tests exercise the real Tiptap schema (not a mock) because the bug they
+ * guard against lives in the schema itself: Tiptap silently discards nodes that
+ * no registered extension can match, so only a real parse proves content survives.
+ *
+ * generateJSON/generateHTML are used instead of `new Editor()` because
+ * instantiating an editor view requires DOM APIs jsdom does not implement
+ * (elementFromPoint). The parse path being tested is identical.
+ */
+const extensions = createRichEditorExtensions('Digite aqui...');
+
+const roundTrip = (html: string): string =>
+  generateHTML(generateJSON(html, extensions), extensions);
+
+describe('createRichEditorExtensions', () => {
+  describe('imagens', () => {
+    it('deve preservar a tag <img> ao carregar HTML existente', () => {
+      const html = roundTrip(
+        '<p>Antes</p><img src="https://cdn.exemplo.com/foto.png"><p>Depois</p>'
+      );
+
+      expect(html).toContain('<img');
+      expect(html).toContain('https://cdn.exemplo.com/foto.png');
+      expect(html).toContain('Antes');
+      expect(html).toContain('Depois');
+    });
+
+    it('deve preservar o atributo alt da imagem', () => {
+      const html = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" alt="Gráfico de barras">'
+      );
+
+      expect(html).toContain('alt="Gráfico de barras"');
+    });
+
+    it('deve manter a imagem intacta ao reabrir a questão salva', () => {
+      const original =
+        '<p>Enunciado</p><img src="https://cdn.exemplo.com/foto.png" alt="Figura 1">';
+
+      const afterFirstSave = roundTrip(original);
+      // Simulates reopening the question with whatever was persisted.
+      const afterSecondSave = roundTrip(afterFirstSave);
+
+      expect(afterSecondSave).toContain('https://cdn.exemplo.com/foto.png');
+      expect(afterSecondSave).toEqual(afterFirstSave);
+    });
+  });
+
+  describe('formatações existentes', () => {
+    it('deve preservar formatações de texto ao carregar HTML', () => {
+      const html = roundTrip(
+        '<p><strong>negrito</strong> e <em>itálico</em></p>'
+      );
+
+      expect(html).toContain('<strong>negrito</strong>');
+      expect(html).toContain('<em>itálico</em>');
+    });
+
+    it('deve preservar links ao carregar HTML', () => {
+      const html = roundTrip('<p><a href="https://exemplo.com">link</a></p>');
+
+      expect(html).toContain('href="https://exemplo.com"');
+    });
+
+    it('deve preservar listas ao carregar HTML', () => {
+      const html = roundTrip('<ul><li><p>um</p></li><li><p>dois</p></li></ul>');
+
+      expect(html).toContain('<ul>');
+      expect(html).toContain('um');
+      expect(html).toContain('dois');
+    });
+  });
+});

--- a/src/components/RichEditor/components/extensions.ts
+++ b/src/components/RichEditor/components/extensions.ts
@@ -1,0 +1,37 @@
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import TextAlign from '@tiptap/extension-text-align';
+import { Color } from '@tiptap/extension-color';
+import { TextStyle } from '@tiptap/extension-text-style';
+import Highlight from '@tiptap/extension-highlight';
+import Subscript from '@tiptap/extension-subscript';
+import Superscript from '@tiptap/extension-superscript';
+import Link from '@tiptap/extension-link';
+import Placeholder from '@tiptap/extension-placeholder';
+import Image from '@tiptap/extension-image';
+import { MathNode } from './MathNode';
+
+/**
+ * Extension list backing the RichEditor.
+ *
+ * Tiptap validates incoming HTML against the schema these extensions build and
+ * silently discards any node it cannot match. Anything the editor must be able
+ * to *load* has to be registered here, not only what it can create — omitting
+ * Image is what made `<img>` tags disappear from existing content.
+ */
+export function createRichEditorExtensions(placeholder: string) {
+  return [
+    StarterKit,
+    Underline,
+    TextStyle,
+    Color,
+    Highlight.configure({ multicolor: true }),
+    Subscript,
+    Superscript,
+    TextAlign.configure({ types: ['heading', 'paragraph'] }),
+    Link.configure({ openOnClick: false }),
+    Placeholder.configure({ placeholder }),
+    Image.configure({ inline: false, allowBase64: false }),
+    MathNode,
+  ];
+}

--- a/src/components/RichEditor/components/utils.ts
+++ b/src/components/RichEditor/components/utils.ts
@@ -1,3 +1,6 @@
+// Re-exported so RichEditor consumers keep a single import surface.
+export { normalizeLineBreaksInHtml } from '../../../utils/htmlLineBreaks';
+
 /**
  * Processa HTML convertendo padrões $...$ para spans de math-inline
  * que o TipTap pode reconhecer

--- a/src/components/RichEditor/index.ts
+++ b/src/components/RichEditor/index.ts
@@ -2,7 +2,7 @@
  * RichEditor - A rich text editor with LaTeX support
  *
  * This component requires tiptap dependencies to be installed:
- * yarn add @tiptap/react @tiptap/starter-kit @tiptap/extension-underline @tiptap/extension-text-align @tiptap/extension-color @tiptap/extension-text-style @tiptap/extension-highlight @tiptap/extension-subscript @tiptap/extension-superscript @tiptap/extension-link @tiptap/extension-placeholder @tiptap/core
+ * yarn add @tiptap/react @tiptap/starter-kit @tiptap/extension-underline @tiptap/extension-text-align @tiptap/extension-color @tiptap/extension-text-style @tiptap/extension-highlight @tiptap/extension-subscript @tiptap/extension-superscript @tiptap/extension-link @tiptap/extension-placeholder @tiptap/extension-image @tiptap/core
  *
  * Import from:
  * import { RichEditor } from 'analytica-frontend-lib/RichEditor';
@@ -10,4 +10,5 @@
 
 export { RichEditor } from './RichEditor';
 export { FormulaDialog } from './components/FormulaDialog';
+export { ImageDialog, MAX_IMAGE_SIZE } from './components/ImageDialog';
 export { processLatexInHtml, unprocessLatexInHtml } from './components/utils';

--- a/src/utils/htmlLineBreaks.test.ts
+++ b/src/utils/htmlLineBreaks.test.ts
@@ -101,4 +101,28 @@ describe('normalizeLineBreaksInHtml', () => {
       expect(normalizeLineBreaksInHtml('  \n\n   \n  ')).toBe('  \n\n   \n  ');
     });
   });
+
+  describe('quebras CRLF', () => {
+    it('deve separar parágrafos vindos de conteúdo com CRLF', () => {
+      // CSV/XLSX importado traz \r\n; sem normalizar, o \r fica entre os \n
+      // e o split por \n{2,} nunca casa.
+      expect(normalizeLineBreaksInHtml('um\r\n\r\ndois')).toBe(
+        '<p>um</p><p>dois</p>'
+      );
+    });
+
+    it('deve tratar CRLF simples como quebra suave', () => {
+      expect(normalizeLineBreaksInHtml('um\r\ndois')).toBe('<p>um<br>dois</p>');
+    });
+
+    it('não deve deixar \\r solto na saída', () => {
+      expect(normalizeLineBreaksInHtml('um\r\n\r\ndois')).not.toContain('\r');
+    });
+
+    it('deve normalizar CRLF em conteúdo já estruturado', () => {
+      expect(normalizeLineBreaksInHtml('<p>um</p>\r\n<p>dois</p>')).toBe(
+        '<p>um</p>\n<p>dois</p>'
+      );
+    });
+  });
 });

--- a/src/utils/htmlLineBreaks.test.ts
+++ b/src/utils/htmlLineBreaks.test.ts
@@ -93,4 +93,12 @@ describe('normalizeLineBreaksInHtml', () => {
       ).toBe('A) <b>ok</b><br><br>B) <b>não</b>');
     });
   });
+
+  describe('conteúdo só com quebras', () => {
+    it('deve devolver o original quando não sobra bloco algum', () => {
+      // Every block is whitespace, so there is nothing to wrap.
+      expect(normalizeLineBreaksInHtml('\n\n')).toBe('\n\n');
+      expect(normalizeLineBreaksInHtml('  \n\n   \n  ')).toBe('  \n\n   \n  ');
+    });
+  });
 });

--- a/src/utils/htmlLineBreaks.test.ts
+++ b/src/utils/htmlLineBreaks.test.ts
@@ -1,0 +1,96 @@
+import { normalizeLineBreaksInHtml } from './htmlLineBreaks';
+
+describe('normalizeLineBreaksInHtml', () => {
+  describe('conteúdo sem quebras', () => {
+    it('deve devolver string vazia inalterada', () => {
+      expect(normalizeLineBreaksInHtml('')).toBe('');
+    });
+
+    it('deve devolver texto sem \\n inalterado', () => {
+      expect(normalizeLineBreaksInHtml('Sem quebras.')).toBe('Sem quebras.');
+    });
+
+    it('deve tolerar valor nulo', () => {
+      expect(
+        normalizeLineBreaksInHtml(undefined as unknown as string)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('conteúdo já estruturado', () => {
+    it.each([
+      ['<p>um</p>\n<p>dois</p>'],
+      ['<div>um</div>\n<div>dois</div>'],
+      ['<ul>\n<li>um</li>\n</ul>'],
+      ['<h2>título</h2>\n<p>corpo</p>'],
+      ['<blockquote>cita</blockquote>\n<p>corpo</p>'],
+    ])('deve devolver %s intacto', (html) => {
+      expect(normalizeLineBreaksInHtml(html)).toBe(html);
+    });
+  });
+
+  describe('modo bloco (padrão)', () => {
+    it('deve criar um parágrafo por linha em branco', () => {
+      expect(normalizeLineBreaksInHtml('um\n\ndois')).toBe(
+        '<p>um</p><p>dois</p>'
+      );
+    });
+
+    it('deve tratar quebra simples como <br>', () => {
+      expect(normalizeLineBreaksInHtml('um\ndois')).toBe('<p>um<br>dois</p>');
+    });
+
+    it('deve colapsar múltiplas linhas em branco em uma separação', () => {
+      expect(normalizeLineBreaksInHtml('um\n\n\n\ndois')).toBe(
+        '<p>um</p><p>dois</p>'
+      );
+    });
+
+    it('deve descartar blocos vazios e espaços nas bordas', () => {
+      expect(normalizeLineBreaksInHtml('  um  \n\n   \n\n  dois  ')).toBe(
+        '<p>um</p><p>dois</p>'
+      );
+    });
+
+    it('deve preservar tags inline soltas', () => {
+      expect(normalizeLineBreaksInHtml('A) <b>ok</b>\n\nB) <b>não</b>')).toBe(
+        '<p>A) <b>ok</b></p><p>B) <b>não</b></p>'
+      );
+    });
+
+    it('não deve envolver imagem isolada em parágrafo', () => {
+      expect(
+        normalizeLineBreaksInHtml('texto\n\n<img src="a.png">\n\nmais')
+      ).toBe('<p>texto</p><img src="a.png"><p>mais</p>');
+    });
+
+    it('deve envolver imagem acompanhada de texto', () => {
+      expect(normalizeLineBreaksInHtml('veja <img src="a.png">\n\nfim')).toBe(
+        '<p>veja <img src="a.png"></p><p>fim</p>'
+      );
+    });
+  });
+
+  describe('modo inline', () => {
+    it('não deve emitir <p>', () => {
+      const result = normalizeLineBreaksInHtml('um\n\ndois', { inline: true });
+
+      expect(result).not.toContain('<p>');
+      expect(result).toBe('um<br><br>dois');
+    });
+
+    it('deve tratar quebra simples como um único <br>', () => {
+      expect(normalizeLineBreaksInHtml('um\ndois', { inline: true })).toBe(
+        'um<br>dois'
+      );
+    });
+
+    it('deve preservar tags inline soltas', () => {
+      expect(
+        normalizeLineBreaksInHtml('A) <b>ok</b>\n\nB) <b>não</b>', {
+          inline: true,
+        })
+      ).toBe('A) <b>ok</b><br><br>B) <b>não</b>');
+    });
+  });
+});

--- a/src/utils/htmlLineBreaks.ts
+++ b/src/utils/htmlLineBreaks.ts
@@ -34,14 +34,19 @@ export function normalizeLineBreaksInHtml(
   options: NormalizeLineBreaksOptions = {}
 ): string {
   if (!html?.includes('\n')) return html;
-  if (BLOCK_LEVEL_TAG.test(html)) return html;
 
-  const blocks = html
+  // Content imported from CSV/XLSX arrives with CRLF. Without this the `\r`
+  // sits between the two `\n`, so `\n{2,}` never matches and a paragraph break
+  // degrades into a soft break with a stray `\r` left in the output.
+  const normalizedHtml = html.replaceAll('\r\n', '\n');
+  if (BLOCK_LEVEL_TAG.test(normalizedHtml)) return normalizedHtml;
+
+  const blocks = normalizedHtml
     .split(/\n{2,}/)
     .map((block) => block.trim())
     .filter(Boolean);
 
-  if (blocks.length === 0) return html;
+  if (blocks.length === 0) return normalizedHtml;
 
   if (options.inline) {
     // A blank line still reads as a stronger separation than a soft break.

--- a/src/utils/htmlLineBreaks.ts
+++ b/src/utils/htmlLineBreaks.ts
@@ -1,0 +1,62 @@
+/**
+ * Block-level containers that indicate the content is already structured HTML.
+ * Void/inline elements (img, br, b, span) are deliberately excluded: content can
+ * mix them with plain-text line breaks and still need normalization.
+ */
+const BLOCK_LEVEL_TAG =
+  /<(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|figure|section|article)\b/i;
+
+/** A block whose entire content is a single image tag. */
+const STANDALONE_IMAGE = /^<img\b[^>]*\/?>$/i;
+
+export interface NormalizeLineBreaksOptions {
+  /**
+   * Render breaks using only `<br>` instead of `<p>` blocks. Required when the
+   * output is placed inside phrasing content (a `<span>` or `<label>`), where
+   * block elements are invalid HTML.
+   */
+  inline?: boolean;
+}
+
+/**
+ * Converte quebras de linha de texto puro em estrutura HTML.
+ *
+ * Parte do conteúdo das questões é armazenada como texto puro com `\n`,
+ * misturado a tags inline soltas (`<b>`) e LaTeX. Como `\n` é espaço em branco
+ * insignificante em HTML, os parsers colapsam tudo em uma única linha corrida.
+ * Esta função restaura a intenção antes da renderização.
+ *
+ * Conteúdo que já possui blocos é devolvido intacto — reconvertê-lo duplicaria
+ * parágrafos e corromperia o que já está correto.
+ */
+export function normalizeLineBreaksInHtml(
+  html: string,
+  options: NormalizeLineBreaksOptions = {}
+): string {
+  if (!html?.includes('\n')) return html;
+  if (BLOCK_LEVEL_TAG.test(html)) return html;
+
+  const blocks = html
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  if (blocks.length === 0) return html;
+
+  if (options.inline) {
+    // A blank line still reads as a stronger separation than a soft break.
+    return blocks
+      .map((block) => block.replaceAll('\n', '<br>'))
+      .join('<br><br>');
+  }
+
+  return blocks
+    .map((block) => {
+      // Images are block-level nodes: wrapping one in <p> makes editors lift it
+      // out and leave an empty paragraph behind.
+      if (STANDALONE_IMAGE.test(block)) return block;
+      // A single newline is a soft break inside the same paragraph.
+      return `<p>${block.replaceAll('\n', '<br>')}</p>`;
+    })
+    .join('');
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -75,6 +75,8 @@ export default defineConfig({
     'utils/index': 'src/utils/utils.ts',
 
     'MultipleChoice/index': 'src/components/MultipleChoice/MultipleChoice.tsx',
+    'HtmlMathRenderer/index':
+      'src/components/HtmlMathRenderer/HtmlMathRenderer.tsx',
     'AlertManager/index': 'src/components/AlertManager/AlertsManager.tsx',
     'AlertManagerView/index':
       'src/components/AlertManagerView/AlertsManagerView.tsx',
@@ -335,6 +337,7 @@ export default defineConfig({
     'utils/brazilianStates/index': 'src/utils/brazilianStates.ts', // UF_LIST
     'utils/calendarActivityUtils/index': 'src/utils/calendarActivityUtils.ts', // filterActivitiesFromDate, getActivityDateKey, getCalendarActivityStatus
     'utils/chatUtils/index': 'src/utils/chatUtils.ts', // getChatUserInfo, getChatWsUrl
+    'utils/htmlLineBreaks/index': 'src/utils/htmlLineBreaks.ts', // normalizeLineBreaksInHtml
     'utils/domainUtils/index': 'src/utils/domainUtils.ts', // resolveRootHostname, extractSubdomainSlug, buildLoginUrlWithReturnTo
     'utils/examFilterHelpers/index': 'src/utils/examFilterHelpers.ts', // EXAM_STATUS_OPTIONS
     'utils/lessonAvailabilityUtils/index': 'src/utils/lessonAvailabilityUtils.ts', // checkLessonAvailability

--- a/yarn.lock
+++ b/yarn.lock
@@ -3776,6 +3776,7 @@ __metadata:
     "@tiptap/core": ^3.0.0
     "@tiptap/extension-color": ^3.0.0
     "@tiptap/extension-highlight": ^3.0.0
+    "@tiptap/extension-image": ^3.0.0
     "@tiptap/extension-link": ^3.0.0
     "@tiptap/extension-placeholder": ^3.0.0
     "@tiptap/extension-subscript": ^3.0.0
@@ -3801,6 +3802,8 @@ __metadata:
     "@tiptap/extension-color":
       optional: true
     "@tiptap/extension-highlight":
+      optional: true
+    "@tiptap/extension-image":
       optional: true
     "@tiptap/extension-link":
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2719,6 +2719,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tiptap/extension-image@npm:3.24.0":
+  version: 3.24.0
+  resolution: "@tiptap/extension-image@npm:3.24.0"
+  peerDependencies:
+    "@tiptap/core": 3.24.0
+  checksum: 10c0/10b16193d41d5407fe2354e1f4142ec09b4de6aef289ca3e3bdf2133a44f446a09f3bf37dcf2c660e4d04bcd5137a1df548b329fe37df4eda7b726a08998b4da
+  languageName: node
+  linkType: hard
+
 "@tiptap/extension-italic@npm:^3.24.0":
   version: 3.24.0
   resolution: "@tiptap/extension-italic@npm:3.24.0"
@@ -3699,6 +3708,7 @@ __metadata:
     "@tiptap/core": "npm:^3.24.0"
     "@tiptap/extension-color": "npm:^3.24.0"
     "@tiptap/extension-highlight": "npm:^3.24.0"
+    "@tiptap/extension-image": "npm:3.24.0"
     "@tiptap/extension-link": "npm:^3.24.0"
     "@tiptap/extension-placeholder": "npm:^3.24.0"
     "@tiptap/extension-subscript": "npm:^3.24.0"


### PR DESCRIPTION
## Contexto

Dois bugs distintos faziam o conteúdo das questões ser exibido — e salvo —
incorretamente. Ambos têm a mesma raiz: o conteúdo armazenado não é HTML puro,
é um híbrido de texto com `\n`, tags inline soltas (`<b>`, `<img>`) e LaTeX
`$...$`, mas era tratado como HTML bem-formado.

## 1. Imagens sumiam do editor (e eram apagadas ao salvar)

O `RichEditor` não registrava nenhuma extensão de imagem. O Tiptap valida todo
HTML de entrada contra o schema e **descarta silenciosamente** nós sem extensão
correspondente, então toda `<img>` era removida no parse.

O efeito não era só visual: depois da imagem sumir do documento, qualquer
digitação disparava `onUpdate` → `getHTML()`, que passava a retornar o HTML sem
a `<img>`. **Abrir e editar uma questão com imagem apagava a imagem no banco.**

- `@tiptap/extension-image` adicionado (pinado em `3.24.0` para casar com o
  `@tiptap/core` do projeto; a `3.28` gera conflito de peer) e registrado como
  peer dependency opcional, seguindo o padrão das outras extensões Tiptap.
- Lista de extensões extraída para `components/extensions.ts`. Os testes
  existentes mockam o `useEditor` inteiro e por isso não conseguiam tocar no
  schema, que é onde o bug vive.
- Nova prop `onUploadImage` + `ImageDialog` (abas arquivo/URL e texto
  alternativo). Segue o padrão já existente do `onGenerateLatexWithAI`: a lib
  expõe a UI, o consumidor injeta a chamada de rede. É aditiva — quem não passar
  a prop não ganha o botão.
- O upload acontece na inserção, não no save, para que o HTML persistido nunca
  guarde uma `blob:` URL morta.

## 2. Quebras de linha colapsavam

`\n` é espaço em branco insignificante em HTML, então texto com `\n\n` virava
uma única linha corrida — tanto no editor quanto na visão do aluno.

Novo util `src/utils/htmlLineBreaks.ts` com `normalizeLineBreaksInHtml`:
`\n\n` vira separação de parágrafo, `\n` vira quebra suave, e conteúdo que já
tem tag de bloco passa **intacto** (reconvertê-lo duplicaria parágrafos e
corromperia o que já está correto).

Aplicado em dois lugares:

- **`RichEditorCore`**: nos dois pontos de entrada de conteúdo (init e o
  `useEffect` do carregamento externo). Emite `<p>`, que é o que o Tiptap
  precisa. É auto-corretivo: depois do primeiro save o conteúdo vira HTML
  estruturado de verdade.
- **`HtmlMathRenderer`**: aplicado após o desvio de Markdown (normalizar antes
  mudaria a rota do `isLikelyMarkdown`). Aqui as quebras saem sempre como
  `<br>`, nunca `<p>` — o caminho com matemática fatia o conteúdo e envolve cada
  parte no seu próprio elemento, o que partiria um parágrafo ao meio na
  expressão. `<br>` é inline e sobrevive ao corte; e o `sharedClassName` já tem
  `[&_p]:mb-0`, então bloco não traria ganho visual nenhum.

Deliberadamente **não** usei `whitespace-pre-wrap` (como faz o `LatexRenderer`):
o `HtmlMathRenderer` também recebe HTML real em Forum, QuizContent e Chatbot,
onde `\n` de formatação do fonte é corretamente ignorado hoje — o pre-wrap
criaria linhas em branco espúrias nesses consumidores.

## 3. `HtmlMathRenderer` exposto como subpath

Existia só no barrel raiz. Importar o barrel puxaria a lib inteira, contra a
convenção de subpath do repo. Nova entrada no `tsup.config.ts` →
`analytica-frontend-lib/html-math-renderer`.

## Verificação

- 10186 testes, 385 suítes, typecheck e lint limpos, thresholds de cobertura OK.
- O teste de round-trip da imagem foi validado ao contrário: removendo a
  extensão, os 3 testes de imagem falham e os de formatação continuam passando.
- Durante os testes descobri que texto puro **sem nenhuma tag** já funcionava —
  ele vai pela rota Markdown, que trata `\n\n` nativamente. O bug só aparece com
  qualquer tag HTML presente. Os testes usam o formato híbrido real; com texto
  puro estariam exercitando a rota errada e passariam sem provar nada.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image insertion to the rich text editor (upload or image URL) with a 5 MB size limit and alt text support.
  * Exposed HTML line-break normalization and inline LaTeX conversion utilities.
  * Added new build entry points for the HTML math renderer and line-break utilities.
* **Bug Fixes**
  * Improved handling of newlines/inline HTML to prevent unwanted `<p>` wrapping and preserve structured content.
* **Tests**
  * Added/expanded suites for image insertion/dialog flows, line-break normalization, editor extension behavior, and renderer math/HTML cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->