### PR TITLE
Ae 2963 front web tela inicial de atividades

### DIFF
--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -3922,6 +3922,53 @@ describe('CardReadingFluency', () => {
     });
   });
 
+  describe('caption (activityTitle) vs native title attribute', () => {
+    it('renders the "activityTitle" as the caption below the card', () => {
+      render(
+        <CardReadingFluency
+          activityTitle="A Ilha Misteriosa"
+          data-testid="card-papole"
+        />
+      );
+      expect(screen.getByText('A Ilha Misteriosa')).toBeInTheDocument();
+      // A legenda é renderizada como irmã do card no container externo.
+      const card = screen.getByTestId('card-papole');
+      expect(card.parentElement?.children).toHaveLength(2);
+    });
+
+    it('omits the caption when "activityTitle" is not provided', () => {
+      render(<CardReadingFluency data-testid="card-papole" />);
+      const card = screen.getByTestId('card-papole');
+      // Sem legenda: o container externo tem apenas o card.
+      expect(card.parentElement?.children).toHaveLength(1);
+    });
+
+    it('forwards the native "title" attribute (tooltip) to the root and does not render it as a caption', () => {
+      render(
+        <CardReadingFluency title="Dica nativa" data-testid="card-papole" />
+      );
+      const card = screen.getByTestId('card-papole');
+      expect(card).toHaveAttribute('title', 'Dica nativa');
+      // O title nativo não vira texto visível (legenda).
+      expect(screen.queryByText('Dica nativa')).not.toBeInTheDocument();
+      expect(card.parentElement?.children).toHaveLength(1);
+    });
+
+    it('keeps the caption (activityTitle) and the native title (tooltip) independent', () => {
+      render(
+        <CardReadingFluency
+          activityTitle="Legenda"
+          title="Dica nativa"
+          data-testid="card-papole"
+        />
+      );
+      const card = screen.getByTestId('card-papole');
+      expect(card).toHaveAttribute('title', 'Dica nativa');
+      expect(screen.getByText('Legenda')).toBeInTheDocument();
+      expect(screen.queryByText('Dica nativa')).not.toBeInTheDocument();
+    });
+  });
+
   describe('interactivity (new state)', () => {
     it('becomes a button and activates onClick on click', () => {
       const handleClick = jest.fn();

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1894,6 +1894,8 @@ interface CardReadingFluencyProps extends HTMLAttributes<HTMLDivElement> {
   image?: string;
   /** Texto alternativo/aria da imagem. */
   label?: string;
+  /** Título exibido abaixo do card (bold, xs, text-100). Omitido quando vazio. */
+  title?: string;
 }
 
 /**
@@ -1912,6 +1914,7 @@ const CardReadingFluency = forwardRef<HTMLDivElement, CardReadingFluencyProps>(
       color = '#a3d9b1',
       image,
       label = 'Reading Fluency',
+      title,
       className,
       onClick,
       onKeyDown,
@@ -1933,62 +1936,75 @@ const CardReadingFluency = forwardRef<HTMLDivElement, CardReadingFluencyProps>(
     };
 
     return (
-      <div
-        ref={ref}
-        className={cn(
-          'relative flex items-center justify-center w-[240px] h-[182px] rounded-2xl px-[82px] py-[28px] font-quicksand',
-          isClickable && 'cursor-pointer',
-          isComingSoon &&
-            'pointer-events-none border-2 border-dashed border-border-300',
-          className
-        )}
-        style={{ backgroundColor: color }}
-        onClick={isInteractive ? onClick : undefined}
-        onKeyDown={handleKeyDown}
-        tabIndex={isClickable ? 0 : undefined}
-        role={isClickable ? 'button' : undefined}
-        aria-disabled={isComingSoon ? true : undefined}
-        {...props}
-      >
-        <img
-          src={image ?? readingFluencyBird}
-          alt={label}
-          draggable={false}
+      <div className="flex flex-col items-center gap-3">
+        <div
+          ref={ref}
           className={cn(
-            'w-full h-auto select-none',
-            isComingSoon && 'opacity-40'
+            'relative flex items-center justify-center w-[240px] h-[182px] rounded-2xl px-[82px] py-[28px] font-quicksand',
+            isClickable && 'cursor-pointer',
+            isComingSoon &&
+              'pointer-events-none border-2 border-dashed border-border-300',
+            className
           )}
-        />
-
-        {isDone && (
-          <CheckCircleIcon
-            weight="fill"
-            size={28}
-            className="absolute top-3 right-3 text-background drop-shadow-sm"
-            data-testid="reading-fluency-check"
+          style={{ backgroundColor: color }}
+          onClick={isInteractive ? onClick : undefined}
+          onKeyDown={handleKeyDown}
+          tabIndex={isClickable ? 0 : undefined}
+          role={isClickable ? 'button' : undefined}
+          aria-disabled={isComingSoon ? true : undefined}
+          {...props}
+        >
+          <img
+            src={image ?? readingFluencyBird}
+            alt={label}
+            draggable={false}
+            className={cn(
+              'w-full h-auto select-none',
+              isComingSoon && 'opacity-40'
+            )}
           />
-        )}
 
-        {state === 'new' && (
-          <span
-            className={cn(
-              'absolute bottom-3 left-1/2 -translate-x-1/2 bg-black/70',
-              PAPOLE_BADGE_CLASSES
-            )}
-          >
-            NOVA ATIVIDADE!
-          </span>
-        )}
+          {isDone && (
+            <CheckCircleIcon
+              weight="fill"
+              size={28}
+              className="absolute top-3 right-3 text-background drop-shadow-sm"
+              data-testid="reading-fluency-check"
+            />
+          )}
 
-        {isComingSoon && (
-          <span
-            className={cn(
-              'absolute bottom-3 left-1/2 -translate-x-1/2 bg-black/30',
-              PAPOLE_BADGE_CLASSES
-            )}
+          {state === 'new' && (
+            <span
+              className={cn(
+                'absolute bottom-3 left-1/2 -translate-x-1/2 bg-black/70',
+                PAPOLE_BADGE_CLASSES
+              )}
+            >
+              NOVA ATIVIDADE!
+            </span>
+          )}
+
+          {isComingSoon && (
+            <span
+              className={cn(
+                'absolute bottom-3 left-1/2 -translate-x-1/2 bg-black/30',
+                PAPOLE_BADGE_CLASSES
+              )}
+            >
+              EM BREVE
+            </span>
+          )}
+        </div>
+
+        {title && (
+          <Text
+            size="xs"
+            weight="bold"
+            color="text-text-100"
+            className="w-60 text-center font-quicksand uppercase"
           >
-            EM BREVE
-          </span>
+            {title}
+          </Text>
         )}
       </div>
     );

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1894,8 +1894,12 @@ interface CardReadingFluencyProps extends HTMLAttributes<HTMLDivElement> {
   image?: string;
   /** Texto alternativo/aria da imagem. */
   label?: string;
-  /** Título exibido abaixo do card (bold, xs, text-100). Omitido quando vazio. */
-  title?: string;
+  /**
+   * Legenda exibida abaixo do card (bold, xs, text-100). Omitida quando vazia.
+   * Nome distinto de `title` para não colidir com o atributo HTML nativo
+   * `title` (tooltip), que segue repassável via `...props`.
+   */
+  activityTitle?: string;
 }
 
 /**
@@ -1914,7 +1918,7 @@ const CardReadingFluency = forwardRef<HTMLDivElement, CardReadingFluencyProps>(
       color = '#a3d9b1',
       image,
       label = 'Reading Fluency',
-      title,
+      activityTitle,
       className,
       onClick,
       onKeyDown,
@@ -1996,14 +2000,14 @@ const CardReadingFluency = forwardRef<HTMLDivElement, CardReadingFluencyProps>(
           )}
         </div>
 
-        {title && (
+        {activityTitle && (
           <Text
             size="xs"
             weight="bold"
             color="text-text-100"
             className="w-60 text-center font-quicksand uppercase"
           >
-            {title}
+            {activityTitle}
           </Text>
         )}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reading fluency cards to use a clearer activity title field, avoiding conflicts with the browser’s native title behavior.
  * Activity titles now appear below the card image only when provided.
  * Preserved tooltip support for additional card properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->