### PR TITLE
fix(dropdown-menu): render triggers as their child to avoid nested bu…

### DIFF
--- a/src/components/ActivityFilters/ActivityFilters.tsx
+++ b/src/components/ActivityFilters/ActivityFilters.tsx
@@ -713,7 +713,7 @@ export const ActivityFiltersPopover = ({
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>
         <Button variant="outline">{triggerLabel}</Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/src/components/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppHeader/AppHeader.test.tsx
@@ -82,9 +82,10 @@ describe('AppHeader', () => {
 
   it('does not render calendar trigger when showCalendar is false', () => {
     render(<AppHeader {...baseProps()} />);
-    // Each icon trigger contributes 2 buttons (DropdownMenuTrigger > IconButton).
-    // Without calendar: notification + profile = 4 buttons total.
-    expect(screen.getAllByRole('button')).toHaveLength(4);
+    // Each icon trigger renders a single button (asChild merges the trigger
+    // into its IconButton — no nested <button>).
+    // Without calendar: notification + profile = 2 buttons total.
+    expect(screen.getAllByRole('button')).toHaveLength(2);
   });
 
   it('renders calendar trigger when showCalendar is true', () => {
@@ -96,8 +97,9 @@ describe('AppHeader', () => {
         })}
       />
     );
-    // Calendar + notification + profile = 6 buttons total (2 per icon).
-    expect(screen.getAllByRole('button')).toHaveLength(6);
+    // One button per icon trigger (asChild — no nested <button>).
+    // Calendar + notification + profile = 3 buttons total.
+    expect(screen.getAllByRole('button')).toHaveLength(3);
   });
 
   it('wraps the calendar in an lg:hidden container (visible only below 1024px)', () => {

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -330,7 +330,10 @@ export const AppHeader = ({
                 );
               }}
             >
-              <DropdownMenuTrigger className="text-primary cursor-pointer">
+              <DropdownMenuTrigger
+                className="text-primary cursor-pointer"
+                asChild
+              >
                 <IconButton
                   active={activeStates.profile}
                   onClick={() => toggleActive('profile')}

--- a/src/components/CalendarCard/CalendarCard.tsx
+++ b/src/components/CalendarCard/CalendarCard.tsx
@@ -91,6 +91,7 @@ export const CalendarCard = ({
     <DropdownMenu open={effectiveOpen} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger
         className={`text-primary cursor-pointer ${className ?? ''}`}
+        asChild
       >
         <IconButton active={effectiveOpen} icon={triggerIcon} />
       </DropdownMenuTrigger>

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1731,4 +1731,35 @@ describe('ProfileMenuReadingFluency components', () => {
       );
     });
   });
+
+  describe('DropdownMenuTrigger asChild', () => {
+    it('renders the child as the trigger without a wrapping button and merges the toggle', () => {
+      const childClick = jest.fn();
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild className="extra-class">
+            <button data-testid="as-child-trigger" onClick={childClick}>
+              Abrir
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByTestId('as-child-trigger');
+      // The child button is the trigger — never nested inside another button.
+      expect(document.querySelector('button button')).toBeNull();
+      expect(trigger).toHaveClass('extra-class');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.click(trigger);
+
+      // The child's own handler still runs, and the menu toggles open.
+      expect(childClick).toHaveBeenCalledTimes(1);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1761,5 +1761,55 @@ describe('ProfileMenuReadingFluency components', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
       expect(screen.getByRole('menu')).toBeInTheDocument();
     });
+
+    it('merges the trigger ref with the child ref and toggles a child without its own onClick', () => {
+      const triggerRef = jest.fn(); // callback ref -> covers the function branch of mergeRefs
+      const childRef = React.createRef<HTMLButtonElement>(); // object ref -> covers the else branch
+
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild ref={triggerRef}>
+            <button data-testid="as-child-ref-trigger" ref={childRef}>
+              Abrir
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByTestId('as-child-ref-trigger');
+      // mergeRefs fans the single node out to both refs: the trigger's
+      // forwarded callback ref and the child's own object ref.
+      expect(triggerRef).toHaveBeenCalledWith(trigger);
+      expect(childRef.current).toBe(trigger);
+
+      // The child has no onClick of its own, so clicking runs only the
+      // trigger's toggle (covers the `child.props.onClick?.` short-circuit).
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('applies only the trigger ref when the child has no ref of its own', () => {
+      const triggerRef = React.createRef<HTMLButtonElement>();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild ref={triggerRef}>
+            <button data-testid="as-child-only-trigger-ref">Abrir</button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+
+      // The child has no ref, so mergeRefs returns the trigger ref unchanged.
+      expect(triggerRef.current).toBe(
+        screen.getByTestId('as-child-only-trigger-ref')
+      );
+    });
   });
 });

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -17,6 +17,7 @@ import {
   cloneElement,
   ReactElement,
   useState,
+  Ref,
   RefObject,
   CSSProperties,
 } from 'react';
@@ -196,6 +197,25 @@ const horizontalPortalStyle = (
     : { left: rect.right + sideOffset }),
 });
 
+/**
+ * Merge two refs into one. Returns the single ref when only one is set (no
+ * callback churn), or `undefined` when neither is — so a cloned child without a
+ * ref stays refless.
+ */
+const mergeRefs = <T,>(
+  a: Ref<T> | undefined,
+  b: Ref<T> | undefined
+): Ref<T> | undefined => {
+  if (!a) return b;
+  if (!b) return a;
+  return (node: T | null) => {
+    for (const r of [a, b]) {
+      if (typeof r === 'function') r(node);
+      else (r as RefObject<T | null>).current = node;
+    }
+  };
+};
+
 const injectStore = (
   children: ReactNode,
   store: DropdownStoreApi
@@ -368,33 +388,76 @@ const DropdownMenuTrigger = forwardRef<
   ButtonHTMLAttributes<HTMLButtonElement> & {
     disabled?: boolean;
     store?: DropdownStoreApi;
+    /**
+     * Render the single child as the trigger instead of wrapping it in a
+     * `<button>`. Use when the child is itself a button/interactive element, so
+     * the trigger doesn't nest one button inside another (invalid HTML). The
+     * child keeps its own props; the toggle behaviour and `aria-expanded` are
+     * merged in.
+     */
+    asChild?: boolean;
   }
->(({ className, children, onClick, store: externalStore, ...props }, ref) => {
-  const store = useDropdownStore(externalStore);
+>(
+  (
+    { className, children, onClick, store: externalStore, asChild, ...props },
+    ref
+  ) => {
+    const store = useDropdownStore(externalStore);
 
-  const open = useStore(store, (s) => s.open);
-  const toggleOpen = () => store.setState({ open: !open });
+    const open = useStore(store, (s) => s.open);
+    const toggleOpen = () => store.setState({ open: !open });
 
-  return (
-    <button
-      ref={ref}
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        toggleOpen();
-        onClick?.(e);
-      }}
-      aria-expanded={open}
-      className={cn(
-        'appearance-none bg-transparent border-none p-0',
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-});
+    const handleTriggerClick = (e: MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      toggleOpen();
+      onClick?.(e as MouseEvent<HTMLButtonElement>);
+    };
+
+    // `injectStore` re-wraps children through Children.map, so `children` may be
+    // a single-element array rather than a bare element — unwrap it here.
+    const asChildElement = asChild
+      ? (Children.toArray(children).find(isValidElement) as
+          | ReactElement<{
+              className?: string;
+              onClick?: (e: MouseEvent<HTMLElement>) => void;
+              ref?: Ref<HTMLElement>;
+            }>
+          | undefined)
+      : undefined;
+
+    if (asChildElement) {
+      const child = asChildElement;
+      return cloneElement(child, {
+        ...props,
+        ref: mergeRefs(ref, child.props.ref),
+        className: cn(child.props.className, className),
+        'aria-expanded': open,
+        onClick: (e: MouseEvent<HTMLElement>) => {
+          // Keep the child's own handler, then run the trigger's toggle — same
+          // order as the previous nested-button version.
+          child.props.onClick?.(e);
+          handleTriggerClick(e);
+        },
+      } as Partial<HTMLAttributes<HTMLElement>> & { store?: DropdownStoreApi });
+    }
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={handleTriggerClick}
+        aria-expanded={open}
+        className={cn(
+          'appearance-none bg-transparent border-none p-0',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
 DropdownMenuTrigger.displayName = 'DropdownMenuTrigger';
 
 const ITEM_SIZE_CLASSES = {

--- a/src/components/NotificationCard/NotificationCard.test.tsx
+++ b/src/components/NotificationCard/NotificationCard.test.tsx
@@ -1330,6 +1330,26 @@ describe('NotificationCard', () => {
       expect(onToggleActive).toHaveBeenCalledTimes(1);
     });
 
+    it('renders the desktop trigger as a single button (no nested button)', () => {
+      const mockProps = {
+        variant: 'center' as const,
+        isActive: false,
+        onToggleActive: jest.fn(),
+        unreadCount: 3,
+        groupedNotifications: [],
+        onFetchNotifications: jest.fn(),
+      };
+
+      const { container } = render(<LegacyNotificationCard {...mockProps} />);
+
+      // A button must never wrap another button (invalid HTML → hydration error).
+      expect(container.querySelector('button button')).toBeNull();
+      // The trigger is still a labelled button wired for the dropdown.
+      expect(screen.getByLabelText('Botão de ação')).toHaveAttribute(
+        'aria-expanded'
+      );
+    });
+
     it('renders notification center button in mobile mode', () => {
       mockUseMobile.mockReturnValue(
         makeUseMobileMock({

--- a/src/components/NotificationCard/NotificationCard.tsx
+++ b/src/components/NotificationCard/NotificationCard.tsx
@@ -825,7 +825,7 @@ const NotificationCenter = ({
           ? { open: isActive, onOpenChange: handleOpenChange }
           : { onOpenChange: handleOpenChange })}
       >
-        <DropdownMenuTrigger className="text-primary cursor-pointer">
+        <DropdownMenuTrigger className="text-primary cursor-pointer" asChild>
           <IconButton
             active={isActive}
             onClick={handleDesktopClick}

--- a/src/hooks/useRecommendedLessonsPage.test.ts
+++ b/src/hooks/useRecommendedLessonsPage.test.ts
@@ -414,6 +414,29 @@ describe('useRecommendedLessonsPage', () => {
     expect(response).toEqual(validRecommendedClassModelsResponse);
   });
 
+  it('fetchRecommendedClassModels: does not throw when the response has no drafts', async () => {
+    // A malformed/empty response must degrade gracefully, not throw
+    // "drafts is not iterable".
+    const responseWithoutDrafts = {
+      message: 'Success',
+      data: { total: 0 },
+    } as unknown as RecommendedClassModelsApiResponse;
+    (mockApi.get as jest.Mock).mockResolvedValueOnce({
+      data: responseWithoutDrafts,
+    });
+
+    const { result } = setupHook();
+    let response: RecommendedClassModelsApiResponse | undefined;
+
+    await act(async () => {
+      response = await result.current.historyProps.fetchRecommendedClassModels(
+        {}
+      );
+    });
+
+    expect(response).toEqual(responseWithoutDrafts);
+  });
+
   it('fetchRecommendedClassModels: should extract subjects and update userFilterData', async () => {
     const responseWithSubject: RecommendedClassModelsApiResponse = {
       message: 'Success',

--- a/src/hooks/useRecommendedLessonsPage.ts
+++ b/src/hooks/useRecommendedLessonsPage.ts
@@ -392,10 +392,10 @@ const extractMapsFromItems = (
  * Extract unique subjects from draft/model items for filter population
  */
 const extractSubjectsFromDraftItems = (
-  drafts: RecommendedClassModelResponse[]
+  drafts: RecommendedClassModelResponse[] | undefined | null
 ): Array<{ id: string; name: string }> => {
   const subjectMap = new Map<string, string>();
-  for (const draft of drafts) {
+  for (const draft of drafts ?? []) {
     if (draft.subject?.id && draft.subject?.name) {
       subjectMap.set(draft.subject.id, draft.subject.name);
     }


### PR DESCRIPTION
…ttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dropdown triggers across filters, calendars, profiles, and notifications to avoid nested buttons and ensure correct accessibility states.
  - Prevented recommended lessons from failing when draft data is missing or unavailable.

- **Accessibility**
  - Dropdown controls now correctly expose their expanded or collapsed state.

- **Tests**
  - Added coverage for streamlined dropdown triggers and missing draft data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->