### PR TITLE
AE-2934: refact map tooltip: show only active profile data

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -881,6 +881,36 @@ describe('ChoroplethMap animations', () => {
     expect(screen.queryByText(/Acessos: 200/)).not.toBeInTheDocument();
   });
 
+  it('shows only the selected profile line when activeProfile is set', async () => {
+    await renderAndHoverRegion({
+      activeProfile: 'students',
+      data: [
+        {
+          id: 'r1',
+          name: 'NRE Test',
+          value: 0.5,
+          accessCount: 200,
+          accessBreakdown: {
+            students: { withAccess: 300, withoutAccess: 1000 },
+            teachers: { withAccess: 40, withoutAccess: 5 },
+            managers: { withAccess: 2, withoutAccess: 8 },
+          },
+          geoJson: {
+            type: 'Feature',
+            properties: {},
+            geometry: { type: 'Polygon', coordinates: [[]] },
+          },
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(/Estudantes: 300 com acesso, 1\.000 sem acessos/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Professores\(as\):/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Diretores\(as\):/)).not.toBeInTheDocument();
+  });
+
   it('renders a headerAction on the right of the header', () => {
     render(
       <ChoroplethMap

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '../../hooks/useTheme';
 import Text from '../Text/Text';
 import Alert from '../Alert/Alert';
 import type {
+  AccessBreakdown,
   ChoroplethMapProps,
   ColorClass,
   RegionData,
@@ -18,6 +19,17 @@ import type {
  * Must NOT use useId() — the loader rejects re-initialization with different IDs.
  */
 const GOOGLE_MAPS_LOADER_ID = 'google-maps-script';
+
+/**
+ * Profile lines rendered in the region tooltip, in display order. Each entry maps
+ * an `accessBreakdown` group to its Portuguese label. Used to render every line
+ * by default, or a single one when `activeProfile` is set.
+ */
+const TOOLTIP_PROFILE_LINES: { key: keyof AccessBreakdown; label: string }[] = [
+  { key: 'students', label: 'Estudantes' },
+  { key: 'teachers', label: 'Professores(as)' },
+  { key: 'managers', label: 'Diretores(as)' },
+];
 
 /**
  * Fade-in animation duration in milliseconds
@@ -297,6 +309,7 @@ const ChoroplethMap = ({
   onRegionClick,
   headerAction,
   infoText,
+  activeProfile,
   className,
 }: ChoroplethMapProps) => {
   const mapId = GOOGLE_MAPS_LOADER_ID;
@@ -860,39 +873,19 @@ const ChoroplethMap = ({
                 <div className="h-px self-stretch bg-border-200" />
                 {hoveredRegion.accessBreakdown ? (
                   <div className="flex flex-col gap-1">
-                    <Text size="md" color="text-text-50">
-                      Estudantes:{' '}
-                      {hoveredRegion.accessBreakdown.students.withAccess.toLocaleString(
-                        'pt-BR'
-                      )}{' '}
-                      com acesso,{' '}
-                      {hoveredRegion.accessBreakdown.students.withoutAccess.toLocaleString(
-                        'pt-BR'
-                      )}{' '}
-                      sem acessos
-                    </Text>
-                    <Text size="md" color="text-text-50">
-                      Professores(as):{' '}
-                      {hoveredRegion.accessBreakdown.teachers.withAccess.toLocaleString(
-                        'pt-BR'
-                      )}{' '}
-                      com acesso,{' '}
-                      {hoveredRegion.accessBreakdown.teachers.withoutAccess.toLocaleString(
-                        'pt-BR'
-                      )}{' '}
-                      sem acessos
-                    </Text>
-                    <Text size="md" color="text-text-50">
-                      Diretores(as):{' '}
-                      {hoveredRegion.accessBreakdown.managers.withAccess.toLocaleString(
-                        'pt-BR'
-                      )}{' '}
-                      com acesso,{' '}
-                      {hoveredRegion.accessBreakdown.managers.withoutAccess.toLocaleString(
-                        'pt-BR'
-                      )}{' '}
-                      sem acessos
-                    </Text>
+                    {TOOLTIP_PROFILE_LINES.filter(
+                      (line) => !activeProfile || line.key === activeProfile
+                    ).map((line) => {
+                      const entry = hoveredRegion.accessBreakdown![line.key];
+                      return (
+                        <Text key={line.key} size="md" color="text-text-50">
+                          {line.label}:{' '}
+                          {entry.withAccess.toLocaleString('pt-BR')} com acesso,{' '}
+                          {entry.withoutAccess.toLocaleString('pt-BR')} sem
+                          acessos
+                        </Text>
+                      );
+                    })}
                   </div>
                 ) : (
                   <Text size="md" color="text-text-50">

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -109,6 +109,12 @@ export interface ChoroplethMapProps {
    * inside the map card.
    */
   infoText?: string;
+  /**
+   * When set, the region tooltip shows only the given profile's access line
+   * instead of all three. Omit to show every profile (default; used by the
+   * schools map, which aggregates all three profile groups).
+   */
+  activeProfile?: keyof AccessBreakdown;
   /** Optional additional CSS classes */
   className?: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Map tooltips can now display access information for a selected profile only.
  * When no profile is selected, tooltips continue to show all available access categories.

* **Tests**
  * Added coverage to verify that profile-specific tooltips show the correct line and hide unrelated profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->