### PR TITLE
fix(dropdown-menu): fit portaled menus to the viewport

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -405,6 +405,21 @@ describe('DropdownMenuContent direction and positioning', () => {
         expect(screen.getByRole('menu').style.maxHeight).toBe('200px');
       });
 
+      // The minimum floors the room the viewport offers, not the caller's
+      // ceiling: asking for 80px must not be raised to 120px.
+      it('honours a maximum height below the minimum', () => {
+        render(<TestPortalDropdown maxHeight={80} />);
+
+        expect(screen.getByRole('menu').style.maxHeight).toBe('80px');
+      });
+
+      it('honours a maximum height below the minimum when cramped too', () => {
+        placeTrigger(700);
+        render(<TestPortalDropdown maxHeight={80} />);
+
+        expect(screen.getByRole('menu').style.maxHeight).toBe('80px');
+      });
+
       it('shrinks to the space below the trigger', () => {
         // 800 - 600 bottom - 4 offset - 8 margin = 188px of room.
         placeTrigger(570);
@@ -433,6 +448,33 @@ describe('DropdownMenuContent direction and positioning', () => {
         render(<TestPortalDropdown />);
 
         expect(screen.getByRole('menu').style.maxHeight).toBe('120px');
+      });
+
+      // A side menu runs downwards from the trigger's top, so it overflows the
+      // bottom of the screen just as a menu opening below would.
+      it.each([['left'], ['right']] as const)(
+        'clamps a side="%s" menu to the room under the trigger',
+        (side) => {
+          // 800 - 570 top - 8 margin = 222px of room.
+          placeTrigger(570);
+          render(<TestPortalDropdown side={side} />);
+
+          const menu = screen.getByRole('menu');
+          expect(menu.style.maxHeight).toBe('222px');
+          expect(menu.style.overflowY).toBe('auto');
+          expect(menu.style.top).toBe('570px');
+        }
+      );
+
+      it('keeps a side menu anchored by the edge facing the trigger', () => {
+        placeTrigger(570);
+        render(<TestPortalDropdown side="left" />);
+
+        const menu = screen.getByRole('menu');
+        expect(menu.style.right).toBe(
+          `${VIEWPORT.width - TRIGGER_RECT.left + 4}px`
+        );
+        expect(menu.style.left).toBe('');
       });
     });
 

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -261,6 +261,11 @@ describe('DropdownMenuContent direction and positioning', () => {
     const TestPortalDropdown = ({
       align = 'start' as 'start' | 'center' | 'end',
       side = 'bottom' as 'top' | 'bottom' | 'left' | 'right',
+      maxHeight,
+    }: {
+      align?: 'start' | 'center' | 'end';
+      side?: 'top' | 'bottom' | 'left' | 'right';
+      maxHeight?: number;
     }) => {
       const triggerRef = React.useRef<HTMLButtonElement>(null);
       return (
@@ -271,6 +276,7 @@ describe('DropdownMenuContent direction and positioning', () => {
             triggerRef={triggerRef}
             align={align}
             side={side}
+            maxHeight={maxHeight}
           >
             <DropdownMenuItem>Item 1</DropdownMenuItem>
           </DropdownMenuContent>
@@ -369,6 +375,65 @@ describe('DropdownMenuContent direction and positioning', () => {
       const menu = screen.getByRole('menu');
       expect(menu.style.left).toBe(`${TRIGGER_RECT.right + 4}px`);
       expect(menu.style.top).toBe(`${TRIGGER_RECT.top}px`);
+    });
+
+    // A portaled menu is position:fixed, so whatever falls past the bottom of
+    // the viewport can never be scrolled to — the tail of the list is simply
+    // unreachable. It has to be given the room that actually exists.
+    describe('fitting the viewport', () => {
+      /** Places the trigger somewhere else for a single test. */
+      const placeTrigger = (top: number, height = 30) =>
+        rectSpy.mockReturnValue({
+          ...TRIGGER_RECT,
+          top,
+          bottom: top + height,
+          y: top,
+          height,
+        } as DOMRect);
+
+      it('opens at its full height when there is room, and scrolls', () => {
+        render(<TestPortalDropdown />);
+
+        const menu = screen.getByRole('menu');
+        expect(menu.style.maxHeight).toBe('320px');
+        expect(menu.style.overflowY).toBe('auto');
+      });
+
+      it('honours a caller-supplied maximum height', () => {
+        render(<TestPortalDropdown maxHeight={200} />);
+
+        expect(screen.getByRole('menu').style.maxHeight).toBe('200px');
+      });
+
+      it('shrinks to the space below the trigger', () => {
+        // 800 - 600 bottom - 4 offset - 8 margin = 188px of room.
+        placeTrigger(570);
+        render(<TestPortalDropdown />);
+
+        const menu = screen.getByRole('menu');
+        expect(menu.style.maxHeight).toBe('188px');
+        expect(menu.style.top).toBe('604px');
+      });
+
+      it('flips above the trigger when the space below is too tight', () => {
+        // 58px below, 688px above — clamping alone would leave it overhanging.
+        placeTrigger(700);
+        render(<TestPortalDropdown />);
+
+        const menu = screen.getByRole('menu');
+        expect(menu.style.bottom).toBe(`${VIEWPORT.height - 700 + 4}px`);
+        expect(menu.style.top).toBe('');
+        expect(menu.style.maxHeight).toBe('320px');
+      });
+
+      it('never shrinks below a usable height', () => {
+        // Cramped on both sides: 88px above, 58px below.
+        window.innerHeight = 200;
+        placeTrigger(100);
+        render(<TestPortalDropdown />);
+
+        expect(screen.getByRole('menu').style.maxHeight).toBe('120px');
+      });
     });
 
     it('does not close when clicking inside portal content', async () => {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -68,10 +68,23 @@ const PORTAL_STYLE_KEYS = [
   'left',
   'right',
   'transform',
+  'maxHeight',
 ] as const;
 
 const isSamePortalStyle = (a: CSSProperties, b: CSSProperties): boolean =>
   PORTAL_STYLE_KEYS.every((key) => a[key] === b[key]);
+
+/** Tallest a portaled menu gets when there is room for it. */
+const DEFAULT_PORTAL_MAX_HEIGHT = 320;
+
+/** Breathing room between the menu and the edge of the viewport. */
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * Never shrink a menu below this, however cramped the trigger is: a 20px-tall
+ * scroller is worse than one that overhangs a little.
+ */
+const MIN_PORTAL_MAX_HEIGHT = 120;
 
 const injectStore = (
   children: ReactNode,
@@ -322,6 +335,11 @@ const DropdownMenuContent = forwardRef<
     store?: DropdownStoreApi;
     portal?: boolean;
     triggerRef?: RefObject<HTMLElement | null>;
+    /**
+     * Tallest the menu gets, in px, when the viewport allows it. Portaled menus
+     * only — it is capped by the space actually available around the trigger.
+     */
+    maxHeight?: number;
   }
 >(
   (
@@ -335,6 +353,7 @@ const DropdownMenuContent = forwardRef<
       store: externalStore,
       portal = false,
       triggerRef,
+      maxHeight = DEFAULT_PORTAL_MAX_HEIGHT,
       ...props
     },
     ref
@@ -372,7 +391,33 @@ const DropdownMenuContent = forwardRef<
           style.left = rect.right + sideOffset;
         }
       } else {
-        if (side === 'top') {
+        // A fixed menu can't be scrolled to, so anything past the bottom of the
+        // viewport is simply unreachable. Give it the room that actually
+        // exists, and flip it above the trigger when that side has more.
+        //
+        // The flip threshold is the minimum height, not the maximum: flipping
+        // as soon as the menu could not open at full height would send it over
+        // the table on any trigger past the middle of the screen, which reads
+        // as a glitch. It only turns over when clamping alone would still leave
+        // it overhanging.
+        const spaceBelow =
+          window.innerHeight - rect.bottom - sideOffset - VIEWPORT_MARGIN;
+        const spaceAbove = rect.top - sideOffset - VIEWPORT_MARGIN;
+        const openAbove =
+          side === 'top' ||
+          (spaceBelow < Math.min(maxHeight, MIN_PORTAL_MAX_HEIGHT) &&
+            spaceAbove > spaceBelow);
+
+        const available = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
+        style.maxHeight = Math.max(
+          Math.min(maxHeight, available),
+          MIN_PORTAL_MAX_HEIGHT
+        );
+        // Wins over the `overflow-hidden` of the base class, so the clamped
+        // menu scrolls instead of hiding its tail.
+        style.overflowY = 'auto';
+
+        if (openAbove) {
           style.bottom = window.innerHeight - rect.top + sideOffset;
         } else {
           style.top = rect.bottom + sideOffset;
@@ -389,7 +434,7 @@ const DropdownMenuContent = forwardRef<
       }
 
       setPortalStyle((prev) => (isSamePortalStyle(prev, style) ? prev : style));
-    }, [portal, triggerRef, align, side, sideOffset]);
+    }, [portal, triggerRef, align, side, sideOffset, maxHeight]);
 
     useLayoutEffect(() => {
       if (open) updatePortalPosition();

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -86,6 +86,115 @@ const VIEWPORT_MARGIN = 8;
  */
 const MIN_PORTAL_MAX_HEIGHT = 120;
 
+type PortalSide = 'top' | 'right' | 'bottom' | 'left';
+type PortalAlign = 'start' | 'center' | 'end';
+
+interface PortalPlacement {
+  side: PortalSide;
+  align: PortalAlign;
+  sideOffset: number;
+  maxHeight: number;
+}
+
+/**
+ * Height cap for a portaled menu, given the room it has.
+ *
+ * The minimum is a floor on the *viewport-derived* room only — it keeps a menu
+ * squeezed against an edge from collapsing into a sliver. A caller that asks
+ * for a shorter menu than the minimum still gets what it asked for: its value
+ * is the ceiling, never something to be raised.
+ *
+ * @param available - Room in px between the trigger and the viewport edge
+ * @param maxHeight - Tallest the caller allows the menu to be
+ * @returns The `max-height` to apply, in px
+ */
+const clampMenuHeight = (available: number, maxHeight: number): number =>
+  Math.min(maxHeight, Math.max(available, MIN_PORTAL_MAX_HEIGHT));
+
+/**
+ * Horizontal edge the menu lines up with, for the `top`/`bottom` sides.
+ *
+ * @param rect - Trigger bounding rect
+ * @param align - Requested alignment
+ * @returns The horizontal part of the portal style
+ */
+const alignPortalStyle = (rect: DOMRect, align: PortalAlign): CSSProperties => {
+  if (align === 'end') return { right: window.innerWidth - rect.right };
+  if (align === 'center') {
+    return {
+      left: rect.left + rect.width / 2,
+      transform: 'translateX(-50%)',
+    };
+  }
+  return { left: rect.left };
+};
+
+/**
+ * Place a menu above or below its trigger, sized to the room that exists.
+ *
+ * A portaled menu is `position: fixed`, so whatever falls past the edge of the
+ * viewport can never be scrolled to. The menu therefore takes the space it
+ * actually has and scrolls inside it, and turns over to the other side when
+ * clamping alone would still leave it overhanging.
+ *
+ * The flip threshold is the minimum height rather than the maximum: turning
+ * over as soon as the menu could not open at full height would send it over the
+ * content on any trigger past the middle of the screen, which reads as a
+ * glitch. `side="top"` always opens above — the caller asked for it.
+ *
+ * @param rect - Trigger bounding rect
+ * @param placement - Requested side/alignment, offset and height ceiling
+ * @returns Style for a fixed menu anchored to the trigger's top or bottom edge
+ */
+const verticalPortalStyle = (
+  rect: DOMRect,
+  { side, align, sideOffset, maxHeight }: PortalPlacement
+): CSSProperties => {
+  const spaceBelow =
+    window.innerHeight - rect.bottom - sideOffset - VIEWPORT_MARGIN;
+  const spaceAbove = rect.top - sideOffset - VIEWPORT_MARGIN;
+  const openAbove =
+    side === 'top' ||
+    (spaceBelow < Math.min(maxHeight, MIN_PORTAL_MAX_HEIGHT) &&
+      spaceAbove > spaceBelow);
+
+  return {
+    maxHeight: clampMenuHeight(openAbove ? spaceAbove : spaceBelow, maxHeight),
+    overflowY: 'auto',
+    ...(openAbove
+      ? { bottom: window.innerHeight - rect.top + sideOffset }
+      : { top: rect.bottom + sideOffset }),
+    ...alignPortalStyle(rect, align),
+  };
+};
+
+/**
+ * Place a menu beside its trigger, sized to the room below the trigger's top.
+ *
+ * Anchored by the edge that faces the trigger: a `left` for `side="left"` would
+ * grow the menu back over the trigger it was meant to sit outside of. It runs
+ * downwards from the trigger's top, so it needs the same clamping as a menu
+ * opening below — without it a long list disappears past the viewport bottom.
+ *
+ * @param rect - Trigger bounding rect
+ * @param placement - Requested side, offset and height ceiling
+ * @returns Style for a fixed menu anchored to the trigger's left or right edge
+ */
+const horizontalPortalStyle = (
+  rect: DOMRect,
+  { side, sideOffset, maxHeight }: PortalPlacement
+): CSSProperties => ({
+  top: rect.top,
+  maxHeight: clampMenuHeight(
+    window.innerHeight - rect.top - VIEWPORT_MARGIN,
+    maxHeight
+  ),
+  overflowY: 'auto',
+  ...(side === 'left'
+    ? { right: window.innerWidth - rect.left + sideOffset }
+    : { left: rect.right + sideOffset }),
+});
+
 const injectStore = (
   children: ReactNode,
   store: DropdownStoreApi
@@ -377,61 +486,11 @@ const DropdownMenuContent = forwardRef<
       if (!portal || !triggerRef?.current) return;
 
       const rect = triggerRef.current.getBoundingClientRect();
-      const style: CSSProperties = {};
-
-      // Each side anchors the menu by the edge that faces the trigger. Placing a
-      // `top`/`left` for the `top`/`left` sides would grow the menu back over
-      // the trigger instead of away from it.
-      if (side === 'left' || side === 'right') {
-        style.top = rect.top;
-
-        if (side === 'left') {
-          style.right = window.innerWidth - rect.left + sideOffset;
-        } else {
-          style.left = rect.right + sideOffset;
-        }
-      } else {
-        // A fixed menu can't be scrolled to, so anything past the bottom of the
-        // viewport is simply unreachable. Give it the room that actually
-        // exists, and flip it above the trigger when that side has more.
-        //
-        // The flip threshold is the minimum height, not the maximum: flipping
-        // as soon as the menu could not open at full height would send it over
-        // the table on any trigger past the middle of the screen, which reads
-        // as a glitch. It only turns over when clamping alone would still leave
-        // it overhanging.
-        const spaceBelow =
-          window.innerHeight - rect.bottom - sideOffset - VIEWPORT_MARGIN;
-        const spaceAbove = rect.top - sideOffset - VIEWPORT_MARGIN;
-        const openAbove =
-          side === 'top' ||
-          (spaceBelow < Math.min(maxHeight, MIN_PORTAL_MAX_HEIGHT) &&
-            spaceAbove > spaceBelow);
-
-        const available = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
-        style.maxHeight = Math.max(
-          Math.min(maxHeight, available),
-          MIN_PORTAL_MAX_HEIGHT
-        );
-        // Wins over the `overflow-hidden` of the base class, so the clamped
-        // menu scrolls instead of hiding its tail.
-        style.overflowY = 'auto';
-
-        if (openAbove) {
-          style.bottom = window.innerHeight - rect.top + sideOffset;
-        } else {
-          style.top = rect.bottom + sideOffset;
-        }
-
-        if (align === 'end') {
-          style.right = window.innerWidth - rect.right;
-        } else if (align === 'center') {
-          style.left = rect.left + rect.width / 2;
-          style.transform = 'translateX(-50%)';
-        } else {
-          style.left = rect.left;
-        }
-      }
+      const placement = { side, align, sideOffset, maxHeight };
+      const style =
+        side === 'left' || side === 'right'
+          ? horizontalPortalStyle(rect, placement)
+          : verticalPortalStyle(rect, placement);
 
       setPortalStyle((prev) => (isSamePortalStyle(prev, style) ? prev : style));
     }, [portal, triggerRef, align, side, sideOffset, maxHeight]);

--- a/src/components/Table/ColumnFilterMenu.test.tsx
+++ b/src/components/Table/ColumnFilterMenu.test.tsx
@@ -31,6 +31,44 @@ describe('ColumnFilterMenu', () => {
     expect(screen.queryByTestId('phosphor-arrow-up')).not.toBeInTheDocument();
   });
 
+  // The menu used to carry a fixed `max-h-80`, which ignored the viewport: a
+  // filter near the footer opened past the bottom of the screen and its last
+  // option could not be reached, since a fixed element doesn't scroll.
+  it('sizes itself to the space around the trigger, not to a fixed height', () => {
+    const rectSpy = jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({
+        top: 500,
+        bottom: 530,
+        left: 200,
+        right: 260,
+        width: 60,
+        height: 30,
+        x: 200,
+        y: 500,
+        toJSON: () => ({}),
+      } as DOMRect);
+    window.innerHeight = 700;
+
+    render(
+      <ColumnFilterMenu
+        columnLabel="Status"
+        config={config}
+        value={[]}
+        onChange={jest.fn()}
+      />
+    );
+    openMenu();
+
+    const menu = screen.getByRole('menu');
+    // 700 - 530 - 4 offset - 8 margin = 158px of room.
+    expect(menu.style.maxHeight).toBe('158px');
+    expect(menu.style.overflowY).toBe('auto');
+    expect(menu).not.toHaveClass('max-h-80');
+
+    rectSpy.mockRestore();
+  });
+
   it('opens the menu on the trigger and lists the options', () => {
     render(
       <ColumnFilterMenu

--- a/src/components/Table/ColumnFilterMenu.tsx
+++ b/src/components/Table/ColumnFilterMenu.tsx
@@ -101,12 +101,15 @@ const ColumnFilterMenu = ({
          * events through the component tree, not the DOM tree, so a click on an
          * item would otherwise reach whatever wraps this header. (The trigger
          * guards its own click; this covers the items.)
+         *
+         * The height is left to the menu: a fixed `max-h` here ignored the
+         * viewport, so a filter near the footer opened past the bottom of the
+         * screen with its last option unreachable.
          */}
         <DropdownMenuContent
           portal
           triggerRef={triggerRef}
           align="start"
-          className="max-h-80 overflow-y-auto"
           onClick={(event) => event.stopPropagation()}
         >
           {searchable && (


### PR DESCRIPTION
A portaled menu is position:fixed, so whatever falls past the bottom of the screen can never be scrolled to — the tail of the list is simply unreachable. `updatePortalPosition` only ever computed top/left, and `ColumnFilterMenu` capped itself with a fixed `max-h-80` that ignored the viewport entirely, so a table filter opened near the footer lost its last option.

The menu now derives its height from the space that actually exists around the trigger, scrolls inside it, and turns over above the trigger when clamping alone would still leave it overhanging. The flip threshold is the minimum height rather than the maximum, so a trigger merely past the middle of the screen does not flip and read as a glitch.

Scoped to the `portal` branch: non-portal menus are absolutely positioned and unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropdown menus now automatically size themselves to fit available viewport space.
  * Menus can be configured with a custom maximum height.
  * Menus flip above their trigger when insufficient space is available below and remain scrollable when content exceeds the available height.

* **Bug Fixes**
  * Improved table filter menus near the bottom of the screen to prevent them from extending beyond the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->