### PR TITLE
AE-2961: fix map calc

### DIFF
--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -394,6 +394,38 @@ describe('ChoroplethMap', () => {
     expect(mockAddGeoJson).toHaveBeenCalledTimes(mockRegionData.length);
   });
 
+  it('does not redraw the map when legendLabels declares the same captions in another key order', async () => {
+    // Serializing the object would hash these two as different values, since
+    // JSON.stringify preserves insertion order.
+    const { rerender } = render(
+      <ChoroplethMap
+        data={mockRegionData}
+        apiKey={mockApiKey}
+        legendLabels={{
+          highlight: 'Destaque (75% realizaram)',
+          none: 'Ninguém realizou (0%)',
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(mockRegionData.length);
+    });
+
+    rerender(
+      <ChoroplethMap
+        data={mockRegionData}
+        apiKey={mockApiKey}
+        legendLabels={{
+          none: 'Ninguém realizou (0%)',
+          highlight: 'Destaque (75% realizaram)',
+        }}
+      />
+    );
+
+    expect(mockAddGeoJson).toHaveBeenCalledTimes(mockRegionData.length);
+  });
+
   it('sets up mouse event listeners', async () => {
     render(<ChoroplethMap data={mockRegionData} apiKey={mockApiKey} />);
 

--- a/src/components/ChoroplethMap/ChoroplethMap.test.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.test.tsx
@@ -229,6 +229,42 @@ describe('ChoroplethMap', () => {
     expect(screen.getByText('Sem acesso (0%)')).toBeInTheDocument();
   });
 
+  it('renders custom legend labels when legendLabels is provided', () => {
+    render(
+      <ChoroplethMap
+        data={[]}
+        apiKey={mockApiKey}
+        legendLabels={{
+          highlight: 'Destaque (75% realizaram)',
+          aboveAverage: 'Acima da média (50 até 74% realizaram)',
+          belowAverage: 'Abaixo da média (25 até 49% realizaram)',
+          attention: 'Ponto de atenção (Abaixo de 25% realizaram)',
+          none: 'Ninguém realizou (0%)',
+        }}
+      />
+    );
+
+    expect(screen.getByText('Destaque (75% realizaram)')).toBeInTheDocument();
+    expect(screen.getByText('Ninguém realizou (0%)')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Destaque (75% com acesso)')
+    ).not.toBeInTheDocument();
+  });
+
+  it('merges partial legendLabels over the defaults', () => {
+    render(
+      <ChoroplethMap
+        data={[]}
+        apiKey={mockApiKey}
+        legendLabels={{ none: 'Sem desempenho (0%)' }}
+      />
+    );
+
+    expect(screen.getByText('Sem desempenho (0%)')).toBeInTheDocument();
+    // Untouched bands keep the default access wording.
+    expect(screen.getByText('Destaque (75% com acesso)')).toBeInTheDocument();
+  });
+
   it('shows loading skeleton when loading is true', () => {
     render(<ChoroplethMap data={[]} apiKey={mockApiKey} loading={true} />);
 
@@ -327,6 +363,35 @@ describe('ChoroplethMap', () => {
     await waitFor(() => {
       expect(mockAddGeoJson).toHaveBeenCalledTimes(mockRegionData.length);
     });
+  });
+
+  it('does not redraw the map when legendLabels is a new object with the same content', async () => {
+    // The labels reach `colorClasses`, which drives the effect that re-adds
+    // every polygon and replays the fade-in. Consumers pass object literals, so
+    // matching by reference would redraw the whole map on every parent render.
+    const { rerender } = render(
+      <ChoroplethMap
+        data={mockRegionData}
+        apiKey={mockApiKey}
+        legendLabels={{ none: 'Ninguém realizou (0%)' }}
+        breakdownLabels={{ withAccess: 'realizaram' }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockAddGeoJson).toHaveBeenCalledTimes(mockRegionData.length);
+    });
+
+    rerender(
+      <ChoroplethMap
+        data={mockRegionData}
+        apiKey={mockApiKey}
+        legendLabels={{ none: 'Ninguém realizou (0%)' }}
+        breakdownLabels={{ withAccess: 'realizaram' }}
+      />
+    );
+
+    expect(mockAddGeoJson).toHaveBeenCalledTimes(mockRegionData.length);
   });
 
   it('sets up mouse event listeners', async () => {
@@ -997,6 +1062,67 @@ describe('ChoroplethMap animations', () => {
     ).toBeInTheDocument();
     // Falls back away from the single-count label
     expect(screen.queryByText(/Acessos: 200/)).not.toBeInTheDocument();
+  });
+
+  it('shows custom breakdown wording when breakdownLabels is provided', async () => {
+    await renderAndHoverRegion({
+      activeProfile: 'teachers',
+      breakdownLabels: {
+        withAccess: 'realizaram',
+        withoutAccess: 'não realizaram',
+      },
+      data: [
+        {
+          id: 'r1',
+          name: 'NRE Test',
+          value: 0.5,
+          accessCount: 200,
+          accessBreakdown: {
+            students: { withAccess: 300, withoutAccess: 1000 },
+            teachers: { withAccess: 40, withoutAccess: 5 },
+            managers: { withAccess: 2, withoutAccess: 8 },
+          },
+          geoJson: {
+            type: 'Feature',
+            properties: {},
+            geometry: { type: 'Polygon', coordinates: [[]] },
+          },
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(/Professores\(as\): 40 realizaram, 5 não realizaram/)
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the default breakdown wording when only one side is overridden', async () => {
+    await renderAndHoverRegion({
+      activeProfile: 'teachers',
+      breakdownLabels: { withAccess: 'acessaram' },
+      data: [
+        {
+          id: 'r1',
+          name: 'NRE Test',
+          value: 0.5,
+          accessCount: 200,
+          accessBreakdown: {
+            students: { withAccess: 300, withoutAccess: 1000 },
+            teachers: { withAccess: 40, withoutAccess: 5 },
+            managers: { withAccess: 2, withoutAccess: 8 },
+          },
+          geoJson: {
+            type: 'Feature',
+            properties: {},
+            geometry: { type: 'Polygon', coordinates: [[]] },
+          },
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(/Professores\(as\): 40 acessaram, 5 sem acessos/)
+    ).toBeInTheDocument();
   });
 
   it('shows only the selected profile line when activeProfile is set', async () => {

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -352,23 +352,49 @@ const ChoroplethMap = ({
   // Label overrides are matched by content, not by reference: `colorClasses`
   // feeds the effect that re-adds the GeoJSON and replays the fade-in, so an
   // inline object literal from the consumer would redraw the whole map on every
-  // render. Same trick as `dataSignature` above.
-  const legendSignature = useMemo(
-    () => JSON.stringify(legendLabels ?? {}),
-    [legendLabels]
-  );
+  // render.
+  //
+  // The dependencies are the individual captions rather than a serialization of
+  // the object: `JSON.stringify` preserves insertion order, so `{none, highlight}`
+  // and `{highlight, none}` would hash differently and redraw the map for a
+  // change that never happened.
+  const {
+    highlight: legendHighlight = DEFAULT_LEGEND_LABELS.highlight,
+    aboveAverage: legendAboveAverage = DEFAULT_LEGEND_LABELS.aboveAverage,
+    belowAverage: legendBelowAverage = DEFAULT_LEGEND_LABELS.belowAverage,
+    attention: legendAttention = DEFAULT_LEGEND_LABELS.attention,
+    none: legendNone = DEFAULT_LEGEND_LABELS.none,
+  } = legendLabels ?? {};
+
   const mergedLegendLabels = useMemo(
-    () => ({ ...DEFAULT_LEGEND_LABELS, ...legendLabels }),
-    [legendSignature]
+    () => ({
+      highlight: legendHighlight,
+      aboveAverage: legendAboveAverage,
+      belowAverage: legendBelowAverage,
+      attention: legendAttention,
+      none: legendNone,
+    }),
+    [
+      legendHighlight,
+      legendAboveAverage,
+      legendBelowAverage,
+      legendAttention,
+      legendNone,
+    ]
   );
 
-  const breakdownSignature = useMemo(
-    () => JSON.stringify(breakdownLabels ?? {}),
-    [breakdownLabels]
-  );
+  const {
+    withAccess: breakdownWithAccess = DEFAULT_BREAKDOWN_LABELS.withAccess,
+    withoutAccess:
+      breakdownWithoutAccess = DEFAULT_BREAKDOWN_LABELS.withoutAccess,
+  } = breakdownLabels ?? {};
+
   const mergedBreakdownLabels = useMemo(
-    () => ({ ...DEFAULT_BREAKDOWN_LABELS, ...breakdownLabels }),
-    [breakdownSignature]
+    () => ({
+      withAccess: breakdownWithAccess,
+      withoutAccess: breakdownWithoutAccess,
+    }),
+    [breakdownWithAccess, breakdownWithoutAccess]
   );
 
   const colorClasses = useMemo(

--- a/src/components/ChoroplethMap/ChoroplethMap.tsx
+++ b/src/components/ChoroplethMap/ChoroplethMap.tsx
@@ -9,6 +9,8 @@ import Text from '../Text/Text';
 import Alert from '../Alert/Alert';
 import type {
   AccessBreakdown,
+  ChoroplethBreakdownLabels,
+  ChoroplethLegendLabels,
   ChoroplethMapProps,
   ColorClass,
   RegionData,
@@ -61,44 +63,70 @@ const getCssVar = (name: string, fallback = ''): string => {
 };
 
 /**
+ * Legend wording of the access map, kept as the default so every consumer that
+ * predates the `legendLabels` prop renders exactly as before.
+ */
+const DEFAULT_LEGEND_LABELS: ChoroplethLegendLabels = {
+  highlight: 'Destaque (75% com acesso)',
+  aboveAverage: 'Acima da média (50 até 74% com acesso)',
+  belowAverage: 'Abaixo da média (25 até 49% com acesso)',
+  attention: 'Ponto de atenção (Abaixo de 25% com acesso)',
+  none: 'Sem acesso (0%)',
+};
+
+/**
+ * Tooltip wording of the access map — the default, for the same reason.
+ */
+const DEFAULT_BREAKDOWN_LABELS: ChoroplethBreakdownLabels = {
+  withAccess: 'com acesso',
+  withoutAccess: 'sem acessos',
+};
+
+/**
  * Build color classes from CSS variables
+ *
+ * The thresholds are fixed — only the captions vary by surface. Consumers
+ * mirror these same cuts elsewhere (spreadsheet exports, status badges), so
+ * moving a boundary here would silently fork them.
+ *
+ * @param labels - Caption of each band
  * @returns Color class array for the choropleth map
  */
-const getColorClasses = (): ColorClass[] => [
+const getColorClasses = (labels: ChoroplethLegendLabels): ColorClass[] => [
   {
     min: 0.75,
     max: 1.01,
     fillColor: getCssVar('--color-map-highlight', '#66b584'),
     strokeColor: getCssVar('--color-map-highlight', '#66b584'),
-    label: 'Destaque (75% com acesso)',
+    label: labels.highlight,
   },
   {
     min: 0.5,
     max: 0.75,
     fillColor: getCssVar('--color-map-above-avg', '#f8cc2e'),
     strokeColor: getCssVar('--color-map-above-avg', '#f8cc2e'),
-    label: 'Acima da média (50 até 74% com acesso)',
+    label: labels.aboveAverage,
   },
   {
     min: 0.25,
     max: 0.5,
     fillColor: getCssVar('--color-map-below-avg', '#fb954b'),
     strokeColor: getCssVar('--color-map-below-avg', '#fb954b'),
-    label: 'Abaixo da média (25 até 49% com acesso)',
+    label: labels.belowAverage,
   },
   {
     min: 0.01,
     max: 0.25,
     fillColor: getCssVar('--color-map-attention', '#b91c1c'),
     strokeColor: getCssVar('--color-map-attention', '#b91c1c'),
-    label: 'Ponto de atenção (Abaixo de 25% com acesso)',
+    label: labels.attention,
   },
   {
     min: -0.01,
     max: 0.01,
     fillColor: getCssVar('--color-map-no-access', '#2f2f2f'),
     strokeColor: getCssVar('--color-map-no-access', '#2f2f2f'),
-    label: 'Sem acesso (0%)',
+    label: labels.none,
   },
 ];
 
@@ -270,6 +298,8 @@ const ChoroplethMap = ({
   headerAction,
   infoText,
   activeProfile,
+  legendLabels,
+  breakdownLabels,
   className,
 }: ChoroplethMapProps) => {
   const mapId = GOOGLE_MAPS_LOADER_ID;
@@ -319,7 +349,32 @@ const ChoroplethMap = ({
   );
   const stableGeometryData = useMemo(() => data, [geometrySignature]);
 
-  const colorClasses = useMemo(() => getColorClasses(), [isDark]);
+  // Label overrides are matched by content, not by reference: `colorClasses`
+  // feeds the effect that re-adds the GeoJSON and replays the fade-in, so an
+  // inline object literal from the consumer would redraw the whole map on every
+  // render. Same trick as `dataSignature` above.
+  const legendSignature = useMemo(
+    () => JSON.stringify(legendLabels ?? {}),
+    [legendLabels]
+  );
+  const mergedLegendLabels = useMemo(
+    () => ({ ...DEFAULT_LEGEND_LABELS, ...legendLabels }),
+    [legendSignature]
+  );
+
+  const breakdownSignature = useMemo(
+    () => JSON.stringify(breakdownLabels ?? {}),
+    [breakdownLabels]
+  );
+  const mergedBreakdownLabels = useMemo(
+    () => ({ ...DEFAULT_BREAKDOWN_LABELS, ...breakdownLabels }),
+    [breakdownSignature]
+  );
+
+  const colorClasses = useMemo(
+    () => getColorClasses(mergedLegendLabels),
+    [isDark, mergedLegendLabels]
+  );
 
   const mapOptions: google.maps.MapOptions = useMemo(() => {
     const bgColor = getCssVar('--color-background-50', '#F6F6F6');
@@ -883,9 +938,10 @@ const ChoroplethMap = ({
                       return (
                         <Text key={line.key} size="md" color="text-text-50">
                           {line.label}:{' '}
-                          {entry.withAccess.toLocaleString('pt-BR')} com acesso,{' '}
-                          {entry.withoutAccess.toLocaleString('pt-BR')} sem
-                          acessos
+                          {entry.withAccess.toLocaleString('pt-BR')}{' '}
+                          {mergedBreakdownLabels.withAccess},{' '}
+                          {entry.withoutAccess.toLocaleString('pt-BR')}{' '}
+                          {mergedBreakdownLabels.withoutAccess}
                         </Text>
                       );
                     })}

--- a/src/components/ChoroplethMap/ChoroplethMap.types.ts
+++ b/src/components/ChoroplethMap/ChoroplethMap.types.ts
@@ -60,6 +60,44 @@ export interface RegionData {
 }
 
 /**
+ * Colour bands of the choropleth legend, best to worst.
+ */
+export const CHOROPLETH_TIER = {
+  HIGHLIGHT: 'highlight',
+  ABOVE_AVERAGE: 'aboveAverage',
+  BELOW_AVERAGE: 'belowAverage',
+  ATTENTION: 'attention',
+  NONE: 'none',
+} as const;
+
+export type ChoroplethTier =
+  (typeof CHOROPLETH_TIER)[keyof typeof CHOROPLETH_TIER];
+
+/**
+ * Legend caption of each colour band.
+ *
+ * The map is reused across surfaces that measure different things — people with
+ * access, people who completed an activity, answer accuracy — so the wording of
+ * the bands belongs to the caller. The thresholds never move: only the sentence
+ * describing them does.
+ */
+export type ChoroplethLegendLabels = Record<ChoroplethTier, string>;
+
+/**
+ * Wording of the two sides of the tooltip breakdown.
+ *
+ * Rendered as `<profile>: <n> <withAccess>, <m> <withoutAccess>` — for the
+ * access map "com acesso" / "sem acessos", for the activities map "realizaram"
+ * / "não realizaram".
+ */
+export interface ChoroplethBreakdownLabels {
+  /** Phrase for the people who performed the action */
+  withAccess: string;
+  /** Phrase for the people who did not */
+  withoutAccess: string;
+}
+
+/**
  * Legend item interface for choropleth map
  */
 export interface LegendItem {
@@ -115,6 +153,17 @@ export interface ChoroplethMapProps {
    * schools map, which aggregates all three profile groups).
    */
   activeProfile?: keyof AccessBreakdown;
+  /**
+   * Wording of the legend bands. Partial: whatever is omitted keeps the default
+   * access phrasing. Pass a stable reference (a module constant or a memo) —
+   * a fresh object literal on every render redraws the whole map.
+   */
+  legendLabels?: Partial<ChoroplethLegendLabels>;
+  /**
+   * Wording of the tooltip breakdown. Partial, same stability caveat as
+   * `legendLabels`.
+   */
+  breakdownLabels?: Partial<ChoroplethBreakdownLabels>;
   /** Optional additional CSS classes */
   className?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,11 @@ export type {
   ColorClass,
   AccessBreakdown,
   AccessBreakdownEntry,
+  ChoroplethTier,
+  ChoroplethLegendLabels,
+  ChoroplethBreakdownLabels,
 } from './components/ChoroplethMap/ChoroplethMap.types';
+export { CHOROPLETH_TIER } from './components/ChoroplethMap/ChoroplethMap.types';
 
 // Map Data Hook
 export { createUseMapData } from './hooks/useMapData';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable labels for choropleth map legend bands.
  - Added customizable “with access” and “without access” wording in map tooltips.
  - Partial customizations are supported while unspecified labels retain their defaults.

- **Bug Fixes**
  - Prevented unnecessary map redraws when label settings remain unchanged.

- **Tests**
  - Added coverage for custom, partial, and default label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->