### PR TITLE
feat(lesson-availability): expose start date with local time

### DIFF
--- a/src/types/lessonAvailability.ts
+++ b/src/types/lessonAvailability.ts
@@ -31,6 +31,13 @@ export interface LessonAvailabilityResult {
   endDate: Date | null;
   /** Formatted start date string for display (DD/MM/YYYY) */
   formattedStartDate: string | null;
+  /**
+   * Formatted start date string including the local time
+   * (D de MMMM de YYYY às HH:mm). Prefer this over `formattedStartDate` when
+   * telling the student when a lesson becomes available — lessons can start at
+   * any time of day, and the date alone reads as "available now".
+   */
+  formattedStartDateTime: string | null;
   /** Formatted end date string for display (DD/MM/YYYY) */
   formattedEndDate: string | null;
 }

--- a/src/utils/lessonAvailabilityUtils.test.ts
+++ b/src/utils/lessonAvailabilityUtils.test.ts
@@ -5,6 +5,21 @@ import {
   isLessonExpired,
 } from './lessonAvailabilityUtils';
 
+const PT_BR_MONTHS = [
+  'janeiro',
+  'fevereiro',
+  'março',
+  'abril',
+  'maio',
+  'junho',
+  'julho',
+  'agosto',
+  'setembro',
+  'outubro',
+  'novembro',
+  'dezembro',
+];
+
 describe('lessonAvailabilityUtils', () => {
   beforeEach(() => {
     // Mock current date to 2024-06-15T12:00:00Z
@@ -83,6 +98,27 @@ describe('lessonAvailabilityUtils', () => {
       const result = checkLessonAvailability(null, '2024-01-01T00:00:00Z');
 
       expect(result.status).toBe(LESSON_AVAILABILITY.EXPIRADA);
+    });
+
+    it('should format the start date with the local time for display', () => {
+      // 17:30Z is 14:30 in UTC-3. Expectation is derived from native local
+      // getters so the assertion holds in any TZ.
+      const iso = '2024-07-15T17:30:00Z';
+      const local = new Date(iso);
+      const expected =
+        `${local.getDate()} de ${PT_BR_MONTHS[local.getMonth()]} de ` +
+        `${local.getFullYear()} às ${String(local.getHours()).padStart(2, '0')}:` +
+        `${String(local.getMinutes()).padStart(2, '0')}`;
+
+      const result = checkLessonAvailability(iso, null);
+
+      expect(result.formattedStartDateTime).toBe(expected);
+    });
+
+    it('should return null formattedStartDateTime when start date is null', () => {
+      const result = checkLessonAvailability(null, '2024-12-31T23:59:59Z');
+
+      expect(result.formattedStartDateTime).toBeNull();
     });
 
     it('should parse dates correctly', () => {

--- a/src/utils/lessonAvailabilityUtils.ts
+++ b/src/utils/lessonAvailabilityUtils.ts
@@ -3,12 +3,27 @@
  * Helper functions for checking recommended lesson availability based on dates
  */
 
+import dayjs from 'dayjs';
+import 'dayjs/locale/pt-br';
 import {
   LESSON_AVAILABILITY,
   type LessonAvailability,
   type LessonAvailabilityResult,
 } from '../types/lessonAvailability';
 import { formatDateToBrazilian } from './activityDetailsUtils';
+
+/**
+ * Format a lesson date including its time, in LOCAL time.
+ *
+ * Lesson start/final dates are full timestamps — a teacher can schedule a
+ * lesson to open at 14:30. Showing only the day (see formatDateToBrazilian,
+ * which also formats in UTC) makes a lesson that opens later today look like
+ * it should already be available.
+ * @param dateString - ISO date string
+ * @returns Formatted date string "D de MMMM de YYYY às HH:mm"
+ */
+const formatLessonDateTime = (dateString: string): string =>
+  dayjs(dateString).locale('pt-br').format('D [de] MMMM [de] YYYY [às] HH:mm');
 
 /**
  * Check if a date string represents a date in the past
@@ -64,6 +79,7 @@ export const checkLessonAvailability = (
     startDate: start,
     endDate: end,
     formattedStartDate: startDate ? formatDateToBrazilian(startDate) : null,
+    formattedStartDateTime: startDate ? formatLessonDateTime(startDate) : null,
     formattedEndDate: finalDate ? formatDateToBrazilian(finalDate) : null,
   };
 };


### PR DESCRIPTION
## Context

AE-XXXX — when a teacher schedules a recommended lesson to open later in the
day (e.g. in 30 minutes), the student-facing "lesson not available" modal shows
only the day. It reads as if the lesson should already be open.

`start_date` is a `timestamp` column and the API already returns the full ISO
datetime — the time was being dropped at format time.

## Changes

- Add `formattedStartDateTime` to `LessonAvailabilityResult`, formatted as
  `D de MMMM de YYYY às HH:mm` in **local** time — the same format used by the
  activity availability modal, so both modals now read alike.
- `checkLessonAvailability` populates the new field; `formattedStartDate` is
  untouched.

`formatDateToBrazilian` was deliberately left alone: it is exported publicly and
also used by `ActivityDetails`, and it formats in UTC — appending the time there
would render the wrong hour in UTC-3.

## Tests

- Two new cases in `lessonAvailabilityUtils.test.ts`, written test-first.
  Expectations are derived from native local `Date` getters, so they hold in any
  timezone (same convention as the `formatActivityDateToBrazilian` test).
- Full suite green: 397 suites / 10455 tests. `typecheck` and `lint` clean.

## Follow-up

Consumers (`frontend-aluno-web`, `analytica-app-novo`) switch over once this is
published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lesson availability now includes the start date and local time in a localized, user-friendly format.
  * When no start date is available, the formatted date-time display remains empty.

* **Tests**
  * Added coverage for localized formatting, local-time conversion, and missing start dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->