### PR TITLE
AE-2960 - perf(choropleth-map): stop the NRE outline computation from freezing the map

### DIFF
--- a/src/components/AudioMixerReadingFluency/AudioMixerReadingFluency.stories.tsx
+++ b/src/components/AudioMixerReadingFluency/AudioMixerReadingFluency.stories.tsx
@@ -135,7 +135,7 @@ export const AudioMixerControlled: Story = () => {
         </ButtonReadingFluency>
       </div>
 
-      <Text size='xs' className="text-text-700">
+      <Text size="xs" className="text-text-700">
         status atual: <strong>{status}</strong>
       </Text>
     </div>

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -511,6 +511,99 @@ describe('ChoroplethMap color classification', () => {
   });
 });
 
+describe('ChoroplethMap NRE boundary memoization', () => {
+  const mockApiKey = 'test-api-key';
+  // The turf union mock stands in for the (expensive) boundary computation, so
+  // its call count tells us whether the outlines were recomputed.
+  const unionMock = require('@turf/union').default as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockForEach.mockReset();
+    rafCallbacks = new Map();
+    mockAddGeoJson.mockReturnValue([{ setProperty: jest.fn() }]);
+  });
+
+  const city = (id: string, groupName: string, value: number): RegionData => ({
+    id,
+    name: id,
+    groupName,
+    value,
+    accessCount: 100,
+    geoJson: {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-49, -25],
+            [-48, -25],
+            [-48, -26],
+            [-49, -25],
+          ],
+        ],
+      },
+    },
+  });
+
+  it('does not recompute the NRE outlines when only the access metrics change', async () => {
+    // Two cities in one NRE, so the first render merges them at least once.
+    const { rerender } = render(
+      <ChoroplethMap
+        data={[city('c1', 'NRE 1', 0.3), city('c2', 'NRE 1', 0.3)]}
+        apiKey={mockApiKey}
+      />
+    );
+    // Flush the async boundary computation's state update.
+    await act(async () => {});
+
+    const callsAfterFirstRender = unionMock.mock.calls.length;
+    expect(callsAfterFirstRender).toBeGreaterThan(0);
+
+    // Same polygons and grouping, new metrics — as when the period/filter changes.
+    rerender(
+      <ChoroplethMap
+        data={[city('c1', 'NRE 1', 0.9), city('c2', 'NRE 1', 0.9)]}
+        apiKey={mockApiKey}
+      />
+    );
+    await act(async () => {});
+
+    expect(unionMock.mock.calls.length).toBe(callsAfterFirstRender);
+  });
+
+  it('recomputes the NRE outlines when the grouping changes', async () => {
+    const { rerender } = render(
+      <ChoroplethMap
+        data={[
+          city('c1', 'NRE 1', 0.3),
+          city('c2', 'NRE 1', 0.3),
+          city('c3', 'NRE 1', 0.3),
+        ]}
+        apiKey={mockApiKey}
+      />
+    );
+    await act(async () => {});
+    const callsBefore = unionMock.mock.calls.length;
+
+    // A city moves to another NRE — the outlines must be recomputed.
+    rerender(
+      <ChoroplethMap
+        data={[
+          city('c1', 'NRE 1', 0.3),
+          city('c2', 'NRE 1', 0.3),
+          city('c3', 'NRE 2', 0.3),
+        ]}
+        apiKey={mockApiKey}
+      />
+    );
+    await act(async () => {});
+
+    expect(unionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});
+
 describe('ChoroplethMap static map and styling', () => {
   const mockApiKey = 'test-api-key';
 

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -570,7 +570,7 @@ describe('ChoroplethMap NRE boundary memoization', () => {
     );
     await act(async () => {});
 
-    expect(unionMock.mock.calls.length).toBe(callsAfterFirstRender);
+    expect(unionMock.mock.calls).toHaveLength(callsAfterFirstRender);
   });
 
   it('recomputes the NRE outlines when the grouping changes', async () => {
@@ -601,6 +601,31 @@ describe('ChoroplethMap NRE boundary memoization', () => {
     await act(async () => {});
 
     expect(unionMock.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('degrades and logs when the boundary computation throws', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    // union throws on a malformed polygon — the whole computation rejects.
+    unionMock.mockImplementationOnce(() => {
+      throw new Error('self-intersecting polygon');
+    });
+
+    render(
+      <ChoroplethMap
+        data={[city('c1', 'NRE 1', 0.3), city('c2', 'NRE 1', 0.3)]}
+        apiKey={mockApiKey}
+      />
+    );
+    await act(async () => {});
+
+    expect(consoleError).toHaveBeenCalled();
+    const [message, error] = consoleError.mock.calls[0];
+    expect(message).toBe('Failed to compute NRE boundaries:');
+    expect(error).toBeInstanceOf(Error);
+
+    consoleError.mockRestore();
   });
 });
 

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -120,16 +120,40 @@ const getColorClass = (
   return colorClasses[0];
 };
 
+/** Work budget per slice before yielding the main thread back to the browser. */
+const NRE_UNION_SLICE_MS = 8;
+
+/**
+ * Yield control to the browser so it can paint and handle input between slices
+ * of a long computation. MessageChannel avoids the ~4ms clamp of setTimeout(0).
+ */
+const yieldToMain = (): Promise<void> =>
+  new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve();
+    channel.port2.postMessage(undefined);
+  });
+
 /**
  * Compute NRE boundary polygons by merging city polygons that share the same
- * group (the NRE). Grouping uses `groupName` (the NRE label); when a region has
- * no `groupName`, it falls back to its own `name` so it forms its own group.
+ * group (the NRE) — WITHOUT blocking the main thread. Grouping uses `groupName`
+ * (the NRE label); when a region has no `groupName`, it falls back to its own
+ * `name` so it forms its own group.
+ *
+ * Merging hundreds of municipal polygons with `union` is heavy (seconds), so the
+ * work is sliced: after ~`NRE_UNION_SLICE_MS` of merging it yields to the
+ * browser, keeping the page responsive while the outlines fill in a beat after
+ * the cities. Resolves to `null` when `isCancelled` flips (the geometry changed
+ * mid-flight), so a stale result is never applied.
+ *
  * @param data - Array of region data with individual city GeoJSON features
- * @returns Array of GeoJSON features representing NRE boundaries
+ * @param isCancelled - Polled between slices; return true to abort
+ * @returns NRE boundary features, or null if cancelled
  */
-const computeNREBoundaries = (
-  data: RegionData[]
-): Feature<Polygon | MultiPolygon>[] => {
+const computeNREBoundariesAsync = async (
+  data: RegionData[],
+  isCancelled: () => boolean
+): Promise<Feature<Polygon | MultiPolygon>[] | null> => {
   const groups = new Map<string, RegionData[]>();
   data.forEach((region) => {
     const groupKey = region.groupName ?? region.name;
@@ -139,7 +163,9 @@ const computeNREBoundaries = (
   });
 
   const boundaries: Feature<Polygon | MultiPolygon>[] = [];
-  groups.forEach((regions) => {
+  let sliceStart = performance.now();
+
+  for (const regions of groups.values()) {
     let merged: Feature<Polygon | MultiPolygon> | null = null;
     for (const region of regions) {
       if (region.geoJson.type !== 'Feature') continue;
@@ -153,9 +179,15 @@ const computeNREBoundaries = (
       } else {
         merged = feature;
       }
+
+      if (performance.now() - sliceStart > NRE_UNION_SLICE_MS) {
+        await yieldToMain();
+        if (isCancelled()) return null;
+        sliceStart = performance.now();
+      }
     }
     if (merged) boundaries.push(merged);
-  });
+  }
 
   return boundaries;
 };
@@ -347,6 +379,18 @@ const ChoroplethMap = ({
   );
   const stableData = useMemo(() => data, [dataSignature]);
 
+  // The NRE outlines depend only on which municipality belongs to which NRE and
+  // on the polygons themselves — never on the access metrics. Give the expensive
+  // union its own geometry-only signature so it doesn't recompute on every
+  // period/filter change (those keep the same polygons and only recolor them),
+  // which otherwise blocks the main thread for seconds. Recomputes only when the
+  // set of regions or their grouping actually changes.
+  const geometrySignature = useMemo(
+    () => data.map((d) => `${d.id}:${d.groupName ?? d.name}`).join('|'),
+    [data]
+  );
+  const stableGeometryData = useMemo(() => data, [geometrySignature]);
+
   const colorClasses = useMemo(() => getColorClasses(), [isDark]);
 
   const mapOptions: google.maps.MapOptions = useMemo(() => {
@@ -436,10 +480,31 @@ const ChoroplethMap = ({
     setMap(null);
   }, []);
 
-  const nreBoundaries = useMemo(
-    () => computeNREBoundaries(stableData),
-    [stableData]
-  );
+  // NRE outlines are computed off the critical path: merging the municipal
+  // polygons is heavy, so it runs in yielding slices and lands in state when
+  // ready. The cities paint immediately; the outlines follow a beat later,
+  // without ever freezing the page. Keyed on geometry only (stableGeometryData),
+  // so period/filter changes never re-run it, and stale runs are cancelled.
+  const [nreBoundaries, setNreBoundaries] = useState<
+    Feature<Polygon | MultiPolygon>[]
+  >([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    computeNREBoundariesAsync(stableGeometryData, () => cancelled).then(
+      (result) => {
+        if (cancelled || !result) return;
+        // Skip the state update (and re-render) when the outlines stay empty —
+        // e.g. an empty dataset — so nothing downstream churns needlessly.
+        setNreBoundaries((prev) =>
+          prev.length === 0 && result.length === 0 ? prev : result
+        );
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [stableGeometryData]);
 
   /**
    * Add GeoJSON data to map with animations
@@ -452,18 +517,11 @@ const ChoroplethMap = ({
       '--color-map-unmanaged-region',
       '#e0e0e0'
     );
-    const strokeNreColor = getCssVar('--color-map-stroke-nre', '#ffffff');
 
     // Clear existing data
     map.data.forEach((feature) => {
       map.data.remove(feature);
     });
-
-    // Clear existing NRE boundary layer
-    if (nreBoundaryLayerRef.current) {
-      nreBoundaryLayerRef.current.setMap(null);
-      nreBoundaryLayerRef.current = null;
-    }
 
     // Add each region's GeoJSON
     stableData.forEach((region) => {
@@ -503,20 +561,6 @@ const ChoroplethMap = ({
     map.data.setStyle(
       createStyleFunction(0, colorClasses, strokeCityColor, unmanagedFillColor)
     );
-
-    // Add NRE boundary overlay
-    const nreLayer = new google.maps.Data();
-    nreBoundaries.forEach((boundary) => {
-      nreLayer.addGeoJson(boundary);
-    });
-    nreLayer.setStyle({
-      fillOpacity: 0,
-      strokeColor: strokeNreColor,
-      strokeWeight: 1,
-      clickable: false,
-    });
-    nreLayer.setMap(map);
-    nreBoundaryLayerRef.current = nreLayer;
 
     // Animate fade-in from 0 to TARGET_OPACITY
     const startTime = performance.now();
@@ -723,16 +767,48 @@ const ChoroplethMap = ({
       hoverAnimationsRef.current.forEach((id) => cancelAnimationFrame(id));
       hoverAnimationsRef.current.clear();
       if (revertTimeout) clearTimeout(revertTimeout);
-      if (nreBoundaryLayerRef.current) {
-        nreBoundaryLayerRef.current.setMap(null);
-        nreBoundaryLayerRef.current = null;
-      }
       google.maps.event.removeListener(mouseoverListener);
       google.maps.event.removeListener(mouseoutListener);
       google.maps.event.removeListener(mousemoveListener);
       google.maps.event.removeListener(clickListener);
     };
-  }, [map, stableData, colorClasses, nreBoundaries]);
+  }, [map, stableData, colorClasses]);
+
+  // Draw the NRE outline overlay on its own layer, independent of the city
+  // features. It lives on a separate google.maps.Data instance, so recoloring
+  // the cities (period/filter change) never touches it, and it (re)appears
+  // when the async boundary computation lands or the theme changes.
+  useEffect(() => {
+    if (!map) return;
+
+    if (nreBoundaryLayerRef.current) {
+      nreBoundaryLayerRef.current.setMap(null);
+      nreBoundaryLayerRef.current = null;
+    }
+
+    if (!nreBoundaries.length) return;
+
+    const strokeNreColor = getCssVar('--color-map-stroke-nre', '#ffffff');
+    const nreLayer = new google.maps.Data();
+    nreBoundaries.forEach((boundary) => {
+      nreLayer.addGeoJson(boundary);
+    });
+    nreLayer.setStyle({
+      fillOpacity: 0,
+      strokeColor: strokeNreColor,
+      strokeWeight: 1,
+      clickable: false,
+    });
+    nreLayer.setMap(map);
+    nreBoundaryLayerRef.current = nreLayer;
+
+    return () => {
+      if (nreBoundaryLayerRef.current) {
+        nreBoundaryLayerRef.current.setMap(null);
+        nreBoundaryLayerRef.current = null;
+      }
+    };
+  }, [map, nreBoundaries, isDark]);
 
   /**
    * Apply visibility filter based on active legend classes

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -419,16 +419,20 @@ const ChoroplethMap = ({
 
   useEffect(() => {
     let cancelled = false;
-    computeNREBoundariesAsync(stableGeometryData, () => cancelled).then(
-      (result) => {
+    computeNREBoundariesAsync(stableGeometryData, () => cancelled)
+      .then((result) => {
         if (cancelled || !result) return;
         // Skip the state update (and re-render) when the outlines stay empty —
         // e.g. an empty dataset — so nothing downstream churns needlessly.
         setNreBoundaries((prev) =>
           prev.length === 0 && result.length === 0 ? prev : result
         );
-      }
-    );
+      })
+      .catch((error) => {
+        // `union` can throw on malformed/self-intersecting polygons. Degrade to
+        // no outlines rather than leaving the promise rejection unhandled.
+        console.error('Failed to compute NRE boundaries:', error);
+      });
     return () => {
       cancelled = true;
     };

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -1,9 +1,9 @@
 /* global google */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { GoogleMap, useJsApiLoader } from '@react-google-maps/api';
-import union from '@turf/union';
 import type { Feature, MultiPolygon, Polygon } from 'geojson';
 import { cn } from '../../utils/utils';
+import { computeNREBoundariesAsync } from './nreBoundaries';
 import { useTheme } from '../../hooks/useTheme';
 import Text from '../Text/Text';
 import Alert from '../Alert/Alert';
@@ -118,78 +118,6 @@ const getColorClass = (
     }
   }
   return colorClasses[0];
-};
-
-/** Work budget per slice before yielding the main thread back to the browser. */
-const NRE_UNION_SLICE_MS = 8;
-
-/**
- * Yield control to the browser so it can paint and handle input between slices
- * of a long computation. MessageChannel avoids the ~4ms clamp of setTimeout(0).
- */
-const yieldToMain = (): Promise<void> =>
-  new Promise((resolve) => {
-    const channel = new MessageChannel();
-    channel.port1.onmessage = () => resolve();
-    channel.port2.postMessage(undefined);
-  });
-
-/**
- * Compute NRE boundary polygons by merging city polygons that share the same
- * group (the NRE) — WITHOUT blocking the main thread. Grouping uses `groupName`
- * (the NRE label); when a region has no `groupName`, it falls back to its own
- * `name` so it forms its own group.
- *
- * Merging hundreds of municipal polygons with `union` is heavy (seconds), so the
- * work is sliced: after ~`NRE_UNION_SLICE_MS` of merging it yields to the
- * browser, keeping the page responsive while the outlines fill in a beat after
- * the cities. Resolves to `null` when `isCancelled` flips (the geometry changed
- * mid-flight), so a stale result is never applied.
- *
- * @param data - Array of region data with individual city GeoJSON features
- * @param isCancelled - Polled between slices; return true to abort
- * @returns NRE boundary features, or null if cancelled
- */
-const computeNREBoundariesAsync = async (
-  data: RegionData[],
-  isCancelled: () => boolean
-): Promise<Feature<Polygon | MultiPolygon>[] | null> => {
-  const groups = new Map<string, RegionData[]>();
-  data.forEach((region) => {
-    const groupKey = region.groupName ?? region.name;
-    const existing = groups.get(groupKey) ?? [];
-    existing.push(region);
-    groups.set(groupKey, existing);
-  });
-
-  const boundaries: Feature<Polygon | MultiPolygon>[] = [];
-  let sliceStart = performance.now();
-
-  for (const regions of groups.values()) {
-    let merged: Feature<Polygon | MultiPolygon> | null = null;
-    for (const region of regions) {
-      if (region.geoJson.type !== 'Feature') continue;
-      const feature: Feature<Polygon | MultiPolygon> = region.geoJson;
-      if (merged) {
-        const result: Feature<Polygon | MultiPolygon> | null = union({
-          type: 'FeatureCollection' as const,
-          features: [merged, feature],
-        });
-        if (result) merged = result;
-      } else {
-        merged = feature;
-      }
-
-      if (performance.now() - sliceStart > NRE_UNION_SLICE_MS) {
-        await yieldToMain();
-        if (isCancelled()) return null;
-        sliceStart = performance.now();
-      }
-    }
-    if (merged) boundaries.push(merged);
-  }
-
-  return boundaries;
 };
 
 /**
@@ -779,15 +707,10 @@ const ChoroplethMap = ({
   // the cities (period/filter change) never touches it, and it (re)appears
   // when the async boundary computation lands or the theme changes.
   useEffect(() => {
-    if (!map) return;
+    if (!map || !nreBoundaries.length) return;
 
-    if (nreBoundaryLayerRef.current) {
-      nreBoundaryLayerRef.current.setMap(null);
-      nreBoundaryLayerRef.current = null;
-    }
-
-    if (!nreBoundaries.length) return;
-
+    // The previous layer is torn down by this effect's cleanup before it re-runs
+    // (and on unmount), so there's nothing to clear here.
     const strokeNreColor = getCssVar('--color-map-stroke-nre', '#ffffff');
     const nreLayer = new google.maps.Data();
     nreBoundaries.forEach((boundary) => {

--- a/src/components/ChoroplethMap/nreBoundaries.test.ts
+++ b/src/components/ChoroplethMap/nreBoundaries.test.ts
@@ -1,0 +1,175 @@
+import unionDefault from '@turf/union';
+import {
+  computeNREBoundariesAsync,
+  yieldToMain,
+  NRE_UNION_SLICE_MS,
+} from './nreBoundaries';
+import type { RegionData } from './ChoroplethMap.types';
+
+// The test environment has no DOM MessageChannel. Provide a minimal one that
+// honours the onmessage/postMessage contract yieldToMain uses, delivering to the
+// opposite port on a macrotask (like the real thing).
+class FakePort {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  other!: FakePort;
+  postMessage(data: unknown) {
+    const target = this.other;
+    setTimeout(() => target.onmessage?.({ data }), 0);
+  }
+}
+class FakeMessageChannel {
+  port1 = new FakePort();
+  port2 = new FakePort();
+  constructor() {
+    this.port1.other = this.port2;
+    this.port2.other = this.port1;
+  }
+}
+(globalThis as { MessageChannel?: unknown }).MessageChannel =
+  globalThis.MessageChannel ?? FakeMessageChannel;
+
+// Merge stub: return the first feature so `merged` stays truthy.
+jest.mock('@turf/union', () => ({
+  __esModule: true,
+  default: jest.fn((fc: { features: unknown[] }) => fc.features[0]),
+}));
+
+const union = unionDefault as unknown as jest.Mock;
+
+const city = (id: string, groupName?: string): RegionData => ({
+  id,
+  name: id,
+  groupName,
+  value: 0.5,
+  accessCount: 1,
+  geoJson: {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ],
+    },
+  },
+});
+
+/** Make performance.now advance past the slice budget on every call. */
+const advanceClockPastBudget = () => {
+  let elapsed = 0;
+  jest
+    .spyOn(performance, 'now')
+    .mockImplementation(() => (elapsed += NRE_UNION_SLICE_MS + 100));
+};
+
+describe('computeNREBoundariesAsync', () => {
+  beforeEach(() => {
+    union.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('merges cities that share an NRE into one boundary', async () => {
+    const result = await computeNREBoundariesAsync(
+      [city('c1', 'NRE 1'), city('c2', 'NRE 1')],
+      () => false
+    );
+
+    expect(union).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('groups regions without an NRE under their own name (no union)', async () => {
+    const result = await computeNREBoundariesAsync(
+      [city('a'), city('b')],
+      () => false
+    );
+
+    expect(union).not.toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns an empty array for empty data', async () => {
+    await expect(computeNREBoundariesAsync([], () => false)).resolves.toEqual(
+      []
+    );
+  });
+
+  it('skips regions whose geoJson is not a Feature', async () => {
+    const notAFeature = {
+      ...city('x', 'NRE 1'),
+      geoJson: { type: 'FeatureCollection', features: [] },
+    } as unknown as RegionData;
+
+    const result = await computeNREBoundariesAsync(
+      [notAFeature, city('y', 'NRE 1')],
+      () => false
+    );
+
+    // 'x' is skipped, so only 'y' remains — no merge needed.
+    expect(union).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+
+  it('yields to the browser when a slice exceeds the time budget', async () => {
+    advanceClockPastBudget();
+
+    const result = await computeNREBoundariesAsync(
+      [city('c1', 'NRE 1'), city('c2', 'NRE 1')],
+      () => false
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('aborts and returns null when cancelled between slices', async () => {
+    advanceClockPastBudget();
+
+    let cancel = false;
+    // Runs synchronously up to the first `await yieldToMain()`, then suspends.
+    const pending = computeNREBoundariesAsync(
+      [city('c1', 'NRE 1')],
+      () => cancel
+    );
+    cancel = true;
+
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it('produces no boundary for a group with only invalid features', async () => {
+    const notAFeature = {
+      ...city('x', 'NRE 1'),
+      geoJson: { type: 'FeatureCollection', features: [] },
+    } as unknown as RegionData;
+
+    // The one region is skipped, so the group never yields a merged polygon.
+    await expect(
+      computeNREBoundariesAsync([notAFeature], () => false)
+    ).resolves.toEqual([]);
+  });
+
+  it('keeps the running merge when union returns null', async () => {
+    union.mockReturnValueOnce(null);
+
+    // union fails on the second city, so `merged` stays the first one.
+    const result = await computeNREBoundariesAsync(
+      [city('c1', 'NRE 1'), city('c2', 'NRE 1')],
+      () => false
+    );
+
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('yieldToMain', () => {
+  it('resolves on the next macrotask', async () => {
+    await expect(yieldToMain()).resolves.toBeUndefined();
+  });
+});

--- a/src/components/ChoroplethMap/nreBoundaries.ts
+++ b/src/components/ChoroplethMap/nreBoundaries.ts
@@ -16,11 +16,59 @@ export const yieldToMain = (): Promise<void> =>
     channel.port2.postMessage(undefined);
   });
 
+/** A merged NRE outline polygon. */
+type NreBoundary = Feature<Polygon | MultiPolygon>;
+
+/** Group regions by their NRE label, falling back to the region's own name. */
+const groupRegionsByNRE = (data: RegionData[]): Map<string, RegionData[]> => {
+  const groups = new Map<string, RegionData[]>();
+  for (const region of data) {
+    const key = region.groupName ?? region.name;
+    const existing = groups.get(key) ?? [];
+    existing.push(region);
+    groups.set(key, existing);
+  }
+  return groups;
+};
+
+/**
+ * A time-sliced yielder: returns `true` to keep going, or yields to the browser
+ * once the current slice runs past its budget. After a yield it returns whether
+ * the work should continue (i.e. it was not cancelled).
+ */
+const createSlicer = (isCancelled: () => boolean): (() => Promise<boolean>) => {
+  let sliceStart = performance.now();
+  return async () => {
+    if (performance.now() - sliceStart <= NRE_UNION_SLICE_MS) return true;
+    await yieldToMain();
+    sliceStart = performance.now();
+    return !isCancelled();
+  };
+};
+
+/** Merge one NRE group's city polygons into a single outline, yielding between
+ * slices. Reports `cancelled` when the shared slicer aborts mid-merge. */
+const mergeRegionGroup = async (
+  regions: RegionData[],
+  slice: () => Promise<boolean>
+): Promise<{ boundary: NreBoundary | null; cancelled: boolean }> => {
+  let merged: NreBoundary | null = null;
+  for (const region of regions) {
+    if (region.geoJson.type !== 'Feature') continue;
+    const feature = region.geoJson as NreBoundary;
+    merged = merged
+      ? (union({ type: 'FeatureCollection', features: [merged, feature] }) ??
+        merged)
+      : feature;
+    if (!(await slice())) return { boundary: merged, cancelled: true };
+  }
+  return { boundary: merged, cancelled: false };
+};
+
 /**
  * Compute NRE boundary polygons by merging city polygons that share the same
  * group (the NRE) — WITHOUT blocking the main thread. Grouping uses `groupName`
- * (the NRE label); when a region has no `groupName`, it falls back to its own
- * `name` so it forms its own group.
+ * (the NRE label); a region with no `groupName` forms its own group.
  *
  * Merging hundreds of municipal polygons with `union` is heavy (seconds), so the
  * work is sliced: after ~`NRE_UNION_SLICE_MS` of merging it yields to the
@@ -35,40 +83,15 @@ export const yieldToMain = (): Promise<void> =>
 export const computeNREBoundariesAsync = async (
   data: RegionData[],
   isCancelled: () => boolean
-): Promise<Feature<Polygon | MultiPolygon>[] | null> => {
-  const groups = new Map<string, RegionData[]>();
-  data.forEach((region) => {
-    const groupKey = region.groupName ?? region.name;
-    const existing = groups.get(groupKey) ?? [];
-    existing.push(region);
-    groups.set(groupKey, existing);
-  });
-
-  const boundaries: Feature<Polygon | MultiPolygon>[] = [];
-  let sliceStart = performance.now();
+): Promise<NreBoundary[] | null> => {
+  const groups = groupRegionsByNRE(data);
+  const slice = createSlicer(isCancelled);
+  const boundaries: NreBoundary[] = [];
 
   for (const regions of groups.values()) {
-    let merged: Feature<Polygon | MultiPolygon> | null = null;
-    for (const region of regions) {
-      if (region.geoJson.type !== 'Feature') continue;
-      const feature: Feature<Polygon | MultiPolygon> = region.geoJson;
-      if (merged) {
-        const result: Feature<Polygon | MultiPolygon> | null = union({
-          type: 'FeatureCollection' as const,
-          features: [merged, feature],
-        });
-        if (result) merged = result;
-      } else {
-        merged = feature;
-      }
-
-      if (performance.now() - sliceStart > NRE_UNION_SLICE_MS) {
-        await yieldToMain();
-        if (isCancelled()) return null;
-        sliceStart = performance.now();
-      }
-    }
-    if (merged) boundaries.push(merged);
+    const { boundary, cancelled } = await mergeRegionGroup(regions, slice);
+    if (cancelled) return null;
+    if (boundary) boundaries.push(boundary);
   }
 
   return boundaries;

--- a/src/components/ChoroplethMap/nreBoundaries.ts
+++ b/src/components/ChoroplethMap/nreBoundaries.ts
@@ -1,0 +1,75 @@
+import union from '@turf/union';
+import type { Feature, MultiPolygon, Polygon } from 'geojson';
+import type { RegionData } from './ChoroplethMap.types';
+
+/** Work budget per slice before yielding the main thread back to the browser. */
+export const NRE_UNION_SLICE_MS = 8;
+
+/**
+ * Yield control to the browser so it can paint and handle input between slices
+ * of a long computation. MessageChannel avoids the ~4ms clamp of setTimeout(0).
+ */
+export const yieldToMain = (): Promise<void> =>
+  new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve();
+    channel.port2.postMessage(undefined);
+  });
+
+/**
+ * Compute NRE boundary polygons by merging city polygons that share the same
+ * group (the NRE) — WITHOUT blocking the main thread. Grouping uses `groupName`
+ * (the NRE label); when a region has no `groupName`, it falls back to its own
+ * `name` so it forms its own group.
+ *
+ * Merging hundreds of municipal polygons with `union` is heavy (seconds), so the
+ * work is sliced: after ~`NRE_UNION_SLICE_MS` of merging it yields to the
+ * browser, keeping the page responsive while the outlines fill in a beat after
+ * the cities. Resolves to `null` when `isCancelled` flips (the geometry changed
+ * mid-flight), so a stale result is never applied.
+ *
+ * @param data - Array of region data with individual city GeoJSON features
+ * @param isCancelled - Polled between slices; return true to abort
+ * @returns NRE boundary features, or null if cancelled
+ */
+export const computeNREBoundariesAsync = async (
+  data: RegionData[],
+  isCancelled: () => boolean
+): Promise<Feature<Polygon | MultiPolygon>[] | null> => {
+  const groups = new Map<string, RegionData[]>();
+  data.forEach((region) => {
+    const groupKey = region.groupName ?? region.name;
+    const existing = groups.get(groupKey) ?? [];
+    existing.push(region);
+    groups.set(groupKey, existing);
+  });
+
+  const boundaries: Feature<Polygon | MultiPolygon>[] = [];
+  let sliceStart = performance.now();
+
+  for (const regions of groups.values()) {
+    let merged: Feature<Polygon | MultiPolygon> | null = null;
+    for (const region of regions) {
+      if (region.geoJson.type !== 'Feature') continue;
+      const feature: Feature<Polygon | MultiPolygon> = region.geoJson;
+      if (merged) {
+        const result: Feature<Polygon | MultiPolygon> | null = union({
+          type: 'FeatureCollection' as const,
+          features: [merged, feature],
+        });
+        if (result) merged = result;
+      } else {
+        merged = feature;
+      }
+
+      if (performance.now() - sliceStart > NRE_UNION_SLICE_MS) {
+        await yieldToMain();
+        if (isCancelled()) return null;
+        sliceStart = performance.now();
+      }
+    }
+    if (merged) boundaries.push(merged);
+  }
+
+  return boundaries;
+};

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1063,8 +1063,10 @@ const ProfileMenuReadingFluencyInfo = forwardRef<
         {...props}
       >
         <div className="flex flex-col">
-          <Text size='md' className="font-bold text-text-100 truncate">{name}</Text>
-          <Text size='sm' className="font-medium text-secondary-300 truncate">
+          <Text size="md" className="font-bold text-text-100 truncate">
+            {name}
+          </Text>
+          <Text size="sm" className="font-medium text-secondary-300 truncate">
             {email}
           </Text>
         </div>
@@ -1072,12 +1074,15 @@ const ProfileMenuReadingFluencyInfo = forwardRef<
         {hasSchoolBlock && (
           <div className="flex flex-col">
             {schoolName && (
-              <Text size='md' className="font-bold text-text-100 truncate">
+              <Text size="md" className="font-bold text-text-100 truncate">
                 {schoolName}
               </Text>
             )}
             {(classYearName || schoolYearName) && (
-              <Text size='sm' className="font-medium text-secondary-300 truncate">
+              <Text
+                size="sm"
+                className="font-medium text-secondary-300 truncate"
+              >
                 {[classYearName, schoolYearName].filter(Boolean).join(' • ')}
               </Text>
             )}

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -320,7 +320,7 @@ export const MicPermissionReadingFluencyManaged: Story = () => (
     data-theme="papole-light"
     className="flex min-h-[420px] items-center justify-center bg-secondary-700 p-6"
   >
-    <Text size='sm' className="text-center text-text-100">
+    <Text size="sm" className="text-center text-text-100">
       Abre automaticamente se o microfone não estiver concedido.
     </Text>
     <MicPermissionModalReadingFluency

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -202,7 +202,7 @@ const Modal = ({
             {/* Título */}
             <Text
               id={titleId}
-              size='lg'
+              size="lg"
               className="font-semibold text-text-950 text-center"
             >
               {title}
@@ -210,7 +210,10 @@ const Modal = ({
 
             {/* Descrição */}
             {description && (
-              <Text size='sm' className="text-text-400 text-center max-w-md leading-[21px]">
+              <Text
+                size="sm"
+                className="text-text-400 text-center max-w-md leading-[21px]"
+              >
                 {description}
               </Text>
             )}
@@ -447,18 +450,18 @@ const MicPermissionModalReadingFluency = ({
 
         {/* Corpo (padding 24) */}
         <div className="flex flex-col items-center gap-4 bg-background p-6 text-center">
-          <Text size='lg' id={titleId} className="font-bold text-secondary-900">
+          <Text size="lg" id={titleId} className="font-bold text-secondary-900">
             {title}
           </Text>
 
           <div className="flex flex-col gap-3 text-[14px] font-medium text-text-600">
             {description ?? (
               <>
-                <Text size='sm'>
+                <Text size="sm">
                   Usamos o microfone para gravar a leitura da criança e avaliar
                   sua fluência leitora ao longo do tempo.
                 </Text>
-                <Text size='sm'>
+                <Text size="sm">
                   As gravações ficam armazenadas com segurança e são usadas
                   apenas para esse fim.
                 </Text>
@@ -487,7 +490,7 @@ const MicPermissionModalReadingFluency = ({
           <Button
             type="button"
             onClick={onLearnMore}
-            variant='raw'
+            variant="raw"
             className="w-full cursor-pointer rounded-xl bg-secondary-100 px-4 py-4 text-center"
           >
             <span className="text-[14px] font-medium text-secondary-700 underline">
@@ -579,7 +582,7 @@ const MicOffModalReadingFluency = ({
         <div className="flex flex-col items-center gap-4 bg-background p-6 text-center">
           <Text
             id={titleId}
-            size='lg'
+            size="lg"
             className="font-bold uppercase text-secondary-900"
           >
             {title}
@@ -791,7 +794,7 @@ const AudioPlaybackModalReadingFluency = ({
               onClick={togglePlay}
               disabled={!resolvedSrc}
               aria-label={isPlaying ? 'Pausar' : 'Reproduzir'}
-              variant='raw'
+              variant="raw"
               className="flex flex-shrink-0 items-center justify-center disabled:cursor-not-allowed disabled:opacity-40"
             >
               {isPlaying ? (
@@ -805,7 +808,7 @@ const AudioPlaybackModalReadingFluency = ({
               type="button"
               onClick={handleSeek}
               aria-label="Barra de progresso"
-              variant='raw'
+              variant="raw"
               className="h-2 flex-1 overflow-hidden rounded-full bg-background"
             >
               <span
@@ -917,12 +920,15 @@ const SuccessModalReadingFluency = ({
           <div className="flex flex-col items-center gap-1">
             <Text
               id={titleId}
-              size='3xl'
+              size="3xl"
               className="font-bold uppercase text-secondary-900"
             >
               {title}
             </Text>
-            <Text size='sm' className="font-semibold uppercase tracking-wide text-text-500">
+            <Text
+              size="sm"
+              className="font-semibold uppercase tracking-wide text-text-500"
+            >
               {description}
             </Text>
           </div>

--- a/src/components/ReadAloudPromptReadingFluency/ReadAloudPromptReadingFluency.tsx
+++ b/src/components/ReadAloudPromptReadingFluency/ReadAloudPromptReadingFluency.tsx
@@ -61,12 +61,14 @@ export const ReadAloudPromptReadingFluency = ({
         />
       )}
 
-      <Text size='sm' className="font-semibold uppercase text-text-700">
+      <Text size="sm" className="font-semibold uppercase text-text-700">
         {label}
       </Text>
 
       <div className="flex flex-col gap-2 rounded-xl border border-secondary-500 p-4">
-        <Text size='2xl' className="font-bold uppercase text-text-900">{text}</Text>
+        <Text size="2xl" className="font-bold uppercase text-text-900">
+          {text}
+        </Text>
       </div>
     </div>
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved map responsiveness by generating NRE boundaries incrementally instead of blocking the UI.
  - Prevented stale NRE boundary overlays from showing after rapid updates by canceling in-progress computations.
  - Reduced recomputation by reusing geometry-only work when access metrics change, recalculating only when NRE grouping changes.
  - Kept map overlays stable while city polygons refresh.
- **Tests**
  - Added coverage to verify memoization, async yielding behavior, and cancellation handling for NRE boundary generation.
- **Style**
  - Standardized JSX prop formatting across reading fluency menus, modals, prompts, and component stories without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->