### PR TITLE
feat(lib): custom ProgressCircle colours and a chart-components subpath

### DIFF
--- a/src/components/ProgressCircle/ProgressCircle.test.tsx
+++ b/src/components/ProgressCircle/ProgressCircle.test.tsx
@@ -493,4 +493,43 @@ describe('ProgressCircle', () => {
       });
     });
   });
+
+  describe('custom colours', () => {
+    // Apps só dispõem das utilities de cor que a própria lib compila, então
+    // classes `stroke-*` de tokens arbitrários não existem lá — por isso a cor
+    // entra como valor CSS, não como classe.
+    it('paints the arc with `fillColor`, overriding the variant', () => {
+      const { container } = render(
+        <ProgressCircle
+          value={50}
+          variant="green"
+          fillColor="var(--color-warning-400)"
+        />
+      );
+      const [, arc] = container.querySelectorAll('circle');
+
+      expect(arc).toHaveStyle({ stroke: 'var(--color-warning-400)' });
+      expect(arc).not.toHaveClass('stroke-success-200');
+    });
+
+    it('paints the track with `trackColor`', () => {
+      const { container } = render(
+        <ProgressCircle value={50} trackColor="var(--color-background-300)" />
+      );
+      const [track] = container.querySelectorAll('circle');
+
+      expect(track).toHaveStyle({ stroke: 'var(--color-background-300)' });
+    });
+
+    it('keeps the variant classes when no colour is given', () => {
+      const { container } = render(
+        <ProgressCircle value={50} variant="green" />
+      );
+      const [track, arc] = container.querySelectorAll('circle');
+
+      expect(arc).toHaveClass('stroke-success-200');
+      expect(track).toHaveClass('stroke-background-300');
+      expect(arc.getAttribute('style')).toBeNull();
+    });
+  });
 });

--- a/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/src/components/ProgressCircle/ProgressCircle.tsx
@@ -68,6 +68,16 @@ export type ProgressCircleProps = {
   size?: ProgressCircleSize;
   /** Color variant of the progress circle */
   variant?: ProgressCircleVariant;
+  /**
+   * Overrides the variant's arc colour with a raw CSS value, e.g.
+   * `var(--color-success-400)` or `#489766`. Use this — not a `stroke-*` class
+   * — when the colour encodes data (a score band): consumer apps only ship the
+   * colour utilities the lib itself compiles, so `stroke-*` classes for
+   * arbitrary tokens simply do not exist there and the arc renders invisible.
+   */
+  fillColor?: string;
+  /** Same as `fillColor`, for the track behind the arc. */
+  trackColor?: string;
   /** Optional label to display below percentage */
   label?: ReactNode;
   /** Show percentage text */
@@ -108,6 +118,8 @@ const ProgressCircle = ({
   max = 100,
   size = 'small',
   variant = 'blue',
+  fillColor,
+  trackColor,
   label,
   showPercentage = true,
   className = '',
@@ -122,6 +134,9 @@ const ProgressCircle = ({
   // Get size and variant classes
   const sizeClasses = SIZE_CLASSES[size];
   const variantClasses = VARIANT_CLASSES[variant];
+  // A cor por valor vence a da variante; quando ausente, mantém a classe.
+  const trackClass = trackColor ? undefined : variantClasses.background;
+  const fillClass = fillColor ? undefined : variantClasses.fill;
 
   // Calculate SVG dimensions and stroke properties
   // small: 107px container, radius = (107 - strokeWidth*2) / 2 ≈ 49.5, center = 53.5
@@ -156,7 +171,8 @@ const ProgressCircle = ({
           r={radius}
           fill="none"
           strokeWidth={sizeClasses.strokeWidth}
-          className={cn(variantClasses.background, 'rounded-lg')}
+          className={cn(trackClass, 'rounded-lg')}
+          style={trackColor ? { stroke: trackColor } : undefined}
         />
         {/* Progress circle - SVG stroke properties require style for animation */}
         <circle
@@ -169,9 +185,10 @@ const ProgressCircle = ({
           strokeDasharray={circumference}
           strokeDashoffset={strokeDashoffset}
           className={cn(
-            variantClasses.fill,
+            fillClass,
             'transition-all duration-500 ease-out shadow-soft-shadow-3 rounded-lg'
           )}
+          style={fillColor ? { stroke: fillColor } : undefined}
         />
       </svg>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,15 @@ export type { ColorPickerProps } from './components/ColorPicker/ColorPicker';
 export { default as Search } from './components/Search/Search';
 export { default as Chips } from './components/Chips/Chips';
 export { default as ProgressBar } from './components/ProgressBar/ProgressBar';
+export {
+  SimplePieChart,
+  LegendRow,
+  LegendPieCard,
+} from './components/shared/ChartComponents';
+export type {
+  PieSlice,
+  SimplePieChartProps,
+} from './components/shared/ChartComponents';
 export { RangeGauge, pointerPercent } from './components/RangeGauge/RangeGauge';
 export type {
   RangeGaugeProps,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     'NavButton/index': 'src/components/NavButton/NavButton.tsx',
     'Search/index': 'src/components/Search/Search.tsx',
     'ProgressBar/index': 'src/components/ProgressBar/ProgressBar.tsx',
+    'ChartComponents/index': 'src/components/shared/ChartComponents.tsx',
     'RangeGauge/index': 'src/components/RangeGauge/RangeGauge.tsx',
     'LevelBar/index': 'src/components/LevelBar/LevelBar.tsx',
     'Avatar/index': 'src/components/Avatar/Avatar.tsx',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional custom fill and track colors to progress circles.
  * Exported reusable pie chart components and related types for broader integration.
* **Tests**
  * Added coverage for custom progress circle colors and preserved variant-based coloring when overrides are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->