### PR TITLE
AE-2945: fix latex

### DIFF
--- a/src/components/HtmlMathRenderer/HtmlMathRenderer.test.tsx
+++ b/src/components/HtmlMathRenderer/HtmlMathRenderer.test.tsx
@@ -488,6 +488,90 @@ describe('utils', () => {
       });
     });
 
+    describe('processHtmlWithMath — spans do editor (data-type="math-inline")', () => {
+      // Este é o formato que o RichEditor grava. Sem um branch para ele, o span
+      // sobrevivia à sanitização, todas as partes voltavam como `text` e a
+      // fórmula era injetada como elemento vazio — sumia para o aluno.
+      it('renderiza o span math-inline como matemática inline', () => {
+        const parts = processHtmlWithMath(
+          '<p>Para cada número real <span data-type="math-inline" data-latex="x \\neq 0"></span>, definimos</p>'
+        );
+        const mathParts = parts.filter((p) => p.type === 'math');
+        expect(mathParts).toHaveLength(1);
+        expect(mathParts[0].latex).toBe('x \\neq 0');
+      });
+
+      it('respeita data-display-mode como matemática em bloco', () => {
+        const parts = processHtmlWithMath(
+          '<span data-type="math-inline" data-display-mode="true" data-latex="\\frac{a}{b}"></span>'
+        );
+        expect(parts.filter((p) => p.type === 'block-math')).toHaveLength(1);
+      });
+
+      it('não depende da ordem dos atributos emitida pelo TipTap', () => {
+        const parts = processHtmlWithMath(
+          '<span class="inline-math" data-latex="x^2" data-type="math-inline"></span>'
+        );
+        expect(parts.filter((p) => p.type === 'math')[0].latex).toBe('x^2');
+      });
+
+      it('descarta o span quando o latex está vazio', () => {
+        const parts = processHtmlWithMath(
+          'antes <span data-type="math-inline" data-latex=""></span> depois'
+        );
+        expect(parts.every((p) => p.type === 'text')).toBe(true);
+        expect(parts.map((p) => p.content).join('')).toBe('antes  depois');
+      });
+
+      it('decodifica o & de alinhamento vindo do atributo escapado', () => {
+        const parts = processHtmlWithMath(
+          '<span data-type="math-inline" data-latex="\\begin{pmatrix} a &amp; b \\end{pmatrix}"></span>'
+        );
+        expect(parts[0].latex).toContain('a & b');
+      });
+
+      it('containsMath reconhece o span do editor', () => {
+        expect(
+          containsMath('<span data-type="math-inline" data-latex="x^2"></span>')
+        ).toBe(true);
+      });
+
+      it('stripHtml remove o span do editor', () => {
+        expect(
+          stripHtml(
+            'texto <span data-type="math-inline" data-latex="x^2"></span> fim'
+          )
+        ).toBe('texto  fim');
+      });
+    });
+
+    describe('processHtmlWithMath — $$ e valores monetários', () => {
+      it('trata $$...$$ como bloco sem quebrar o par interno', () => {
+        const parts = processHtmlWithMath('resultado $$x^2$$ fim');
+        const blockParts = parts.filter((p) => p.type === 'block-math');
+        expect(blockParts).toHaveLength(1);
+        expect(blockParts[0].latex).toBe('x^2');
+        // O par interno `$x^2$` não pode ser reivindicado como inline.
+        expect(parts.filter((p) => p.type === 'math')).toHaveLength(0);
+      });
+
+      it('NÃO transforma R$1,00 e de R$0,50 em fórmula', () => {
+        // Problema relatado: renderizava `R 1,00edeR 0,50`.
+        const input =
+          'Guardava moedas de R$1,00 e de R$0,50. Total de R$370,00.';
+        const parts = processHtmlWithMath(input);
+        expect(parts.every((p) => p.type === 'text')).toBe(true);
+        expect(parts.map((p) => p.content).join('')).toBe(input);
+      });
+
+      it('ainda encontra a fórmula que vem depois de um preço', () => {
+        const parts = processHtmlWithMath('custou R$50,00 e vale $x^2$ pontos');
+        const mathParts = parts.filter((p) => p.type === 'math');
+        expect(mathParts).toHaveLength(1);
+        expect(mathParts[0].latex).toBe('x^2');
+      });
+    });
+
     describe('processHtmlWithMath — katex-error recovery', () => {
       it('should recover LaTeX from a katex-error wrapper title', () => {
         const persisted =

--- a/src/components/HtmlMathRenderer/utils.ts
+++ b/src/components/HtmlMathRenderer/utils.ts
@@ -528,7 +528,7 @@ export const containsMath = (content: string): boolean => {
   const patterns = [
     /\$\$[\s\S]+?\$\$/, // Display mode $$...$$
     /(?<!\\)\$[\s\S]+?\$/, // Inline mode $...$
-    new RegExp(String.raw`<span[^>]*data-type="${MATH_SPAN_TYPE}"`), // Editor spans (current format)
+    new RegExp(`<span[^>]*data-type="${MATH_SPAN_TYPE}"`), // Editor spans (current format)
     /<span[^>]*class="math-formula"/, // Editor spans
     /<span[^>]*class="math-expression"/, // Legacy spans
     /<latex>|&lt;latex&gt;/, // LaTeX tags

--- a/src/components/HtmlMathRenderer/utils.ts
+++ b/src/components/HtmlMathRenderer/utils.ts
@@ -2,6 +2,21 @@
  * Utilities for processing HTML content with LaTeX math expressions
  */
 
+import {
+  createLatexEnvPattern,
+  createMathSpanPattern,
+  readMathSpanAttributes,
+  replaceDollarMath,
+} from '../../utils/latexMath';
+
+/**
+ * Re-exported under its historical name: this is a public entry point of the
+ * package and several consumers/tests import `looksLikeLatex` directly. The
+ * implementation now lives in `utils/latexMath` so the RichEditor applies the
+ * exact same heuristic when deciding what to turn into a math node.
+ */
+export { looksLikeMath as looksLikeLatex } from '../../utils/latexMath';
+
 export interface MathPart {
   type: 'text' | 'math' | 'block-math';
   content: string;
@@ -35,28 +50,6 @@ export const cleanLatex = (str: string): string => {
     .replaceAll(/&amp;gt;|&gt;/gi, String.raw`\gt `)
     .replaceAll(/&amp;amp;|&amp;/gi, '&')
     .trim();
-};
-
-/**
- * Heuristic that flags a string as "likely real LaTeX math" vs prose.
- * Used to reject `$...$` blocks that wrap regular text \u2014 typically
- * happens when authors type `$` as a currency symbol and the renderer
- * pairs unrelated occurrences as math delimiters, sending Portuguese
- * prose to KaTeX (which then renders each letter as a math variable).
- *
- * Approach:
- * - Backslash commands / sub-super / grouping braces \u2192 definitely math.
- * - Otherwise, treat it as PROSE only when it contains 2+ real words
- *   (runs of 3+ letters). A sentence like "15,00 pelo custo fixo" has
- *   many such words; genuine math \u2014 `x = 1`, `a + b`, `1 < 2`, `f0`,
- *   even a lone `abc` \u2014 does not. This keeps normal spaced equations
- *   rendering while still rejecting currency-`$` prose.
- */
-export const looksLikeLatex = (str: string): boolean => {
-  if (/[\\^_{}]/.test(str)) return true;
-  const words = str.match(/[a-zA-Z]{3,}/g);
-  if (words && words.length >= 2) return false;
-  return true;
 };
 
 /**
@@ -382,6 +375,23 @@ export const processHtmlWithMath = (htmlContent: string): MathPart[] => {
   // Generate unique sentinel per call to avoid collision with content
   const sentinel = `__MATH_${generateSecureRandomId()}_`;
 
+  // Step 0: Handle the canonical span the RichEditor persists today.
+  // It carries no text content and no class, so without this branch the span
+  // survives sanitization, every part comes back as `text`, and the formula is
+  // injected as an empty element — i.e. it silently disappears for the student.
+  const mathSpanPattern = createMathSpanPattern();
+  processedContent = processedContent.replaceAll(mathSpanPattern, (match) => {
+    const { latex, display } = readMathSpanAttributes(match);
+    if (!latex.trim()) return '';
+    const placeholder = `${sentinel}${parts.length}__`;
+    parts.push({
+      type: display ? 'block-math' : 'math',
+      content: match,
+      latex: cleanLatex(latex),
+    });
+    return placeholder;
+  });
+
   // Step 1: Handle math-formula spans (from the editor)
   const mathFormulaPattern =
     /<span[^>]*class="math-formula"[^>]*data-latex="([^"]*)"[^>]*>[\s\S]*?<\/span>/g;
@@ -415,34 +425,19 @@ export const processHtmlWithMath = (htmlContent: string): MathPart[] => {
     }
   );
 
-  // Step 3: Handle raw $$...$$ expressions (display mode) - BEFORE single $
-  const doubleDollarPattern = /(?<!\\)\$\$([\s\S]+?)\$\$/g;
-  processedContent = processedContent.replaceAll(
-    doubleDollarPattern,
-    (match, latex) => {
+  // Step 3: Handle raw `$$...$$` (display) and `$...$` (inline) in a single
+  // left-to-right scan. Splitting them across two regex passes used to break
+  // `$$x$$`, whose inner `$x$` was claimed by the single-dollar pass first.
+  // The scanner also drops currency pairings (`R$1,00 ... R$0,50`) without
+  // consuming the rest of the sentence, so a real formula that follows a price
+  // is still found.
+  processedContent = replaceDollarMath(
+    processedContent,
+    ({ latex, display }) => {
       const placeholder = `${sentinel}${parts.length}__`;
       parts.push({
-        type: 'block-math',
-        content: match,
-        latex: cleanLatex(latex),
-      });
-      return placeholder;
-    }
-  );
-
-  // Step 4: Handle single $...$ expressions for inline math.
-  // Skip matches whose content doesn't look like LaTeX — those are usually
-  // currency `$` symbols pairing up across prose (e.g. `R$ 15,00 ... R$ 42,00`)
-  // and sending Portuguese text to KaTeX produces gibberish output.
-  const singleDollarPattern = /(?<!\\)\$([\s\S]+?)\$/g;
-  processedContent = processedContent.replaceAll(
-    singleDollarPattern,
-    (match, latex) => {
-      if (!looksLikeLatex(latex)) return match;
-      const placeholder = `${sentinel}${parts.length}__`;
-      parts.push({
-        type: 'math',
-        content: match,
+        type: display ? 'block-math' : 'math',
+        content: display ? `$$${latex}$$` : `$${latex}$`,
         latex: cleanLatex(latex),
       });
       return placeholder;
@@ -466,7 +461,7 @@ export const processHtmlWithMath = (htmlContent: string): MathPart[] => {
   );
 
   // Step 6: Handle standalone LaTeX environments (align, equation, pmatrix, etc.)
-  const latexEnvPattern = /\\begin\{([^}]+)\}([\s\S]*?)\\end\{\1\}/g;
+  const latexEnvPattern = createLatexEnvPattern();
   processedContent = processedContent.replaceAll(latexEnvPattern, (match) => {
     const placeholder = `${sentinel}${parts.length}__`;
     parts.push({
@@ -532,6 +527,7 @@ export const containsMath = (content: string): boolean => {
   const patterns = [
     /\$\$[\s\S]+?\$\$/, // Display mode $$...$$
     /(?<!\\)\$[\s\S]+?\$/, // Inline mode $...$
+    /<span[^>]*data-type="math-inline"/, // Editor spans (current format)
     /<span[^>]*class="math-formula"/, // Editor spans
     /<span[^>]*class="math-expression"/, // Legacy spans
     /<latex>|&lt;latex&gt;/, // LaTeX tags
@@ -548,6 +544,9 @@ export const stripHtml = (htmlContent: string): string => {
   if (!htmlContent) return '';
 
   let content = htmlContent;
+
+  // Remove the editor's math spans (the LaTeX lives in the data attribute)
+  content = content.replaceAll(createMathSpanPattern(), '');
 
   // Remove math-formula spans (keep nothing as the LaTeX is in data attribute)
   content = content.replaceAll(

--- a/src/components/HtmlMathRenderer/utils.ts
+++ b/src/components/HtmlMathRenderer/utils.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  MATH_SPAN_TYPE,
   createLatexEnvPattern,
   createMathSpanPattern,
   readMathSpanAttributes,
@@ -527,7 +528,7 @@ export const containsMath = (content: string): boolean => {
   const patterns = [
     /\$\$[\s\S]+?\$\$/, // Display mode $$...$$
     /(?<!\\)\$[\s\S]+?\$/, // Inline mode $...$
-    /<span[^>]*data-type="math-inline"/, // Editor spans (current format)
+    new RegExp(String.raw`<span[^>]*data-type="${MATH_SPAN_TYPE}"`), // Editor spans (current format)
     /<span[^>]*class="math-formula"/, // Editor spans
     /<span[^>]*class="math-expression"/, // Legacy spans
     /<latex>|&lt;latex&gt;/, // LaTeX tags

--- a/src/components/RichEditor/RichEditorCore.tsx
+++ b/src/components/RichEditor/RichEditorCore.tsx
@@ -123,14 +123,14 @@ export function RichEditor({
     }
   }, [content, editor]);
 
-  const insertFormula = (latex: string) => {
+  const insertFormula = (latex: string, display: boolean) => {
     if (!latex || !editor) return;
     editor
       .chain()
       .focus()
       .insertContent({
         type: 'mathInline',
-        attrs: { latex },
+        attrs: { latex, display },
       })
       .run();
     setFormulaOpen(false);
@@ -349,7 +349,10 @@ export function RichEditor({
         <Text size="xs" color="text-text-400">
           Dica: use{' '}
           <code className="bg-background-200 px-1 rounded">$fórmula$</code> para
-          inserir LaTeX inline diretamente.
+          LaTeX inline e{' '}
+          <code className="bg-background-200 px-1 rounded">$$fórmula$$</code>{' '}
+          para fórmula em bloco. A conversão acontece assim que você fecha os
+          cifrões.
         </Text>
       </div>
 

--- a/src/components/RichEditor/components/FormulaDialog.test.tsx
+++ b/src/components/RichEditor/components/FormulaDialog.test.tsx
@@ -223,7 +223,26 @@ describe('FormulaDialog', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Inserir fórmula' }));
 
-      expect(onInsert).toHaveBeenCalledWith('x^2');
+      expect(onInsert).toHaveBeenCalledWith('x^2', false);
+    });
+
+    it('deve chamar onInsert com display=true quando "Fórmula em bloco" está ligado', async () => {
+      const onInsert = jest.fn();
+      render(<FormulaDialog {...defaultProps} onInsert={onInsert} />);
+
+      const input = screen.getByPlaceholderText(/Ex: \\sqrt\{x\^2 \+ y\^2\}/);
+      fireEvent.change(input, { target: { value: '\\frac{a}{b}' } });
+      fireEvent.click(screen.getByLabelText('Fórmula em bloco'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Inserir fórmula' })
+        ).toBeEnabled();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir fórmula' }));
+
+      expect(onInsert).toHaveBeenCalledWith('\\frac{a}{b}', true);
     });
 
     it('deve desabilitar botão Inserir quando input está vazio', () => {
@@ -587,7 +606,7 @@ describe('FormulaDialog', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Inserir fórmula' }));
 
-      expect(onInsert).toHaveBeenCalledWith(String.raw`E = mc^2`);
+      expect(onInsert).toHaveBeenCalledWith(String.raw`E = mc^2`, false);
     });
 
     it('should trim description before calling onGenerateWithAI', async () => {

--- a/src/components/RichEditor/components/FormulaDialog.tsx
+++ b/src/components/RichEditor/components/FormulaDialog.tsx
@@ -380,11 +380,10 @@ export function FormulaDialog({
                 Fórmula em bloco
               </Text>
               <Text size="xs" className="text-text-400">
-                Ocupa uma linha própria e fica centralizada, equivalente a{' '}
+                Ocupa uma linha própria e fica centralizada — o mesmo que{' '}
                 <code className="bg-background-200 px-1 rounded">
                   $$fórmula$$
                 </code>
-                .
               </Text>
             </div>
           </div>

--- a/src/components/RichEditor/components/FormulaDialog.tsx
+++ b/src/components/RichEditor/components/FormulaDialog.tsx
@@ -5,6 +5,7 @@ import Menu, { MenuContent, MenuItem } from '../../Menu/Menu';
 import Modal from '../../Modal/Modal';
 import Text from '../../Text/Text';
 import TextArea from '../../TextArea/TextArea';
+import ToggleSwitch from '../../ToggleSwitch/ToggleSwitch';
 import { SparkleIcon } from '@phosphor-icons/react/dist/csr/Sparkle';
 import { useMobile } from '../../../hooks/useMobile';
 import katex from 'katex';
@@ -13,7 +14,11 @@ import 'katex/dist/katex.min.css';
 interface FormulaDialogProps {
   readonly open: boolean;
   readonly onClose: () => void;
-  readonly onInsert: (latex: string) => void;
+  /**
+   * @param latex - the LaTeX source to insert
+   * @param display - `true` inserts centered display math on its own line
+   */
+  readonly onInsert: (latex: string, display: boolean) => void;
   /**
    * Optional callback to generate LaTeX using AI
    * If provided, the AI generation feature will be enabled
@@ -156,6 +161,7 @@ export function FormulaDialog({
   const { isTablet } = useMobile();
   const [category, setCategory] = useState<FormulaCategory>('matematica');
   const [latex, setLatex] = useState('');
+  const [display, setDisplay] = useState(false);
   const [preview, setPreview] = useState('');
   const [error, setError] = useState('');
   const [aiDescription, setAiDescription] = useState('');
@@ -169,9 +175,11 @@ export function FormulaDialog({
       return;
     }
     try {
+      // Same displayMode the editor and the student view will use, so the
+      // preview is a faithful WYSIWYG of the inserted formula.
       const rendered = katex.renderToString(latex, {
         throwOnError: true,
-        displayMode: false,
+        displayMode: display,
       });
       setPreview(rendered);
       setError('');
@@ -179,11 +187,11 @@ export function FormulaDialog({
       setError('Fórmula inválida');
       setPreview('');
     }
-  }, [latex]);
+  }, [latex, display]);
 
   const handleInsert = () => {
     if (!latex.trim() || error) return;
-    onInsert(latex);
+    onInsert(latex, display);
     resetState();
   };
 
@@ -194,6 +202,7 @@ export function FormulaDialog({
 
   const resetState = () => {
     setLatex('');
+    setDisplay(false);
     setError('');
     setPreview('');
     setAiDescription('');
@@ -356,6 +365,28 @@ export function FormulaDialog({
               Use sintaxe LaTeX:{' '}
               {String.raw`\sqrt{}, \frac{}{}, ^{}, _{}, \pi, \alpha`}, etc.
             </Text>
+          </div>
+
+          {/* Display mode */}
+          <div className="flex items-start gap-3 mb-4">
+            <ToggleSwitch
+              checked={display}
+              onChange={() => setDisplay((current) => !current)}
+              size="small"
+              aria-label="Fórmula em bloco"
+            />
+            <div>
+              <Text weight="medium" className="text-xs text-text-600">
+                Fórmula em bloco
+              </Text>
+              <Text size="xs" className="text-text-400">
+                Ocupa uma linha própria e fica centralizada, equivalente a{' '}
+                <code className="bg-background-200 px-1 rounded">
+                  $$fórmula$$
+                </code>
+                .
+              </Text>
+            </div>
           </div>
 
           {/* Divider */}

--- a/src/components/RichEditor/components/MathNode.test.tsx
+++ b/src/components/RichEditor/components/MathNode.test.tsx
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ReactElement } from 'react';
+import type { InputRule } from '@tiptap/core';
+import type { Plugin } from '@tiptap/pm/state';
 import { MathNode } from './MathNode';
 
 // Mock katex
@@ -44,6 +46,15 @@ const getConfigMethod = <T,>(
     options: {},
     storage: {},
     parent: undefined,
+    // `addInputRules` closes over `this.type` to build the node it inserts;
+    // echoing the attrs back lets the assertions inspect what would be created.
+    type: {
+      create: (attrs: Record<string, unknown>) => ({
+        type: 'mathInline',
+        attrs,
+      }),
+    },
+    editor: { commands: { insertContent: jest.fn() } },
   });
 };
 
@@ -78,6 +89,14 @@ describe('MathNode Extension', () => {
       expect(attributes).toHaveProperty('latex');
       expect(attributes?.latex.default).toBe('');
     });
+
+    it('deve definir atributo display com valor padrão false', () => {
+      const attributes = getConfigMethod(MathNode.config.addAttributes) as
+        | { display: { default: boolean } }
+        | undefined;
+      expect(attributes).toHaveProperty('display');
+      expect(attributes?.display.default).toBe(false);
+    });
   });
 
   describe('parseHTML', () => {
@@ -96,7 +115,21 @@ describe('MathNode Extension', () => {
       } as unknown as HTMLElement;
 
       const result = getAttrs?.(mockDom);
-      expect(result).toEqual({ latex: 'x^2 + y^2' });
+      expect(result).toEqual({ latex: 'x^2 + y^2', display: false });
+    });
+
+    it('deve extrair display do atributo data-display-mode', () => {
+      const parseRules = getConfigMethod(MathNode.config.parseHTML);
+      const getAttrs = parseRules?.[0].getAttrs;
+
+      const mockDom = {
+        dataset: { latex: '\\frac{a}{b}', displayMode: 'true' },
+      } as unknown as HTMLElement;
+
+      expect(getAttrs?.(mockDom)).toEqual({
+        latex: '\\frac{a}{b}',
+        display: true,
+      });
     });
 
     it('deve usar string vazia quando data-latex está ausente', () => {
@@ -109,7 +142,7 @@ describe('MathNode Extension', () => {
       const mockDom = { dataset: {} } as unknown as HTMLElement;
 
       const result = getAttrs?.(mockDom);
-      expect(result).toEqual({ latex: '' });
+      expect(result).toEqual({ latex: '', display: false });
     });
   });
 
@@ -156,12 +189,117 @@ describe('MathNode Extension', () => {
         },
       ]);
     });
+
+    it('deve emitir data-display-mode apenas para fórmula em bloco', () => {
+      const renderHTML = MathNode.config.renderHTML;
+      const mockNode = { attrs: { latex: '\\frac{a}{b}', display: true } };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (renderHTML as any)?.call(
+        { name: 'mathInline', options: {}, storage: {} },
+        { node: mockNode, HTMLAttributes: {} }
+      );
+
+      expect(result).toEqual([
+        'span',
+        {
+          'data-type': 'math-inline',
+          'data-display-mode': 'true',
+          'data-latex': '\\frac{a}{b}',
+        },
+      ]);
+    });
   });
 
   describe('addInputRules', () => {
-    it('deve retornar array vazio (input rules desabilitadas)', () => {
-      const inputRules = getConfigMethod(MathNode.config.addInputRules);
-      expect(inputRules).toEqual([]);
+    // The old implementation returned [], leaving the Space shortcut as the
+    // only trigger — which is why authors had to type a space after the closing
+    // `$` and why `$$...$$` never converted at all.
+    const getInputRules = () =>
+      getConfigMethod(MathNode.config.addInputRules) as InputRule[];
+
+    /** Drives one input rule the way TipTap's `run()` does. */
+    const applyRule = (rule: InputRule, textBefore: string) => {
+      const match = rule.find as RegExp;
+      const found = match.exec(textBefore);
+      if (!found) return null;
+
+      const replaceRangeWith = jest.fn();
+      const state = {
+        tr: { replaceRangeWith },
+        doc: {
+          textBetween: (from: number, to: number) => textBefore.slice(from, to),
+        },
+      };
+      const range = {
+        from: textBefore.length - found[0].length,
+        to: textBefore.length,
+      };
+
+      rule.handler({ state, range, match: found } as never);
+      return replaceRangeWith;
+    };
+
+    it('deve registrar a regra de bloco antes da regra inline', () => {
+      const rules = getInputRules();
+      expect(rules).toHaveLength(2);
+      expect((rules[0].find as RegExp).source).toContain('\\$\\$');
+    });
+
+    it('não converte quando o conteúdo entre $ está vazio', () => {
+      const rules = getInputRules();
+      expect(applyRule(rules[1], 'texto $   $')).not.toHaveBeenCalled();
+    });
+
+    it('converte $x^2$ assim que o cifrão final é digitado, sem espaço', () => {
+      // Este é o Problema 2/3: antes só o atalho de Espaço convertia, então uma
+      // fórmula no fim da frase (ou colada) ficava como texto cru.
+      const rules = getInputRules();
+      const replaceRangeWith = applyRule(rules[1], 'o valor de $x^2$');
+
+      expect(replaceRangeWith).toHaveBeenCalledWith(11, 16, {
+        type: 'mathInline',
+        attrs: { latex: 'x^2', display: false },
+      });
+    });
+
+    it('converte $$...$$ em fórmula de bloco', () => {
+      const rules = getInputRules();
+      const replaceRangeWith = applyRule(
+        rules[0],
+        'resultado $$\\frac{a}{b}$$'
+      );
+
+      expect(replaceRangeWith).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.any(Number),
+        { type: 'mathInline', attrs: { latex: '\\frac{a}{b}', display: true } }
+      );
+    });
+
+    it('a regra inline não reivindica o par interno de $$...$$', () => {
+      const rules = getInputRules();
+      expect(applyRule(rules[1], 'resultado $$\\frac{a}{b}$$')).toBeNull();
+    });
+
+    it('não converte valores monetários em fórmula', () => {
+      // Problema relatado: "moedas de R$1,00 e de R$0,50" virava
+      // `R 1,00edeR 0,50` porque os dois cifrões fechavam um par válido.
+      const rules = getInputRules();
+      const replaceRangeWith = applyRule(
+        rules[1],
+        'Guardava moedas de R$1,00 e de R$'
+      );
+      expect(replaceRangeWith).not.toHaveBeenCalled();
+    });
+
+    it('não converte prosa entre cifrões', () => {
+      const rules = getInputRules();
+      const replaceRangeWith = applyRule(
+        rules[1],
+        'comprou $valor muito alto$'
+      );
+      expect(replaceRangeWith).not.toHaveBeenCalled();
     });
   });
 
@@ -179,92 +317,79 @@ describe('MathNode Extension', () => {
     });
 
     describe('Space shortcut', () => {
-      it('deve retornar false quando não há padrão $...$ antes do cursor', () => {
-        const shortcuts = getConfigMethod(MathNode.config.addKeyboardShortcuts);
-        const spaceHandler = shortcuts?.Space;
-
-        const mockEditor = {
-          state: {
-            selection: {
-              $from: {
-                parent: {
-                  textBetween: jest.fn(() => 'texto normal sem formula'),
-                },
-                parentOffset: 25,
-                pos: 25,
-              },
-            },
-          },
-          chain: jest.fn(() => ({
-            deleteRange: jest.fn().mockReturnThis(),
-            insertContent: jest.fn().mockReturnThis(),
-            run: jest.fn(),
-          })),
-        };
-
-        const result = spaceHandler?.({ editor: mockEditor } as never);
-        expect(result).toBe(false);
-      });
-
-      it('deve converter $latex$ para math node quando Space é pressionado', () => {
-        const shortcuts = getConfigMethod(MathNode.config.addKeyboardShortcuts);
-        const spaceHandler = shortcuts?.Space;
-
-        const mockChain = {
+      /**
+       * Builds an editor mock whose document is exactly `textBefore`, so the
+       * currency guard can read the characters preceding the opening `$`.
+       */
+      const setupSpace = (textBefore: string) => {
+        const chain = {
           deleteRange: jest.fn().mockReturnThis(),
           insertContent: jest.fn().mockReturnThis(),
           run: jest.fn(),
         };
-
-        const mockEditor = {
+        const editor = {
           state: {
+            doc: {
+              textBetween: (from: number, to: number) =>
+                textBefore.slice(from, to),
+            },
             selection: {
               $from: {
-                parent: {
-                  textBetween: jest.fn(() => 'texto $x^2$'),
-                },
-                parentOffset: 11,
-                pos: 11,
+                parent: { textBetween: jest.fn(() => textBefore) },
+                parentOffset: textBefore.length,
+                pos: textBefore.length,
               },
             },
           },
-          chain: jest.fn(() => mockChain),
+          chain: jest.fn(() => chain),
         };
 
-        const result = spaceHandler?.({ editor: mockEditor } as never);
+        const shortcuts = getConfigMethod(MathNode.config.addKeyboardShortcuts);
+        const result = shortcuts?.Space?.({ editor } as never);
+        return { result, chain, editor };
+      };
+
+      it('deve retornar false quando não há padrão $...$ antes do cursor', () => {
+        const { result } = setupSpace('texto normal sem formula');
+        expect(result).toBe(false);
+      });
+
+      it('deve converter $latex$ para math node quando Space é pressionado', () => {
+        const { result, chain, editor } = setupSpace('texto $x^2$');
 
         expect(result).toBe(true);
-        expect(mockEditor.chain).toHaveBeenCalled();
-        expect(mockChain.deleteRange).toHaveBeenCalled();
-        expect(mockChain.insertContent).toHaveBeenCalledWith([
-          { type: 'mathInline', attrs: { latex: 'x^2' } },
+        expect(editor.chain).toHaveBeenCalled();
+        expect(chain.deleteRange).toHaveBeenCalled();
+        expect(chain.insertContent).toHaveBeenCalledWith([
+          { type: 'mathInline', attrs: { latex: 'x^2', display: false } },
           { type: 'text', text: ' ' },
         ]);
-        expect(mockChain.run).toHaveBeenCalled();
+        expect(chain.run).toHaveBeenCalled();
+      });
+
+      it('deve converter $$latex$$ em fórmula de bloco', () => {
+        const { result, chain } = setupSpace('texto $$\\frac{a}{b}$$');
+
+        expect(result).toBe(true);
+        expect(chain.insertContent).toHaveBeenCalledWith([
+          {
+            type: 'mathInline',
+            attrs: { latex: '\\frac{a}{b}', display: true },
+          },
+          { type: 'text', text: ' ' },
+        ]);
+      });
+
+      it('não converte valores monetários quando Space é pressionado', () => {
+        const { result, editor } = setupSpace('moedas de R$1,00 e de R$');
+        expect(result).toBe(false);
+        expect(editor.chain).not.toHaveBeenCalled();
       });
 
       it('deve retornar false quando $...$ está vazio', () => {
-        const shortcuts = getConfigMethod(MathNode.config.addKeyboardShortcuts);
-        const spaceHandler = shortcuts?.Space;
-
-        const mockEditor = {
-          state: {
-            selection: {
-              $from: {
-                parent: {
-                  textBetween: jest.fn(() => 'texto $   $'),
-                },
-                parentOffset: 11,
-                pos: 11,
-              },
-            },
-          },
-          chain: jest.fn(),
-        };
-
-        const result = spaceHandler?.({ editor: mockEditor } as never);
+        const { result, editor } = setupSpace('texto $   $');
         expect(result).toBe(false);
-        expect(mockEditor.chain).not.toHaveBeenCalled();
+        expect(editor.chain).not.toHaveBeenCalled();
       });
     });
 
@@ -345,6 +470,34 @@ describe('MathNode Extension', () => {
         expect(mockChain.insertContent).toHaveBeenCalledWith('$a^2');
         expect(mockChain.run).toHaveBeenCalled();
       });
+
+      it('devolve fórmula de bloco com delimitador duplo', () => {
+        const shortcuts = getConfigMethod(MathNode.config.addKeyboardShortcuts);
+        const mockChain = {
+          deleteRange: jest.fn().mockReturnThis(),
+          insertContent: jest.fn().mockReturnThis(),
+          run: jest.fn(),
+        };
+        const mockEditor = {
+          state: {
+            selection: {
+              $from: {
+                nodeBefore: {
+                  type: { name: 'mathInline' },
+                  attrs: { latex: '\\frac{a}{b}', display: true },
+                  nodeSize: 1,
+                },
+                pos: 10,
+              },
+            },
+          },
+          chain: jest.fn(() => mockChain),
+        };
+
+        shortcuts?.Backspace?.({ editor: mockEditor } as never);
+
+        expect(mockChain.insertContent).toHaveBeenCalledWith('$$\\frac{a}{b}');
+      });
     });
   });
 
@@ -407,10 +560,12 @@ describe('MathNodeView click handling', () => {
     // the component as undefined (a default would silently substitute it).
     latex,
     docSize = 100,
+    display = false,
   }: {
     pos: number | undefined;
     latex?: unknown;
     docSize?: number;
+    display?: boolean;
   }) => {
     const setTextSelection = jest.fn();
     const run = jest.fn();
@@ -425,7 +580,7 @@ describe('MathNodeView click handling', () => {
       commands: { setTextSelection },
       state: { doc: { content: { size: docSize } } },
     };
-    const node = { attrs: { latex }, nodeSize: 1 };
+    const node = { attrs: { latex, display }, nodeSize: 1 };
 
     const NodeView = getNodeView();
     render(<NodeView node={node} editor={editor} getPos={() => pos} />);
@@ -482,12 +637,153 @@ describe('MathNodeView click handling', () => {
     expect(setTextSelection).toHaveBeenCalledWith(10);
   });
 
+  it('reinsere fórmula de bloco com delimitador duplo ao clicar', () => {
+    const { setTextSelection } = setup({
+      pos: 3,
+      latex: 'x^2',
+      display: true,
+    });
+
+    fireEvent.click(screen.getByTestId('node-view-wrapper'));
+
+    // pos + latex.length + '$$'.length
+    expect(setTextSelection).toHaveBeenCalledWith(8);
+  });
+
+  it('renderiza fórmula de bloco em displayMode', () => {
+    const NodeView = getNodeView();
+    render(
+      <NodeView
+        node={{ attrs: { latex: '\\frac{a}{b}', display: true }, nodeSize: 1 }}
+        editor={{}}
+        getPos={() => 0}
+      />
+    );
+
+    expect(mockRenderToString).toHaveBeenCalledWith('\\frac{a}{b}', {
+      throwOnError: false,
+      displayMode: true,
+    });
+  });
+
+  it('exibe o latex cru quando o katex lança', () => {
+    const NodeView = getNodeView();
+    render(
+      <NodeView
+        node={{ attrs: { latex: 'error-latex' }, nodeSize: 1 }}
+        editor={{}}
+        getPos={() => 0}
+      />
+    );
+
+    expect(screen.getByTestId('node-view-wrapper')).toHaveTextContent(
+      'error-latex'
+    );
+  });
+
   it('posiciona o cursor no fim do texto inserido no caso normal', () => {
     const { setTextSelection } = setup({ pos: 3, latex: 'x^2', docSize: 100 });
 
     fireEvent.click(screen.getByTestId('node-view-wrapper'));
 
     expect(setTextSelection).toHaveBeenCalledWith(7); // 3 + 3 + 1
+  });
+});
+
+describe('MathNode paste handling', () => {
+  // Input rules only fire while typing, so before this plugin a formula copied
+  // from a document or from the KaTeX playground landed as raw text (Problema 3).
+  const setupPastePlugin = () => {
+    const insertContent = jest.fn();
+    const plugins = (
+      MathNode.config.addProseMirrorPlugins as unknown as (
+        this: unknown
+      ) => Plugin[]
+    ).call({
+      name: 'mathInline',
+      options: {},
+      storage: {},
+      editor: { commands: { insertContent } },
+    });
+
+    // ProseMirror types these props with a `this: Plugin` context that the
+    // tests do not need to reproduce.
+    const props = plugins[0].props as {
+      transformPastedHTML?: (html: string) => string;
+      handlePaste?: (view: unknown, event: ClipboardEvent) => boolean;
+    };
+
+    return { props, insertContent };
+  };
+
+  const clipboardEvent = (data: Record<string, string>) =>
+    ({
+      clipboardData: { getData: (type: string) => data[type] ?? '' },
+    }) as unknown as ClipboardEvent;
+
+  it('converte LaTeX em HTML colado', () => {
+    const { props } = setupPastePlugin();
+    const result = props?.transformPastedHTML?.('<p>o valor de $x^2$ aqui</p>');
+
+    expect(result).toContain('data-type="math-inline"');
+    expect(result).toContain('data-latex="x^2"');
+  });
+
+  it('converte texto puro colado e insere como HTML', () => {
+    const { props, insertContent } = setupPastePlugin();
+    const handled = props?.handlePaste?.(
+      null,
+      clipboardEvent({
+        'text/plain': 'A matriz $\\begin{pmatrix} a & b \\end{pmatrix}$',
+      })
+    );
+
+    expect(handled).toBe(true);
+    expect(insertContent).toHaveBeenCalledWith(
+      expect.stringContaining('data-type="math-inline"')
+    );
+  });
+
+  it('deixa o ProseMirror tratar quando o clipboard já traz HTML', () => {
+    const { props, insertContent } = setupPastePlugin();
+    const handled = props?.handlePaste?.(
+      null,
+      clipboardEvent({ 'text/html': '<p>$x^2$</p>', 'text/plain': '$x^2$' })
+    );
+
+    expect(handled).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
+  });
+
+  it('ignora texto colado sem LaTeX', () => {
+    const { props, insertContent } = setupPastePlugin();
+    const handled = props?.handlePaste?.(
+      null,
+      clipboardEvent({ 'text/plain': 'apenas texto comum' })
+    );
+
+    expect(handled).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
+  });
+
+  it('ignora valores monetários colados', () => {
+    const { props, insertContent } = setupPastePlugin();
+    const handled = props?.handlePaste?.(
+      null,
+      clipboardEvent({ 'text/plain': 'moedas de R$1,00 e de R$0,50' })
+    );
+
+    expect(handled).toBe(false);
+    expect(insertContent).not.toHaveBeenCalled();
+  });
+
+  it('ignora colagem sem clipboardData', () => {
+    const { props } = setupPastePlugin();
+    const handled = props?.handlePaste?.(null, {
+      clipboardData: null,
+    } as unknown as ClipboardEvent);
+
+    expect(handled).toBe(false);
   });
 });
 

--- a/src/components/RichEditor/components/MathNode.tsx
+++ b/src/components/RichEditor/components/MathNode.tsx
@@ -44,7 +44,10 @@ function MathNodeView({ node, editor, getPos }: MathNodeViewProps) {
         displayMode: display,
       });
     } catch {
-      return `<span class="text-error-600">${latex}</span>`;
+      // `latex` comes from the `data-latex` of pasted/persisted spans and is
+      // about to reach dangerouslySetInnerHTML, so it must be escaped — unlike
+      // the KaTeX output above, which is markup KaTeX generates itself.
+      return `<span class="text-error-600">${escapeHtmlText(latex)}</span>`;
     }
   }, [latex, display]);
 
@@ -224,7 +227,10 @@ export const MathNode = Node.create({
             if (!clipboard || clipboard.getData('text/html')) return false;
 
             const text = clipboard.getData('text/plain');
-            if (!text || !(text.includes('$') || text.includes('\\begin{'))) {
+            if (
+              !text ||
+              !(text.includes('$') || text.includes(String.raw`\begin{`))
+            ) {
               return false;
             }
 

--- a/src/components/RichEditor/components/MathNode.tsx
+++ b/src/components/RichEditor/components/MathNode.tsx
@@ -1,8 +1,19 @@
-import { Node, mergeAttributes } from '@tiptap/core';
+import { InputRule, Node, mergeAttributes } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { ReactNodeViewRenderer, NodeViewWrapper } from '@tiptap/react';
 import type { NodeViewProps } from '@tiptap/react';
 import katex from 'katex';
 import { useMemo } from 'react';
+import {
+  BLOCK_INPUT_RULE,
+  INLINE_INPUT_RULE,
+  MATH_DISPLAY_ATTR,
+  MATH_SPAN_TYPE,
+  isCurrencyAmount,
+  looksLikeMath,
+} from '../../../utils/latexMath';
+import { normalizeLineBreaksInHtml } from '../../../utils/htmlLineBreaks';
+import { escapeHtmlText, processLatexInHtml } from './utils';
 
 interface MathNodeViewProps {
   readonly node: NodeViewProps['node'];
@@ -10,23 +21,32 @@ interface MathNodeViewProps {
   readonly getPos: NodeViewProps['getPos'];
 }
 
+/**
+ * Classes applied to a display formula. They mirror the wrapper
+ * `HtmlMathRenderer` uses for block math so the line break the author sees in
+ * the editor lands in exactly the same place for the student.
+ */
+const DISPLAY_CLASS = 'block w-full text-center my-2.5';
+const INLINE_CLASS = 'inline-math';
+
 function MathNodeView({ node, editor, getPos }: MathNodeViewProps) {
   // `node.attrs.latex` is not guaranteed to be a string: pasted/imported HTML
   // without a `data-latex` attribute makes parseHTML return `undefined`, which
   // bypasses the attribute's `default: ''`. Normalising here keeps both the
   // KaTeX render and the cursor math below working on a real string.
   const latex = typeof node.attrs.latex === 'string' ? node.attrs.latex : '';
+  const display = node.attrs.display === true;
 
   const renderedHtml = useMemo(() => {
     try {
       return katex.renderToString(latex, {
         throwOnError: false,
-        displayMode: false,
+        displayMode: display,
       });
     } catch {
       return `<span class="text-error-600">${latex}</span>`;
     }
-  }, [latex]);
+  }, [latex, display]);
 
   // When clicked, convert back to editable text
   const handleClick = () => {
@@ -36,36 +56,50 @@ function MathNodeView({ node, editor, getPos }: MathNodeViewProps) {
     // "Position NaN out of range" (FRONTEND-BACKOFFICE-WEB-P).
     if (typeof pos !== 'number' || !Number.isFinite(pos)) return;
 
+    const delimiter = display ? '$$' : '$';
+
     editor
       .chain()
       .focus()
       .deleteRange({ from: pos, to: pos + node.nodeSize })
-      .insertContent(`$${latex}$`)
+      .insertContent(`${delimiter}${latex}${delimiter}`)
       .run();
 
-    // Move cursor to the end of the inserted text (before the last $).
-    // Clamp to the document bounds: the position is derived from `pos`, which
-    // predates the edits above, so it can land past the end of the resulting
-    // document — another way ProseMirror would throw "out of range".
+    // Move cursor to the end of the inserted text (before the closing
+    // delimiter). Clamp to the document bounds: the position is derived from
+    // `pos`, which predates the edits above, so it can land past the end of the
+    // resulting document — another way ProseMirror would throw "out of range".
     const docSize = editor.state.doc.content.size;
-    const newPos = Math.min(Math.max(pos + latex.length + 1, 0), docSize);
+    const newPos = Math.min(
+      Math.max(pos + latex.length + delimiter.length, 0),
+      docSize
+    );
     editor.commands.setTextSelection(newPos);
   };
 
   return (
     <NodeViewWrapper
       as="span"
-      className="inline-math cursor-pointer hover:bg-primary-50 rounded px-0.5 transition-colors"
+      className={`${display ? DISPLAY_CLASS : INLINE_CLASS} cursor-pointer hover:bg-primary-50 rounded px-0.5 transition-colors`}
       onClick={handleClick}
       title="Clique para editar"
     >
       <span
         dangerouslySetInnerHTML={{ __html: renderedHtml }}
-        className="inline"
+        className={display ? 'block' : 'inline'}
       />
     </NodeViewWrapper>
   );
 }
+
+/**
+ * Reads the two characters that precede `from` in the document, so the currency
+ * guard can tell `R$1,00` from a formula that merely starts with a digit.
+ */
+const textBeforeRange = (
+  doc: { textBetween: (from: number, to: number, sep?: string) => string },
+  from: number
+): string => doc.textBetween(Math.max(0, from - 2), Math.max(0, from), '');
 
 export const MathNode = Node.create({
   name: 'mathInline',
@@ -75,9 +109,18 @@ export const MathNode = Node.create({
   selectable: true,
 
   addAttributes() {
+    // Both attributes are serialized explicitly by `renderHTML` below. Without
+    // `renderHTML: () => ({})` TipTap ALSO emits them under their bare names
+    // (`latex="..."`, `display="false"`), which leaks non-canonical attributes
+    // into every saved question.
     return {
       latex: {
         default: '',
+        renderHTML: () => ({}),
+      },
+      display: {
+        default: false,
+        renderHTML: () => ({}),
       },
     };
   },
@@ -85,23 +128,33 @@ export const MathNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'span[data-type="math-inline"]',
+        tag: `span[data-type="${MATH_SPAN_TYPE}"]`,
         getAttrs: (dom) => {
           // Fall back to '' instead of forwarding `undefined`: returning the
           // attribute explicitly overrides the `default: ''` declared above, so
           // HTML pasted without `data-latex` would otherwise produce a node
           // whose `latex` attr is undefined.
-          return { latex: dom.dataset.latex ?? '' };
+          return {
+            latex: dom.dataset.latex ?? '',
+            display: dom.dataset.displayMode === 'true',
+          };
         },
       },
     ];
   },
 
   renderHTML({ node, HTMLAttributes }) {
+    // The display flag is only emitted when set: keeping the serialized markup
+    // minimal means inline formulas produce byte-identical HTML to before.
+    const displayAttributes = node.attrs.display
+      ? { [MATH_DISPLAY_ATTR]: 'true' }
+      : {};
+
     return [
       'span',
       mergeAttributes(HTMLAttributes, {
-        'data-type': 'math-inline',
+        'data-type': MATH_SPAN_TYPE,
+        ...displayAttributes,
         'data-latex': node.attrs.latex,
       }),
     ];
@@ -111,14 +164,87 @@ export const MathNode = Node.create({
     return ReactNodeViewRenderer(MathNodeView);
   },
 
-  // Disable default input rules
+  /**
+   * Converts `$formula$` / `$$formula$$` the moment the closing delimiter is
+   * typed. Previously the only trigger was the Space shortcut below, which is
+   * why authors had to type a space after the last `$` and why a formula that
+   * ended a sentence stayed raw text forever.
+   */
   addInputRules() {
-    return [];
+    const { type } = this;
+
+    const buildRule = (find: RegExp, display: boolean) =>
+      new InputRule({
+        find,
+        handler: ({ state, range, match }) => {
+          const latex = match[1];
+          if (!latex?.trim()) return;
+
+          // Inline math is the ambiguous case: `R$1,00 e de R$0,50` closes a
+          // perfectly valid `$...$` pair across two prices.
+          if (!display) {
+            const before = textBeforeRange(state.doc, range.from);
+            if (isCurrencyAmount(before, latex) || !looksLikeMath(latex)) {
+              return;
+            }
+          }
+
+          state.tr.replaceRangeWith(
+            range.from,
+            range.to,
+            type.create({ latex, display })
+          );
+        },
+      });
+
+    // `$$` first: the inline rule must never claim the inner `$formula$` of a
+    // display block.
+    return [
+      buildRule(BLOCK_INPUT_RULE, true),
+      buildRule(INLINE_INPUT_RULE, false),
+    ];
+  },
+
+  /**
+   * Pasted content never runs through input rules, so a formula copied from a
+   * document or from the KaTeX playground used to land as raw text. Both
+   * clipboard flavours are converted here.
+   */
+  addProseMirrorPlugins() {
+    const { editor } = this;
+
+    return [
+      new Plugin({
+        key: new PluginKey('mathInlinePaste'),
+        props: {
+          transformPastedHTML: (html) => processLatexInHtml(html),
+          handlePaste: (_view, event) => {
+            const clipboard = event.clipboardData;
+            // HTML payloads are already covered by transformPastedHTML above.
+            if (!clipboard || clipboard.getData('text/html')) return false;
+
+            const text = clipboard.getData('text/plain');
+            if (!text || !(text.includes('$') || text.includes('\\begin{'))) {
+              return false;
+            }
+
+            const html = processLatexInHtml(
+              normalizeLineBreaksInHtml(escapeHtmlText(text), { inline: true })
+            );
+            if (!html.includes(`data-type="${MATH_SPAN_TYPE}"`)) return false;
+
+            editor.commands.insertContent(html);
+            return true;
+          },
+        },
+      }),
+    ];
   },
 
   addKeyboardShortcuts() {
     return {
-      // When space is pressed after closing $, convert to math node
+      // Kept for authors used to the old flow (and for `$...$` typed before a
+      // paste re-flowed the text): space after a closing delimiter converts.
       Space: ({ editor }) => {
         const { state } = editor;
         const { selection } = state;
@@ -131,27 +257,36 @@ export const MathNode = Node.create({
           '\n'
         );
 
-        // Check if there's a complete $...$ pattern right before the cursor
-        const regex = /\$([^$]+)\$$/;
-        const match = regex.exec(textBefore);
-        if (match?.[1]?.trim()) {
-          const latex = match[1];
-          const matchStart = $from.pos - match[0].length;
+        // `$$...$$` is tested first so a display block is not split in half.
+        const blockMatch = BLOCK_INPUT_RULE.exec(textBefore);
+        const inlineMatch = blockMatch
+          ? null
+          : INLINE_INPUT_RULE.exec(textBefore);
+        const match = blockMatch ?? inlineMatch;
+        if (!match?.[1]?.trim()) return false;
 
-          // Replace $latex$ with math node, then add a space
-          editor
-            .chain()
-            .deleteRange({ from: matchStart, to: $from.pos })
-            .insertContent([
-              { type: 'mathInline', attrs: { latex } },
-              { type: 'text', text: ' ' },
-            ])
-            .run();
+        const latex = match[1];
+        const display = blockMatch !== null;
+        const matchStart = $from.pos - match[0].length;
 
-          return true;
+        if (!display) {
+          const before = textBeforeRange(state.doc, matchStart);
+          if (isCurrencyAmount(before, latex) || !looksLikeMath(latex)) {
+            return false;
+          }
         }
 
-        return false;
+        // Replace the delimited text with a math node, then add a space
+        editor
+          .chain()
+          .deleteRange({ from: matchStart, to: $from.pos })
+          .insertContent([
+            { type: 'mathInline', attrs: { latex, display } },
+            { type: 'text', text: ' ' },
+          ])
+          .run();
+
+        return true;
       },
 
       // When backspace is pressed on a math node, convert it back to text for editing
@@ -164,12 +299,14 @@ export const MathNode = Node.create({
         if (nodeBefore?.type.name === 'mathInline') {
           const pos = $from.pos - nodeBefore.nodeSize;
           const latex = nodeBefore.attrs.latex;
+          const delimiter = nodeBefore.attrs.display ? '$$' : '$';
 
-          // Convert back to text without the last $, so user can continue editing
+          // Convert back to text without the closing delimiter, so the user can
+          // continue editing
           editor
             .chain()
             .deleteRange({ from: pos, to: $from.pos })
-            .insertContent(`$${latex}`)
+            .insertContent(`${delimiter}${latex}`)
             .run();
 
           return true;

--- a/src/components/RichEditor/components/utils.test.ts
+++ b/src/components/RichEditor/components/utils.test.ts
@@ -95,6 +95,13 @@ describe('unprocessLatexInHtml', () => {
     expect(unprocessLatexInHtml(input)).toBe(expected);
   });
 
+  it('deve reemitir $$...$$ para fórmula em bloco', () => {
+    const input =
+      '<span data-type="math-inline" data-display-mode="true" data-latex="\\frac{a}{b}"></span>';
+
+    expect(unprocessLatexInHtml(input)).toBe('$$\\frac{a}{b}$$');
+  });
+
   it('deve ser inverso de processLatexInHtml', () => {
     const original = 'Fórmula: $a^2 + b^2 = c^2$ aqui';
     const processed = processLatexInHtml(original);

--- a/src/components/RichEditor/components/utils.ts
+++ b/src/components/RichEditor/components/utils.ts
@@ -1,37 +1,92 @@
+import {
+  buildMathSpan,
+  createLatexEnvPattern,
+  createMathSpanPattern,
+  readMathSpanAttributes,
+  replaceDollarMath,
+} from '../../../utils/latexMath';
+
 // Re-exported so RichEditor consumers keep a single import surface.
 export { normalizeLineBreaksInHtml } from '../../../utils/htmlLineBreaks';
 
 /**
- * Processa HTML convertendo padrões $...$ para spans de math-inline
- * que o TipTap pode reconhecer
+ * Escapes plain text so it can be safely spliced into an HTML string.
+ * Used before {@link processLatexInHtml} on clipboard `text/plain` payloads,
+ * which carry no markup of their own.
+ */
+export function escapeHtmlText(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+/**
+ * Applies `convert` only to the stretches of `html` that sit outside an
+ * existing math span.
+ *
+ * Every conversion stage has to be wrapped in this: a `data-latex` payload
+ * routinely holds `\begin{pmatrix}` or `$`, and re-scanning it would nest a
+ * second span inside the attribute and destroy the stored formula. That
+ * includes spans a previous stage just created.
+ */
+function outsideMathSpans(
+  html: string,
+  convert: (segment: string) => string
+): string {
+  let result = '';
+  let cursor = 0;
+
+  for (const match of html.matchAll(createMathSpanPattern())) {
+    result += convert(html.slice(cursor, match.index)) + match[0];
+    cursor = match.index + match[0].length;
+  }
+
+  return result + convert(html.slice(cursor));
+}
+
+/**
+ * Converte LaTeX escrito em texto (`$...$`, `$$...$$` ou um ambiente
+ * `\begin{...}\end{...}` solto) nos spans `math-inline` que o TipTap reconhece.
+ *
+ * `$$...$$` é resolvido antes de `$...$` — a regex única anterior casava o `$x$`
+ * interno de `$$x$$` e deixava cifrões órfãos na tela. Valores monetários
+ * (`R$1,00 e de R$0,50`) são ignorados pelo scanner compartilhado, então nunca
+ * viram fórmula.
  */
 export function processLatexInHtml(html: string): string {
   if (!html) return html;
 
-  // Regex para encontrar $...$ (não-greedy, permite múltiplas linhas)
-  // Captura conteúdo entre $ que não seja vazio
-  const latexPattern = /\$([^$]+?)\$/g;
+  const withDollarMath = outsideMathSpans(html, (segment) =>
+    replaceDollarMath(segment, ({ latex, display }) =>
+      buildMathSpan(latex, display)
+    )
+  );
 
-  return html.replaceAll(latexPattern, (_match: string, latex: string) => {
-    // Escapa aspas duplas no atributo
-    const escapedLatex = latex.replaceAll('"', '&quot;');
-    return `<span data-type="math-inline" data-latex="${escapedLatex}"></span>`;
-  });
+  // Standalone environments (`\begin{pmatrix}...\end{pmatrix}` with no
+  // delimiters around them) reach the editor from AI generation and from older
+  // saves. The display renderer already treats them as block math, so the
+  // editor has to agree — otherwise the same content is a formula for the
+  // student and raw text for the author.
+  return outsideMathSpans(withDollarMath, (segment) =>
+    segment.replaceAll(createLatexEnvPattern(), (match) =>
+      buildMathSpan(match, true)
+    )
+  );
 }
 
 /**
- * Converte spans math-inline de volta para formato $...$
- * Útil para exportar o conteúdo em formato mais simples
+ * Converte spans math-inline de volta para o formato `$...$` / `$$...$$`.
+ * Útil para exportar o conteúdo em formato mais simples.
  */
 export function unprocessLatexInHtml(html: string): string {
   if (!html) return html;
 
-  const mathSpanPattern =
-    /<span[^>]*data-type="math-inline"[^>]*data-latex="([^"]*)"[^>]*><\/span>/g;
-
-  return html.replaceAll(mathSpanPattern, (_match: string, latex: string) => {
+  return html.replaceAll(createMathSpanPattern(), (match) => {
+    const { latex, display } = readMathSpanAttributes(match);
     // Desescapa aspas
     const unescapedLatex = latex.replaceAll('&quot;', '"');
-    return `$${unescapedLatex}$`;
+    const delimiter = display ? '$$' : '$';
+    return `${delimiter}${unescapedLatex}${delimiter}`;
   });
 }

--- a/src/components/RichEditor/latexRoundTrip.test.tsx
+++ b/src/components/RichEditor/latexRoundTrip.test.tsx
@@ -1,0 +1,187 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import HtmlMathRenderer from '../HtmlMathRenderer/HtmlMathRenderer';
+import { createRichEditorExtensions } from './components/extensions';
+import { processLatexInHtml } from './components/utils';
+
+/**
+ * Cross-boundary regression suite.
+ *
+ * The editor writes `<span data-type="math-inline">` while the display pipeline
+ * only knew `math-formula` spans and raw `$...$`, so formulas silently vanished
+ * (or flipped from inline to centered block) in "Ver como estudante" and on the
+ * student surfaces. No test used to feed `editor.getHTML()` into
+ * `HtmlMathRenderer`, which is exactly why the mismatch went unnoticed.
+ */
+
+// KatexMath is mocked so the assertions read the LaTeX that reached the
+// renderer instead of KaTeX's generated markup.
+jest.mock('../HtmlMathRenderer/KatexMath', () => ({
+  KatexMath: ({
+    math,
+    displayMode,
+  }: {
+    math: string;
+    displayMode?: boolean;
+  }) =>
+    displayMode ? (
+      <div data-testid="block-math">{math}</div>
+    ) : (
+      <span data-testid="inline-math">{math}</span>
+    ),
+}));
+
+beforeAll(() => {
+  // jsdom does not implement elementFromPoint, which TipTap's Placeholder
+  // viewport tracking calls while the editor view mounts.
+  Document.prototype.elementFromPoint = () => null;
+});
+
+/** Runs stored content through the editor and returns what it would persist. */
+const roundTrip = (stored: string): string => {
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: createRichEditorExtensions('Digite aqui...'),
+    content: processLatexInHtml(stored),
+  });
+  const html = editor.getHTML();
+  editor.destroy();
+  return html;
+};
+
+const renderAsStudent = (html: string) =>
+  render(<HtmlMathRenderer content={html} testId="student" />);
+
+describe('digitação real: input rules do ProseMirror', () => {
+  /**
+   * Types `text` one character at a time through `handleTextInput` — the exact
+   * ProseMirror hook a real keystroke goes through, so the input rules run
+   * against real document positions.
+   *
+   * `editor.commands.insertContent(..., { applyInputRules: true })` is NOT used
+   * here: it defers the rules to a macrotask with a position captured before
+   * the edit, which throws once a rule shrinks the document.
+   */
+  const type = (text: string): string => {
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: createRichEditorExtensions('Digite aqui...'),
+      content: '<p></p>',
+    });
+
+    for (const char of text) {
+      const { from, to } = editor.state.selection;
+      const fallback = () => editor.state.tr.insertText(char, from, to);
+      const handled = editor.view.someProp('handleTextInput', (handler) =>
+        handler(editor.view, from, to, char, fallback)
+      );
+      if (!handled) {
+        editor.view.dispatch(fallback());
+      }
+    }
+
+    const html = editor.getHTML();
+    editor.destroy();
+    return html;
+  };
+
+  it('converte $x^2$ sem exigir espaço após o cifrão final', () => {
+    const html = type('valor $x^2$');
+
+    expect(html).toContain('data-type="math-inline"');
+    expect(html).toContain('data-latex="x^2"');
+    expect(html).not.toContain('$');
+  });
+
+  it('converte $$...$$ em fórmula de bloco', () => {
+    const html = type('total $$a+b$$');
+
+    expect(html).toContain('data-display-mode="true"');
+    expect(html).toContain('data-latex="a+b"');
+    expect(html).not.toContain('$');
+  });
+
+  it('mantém R$1,00 e de R$0,50 como texto', () => {
+    const html = type('moedas de R$1,00 e de R$0,50');
+
+    expect(html).not.toContain('math-inline');
+    expect(html).toContain('R$1,00 e de R$0,50');
+  });
+});
+
+describe('LaTeX round-trip: editor → HTML salvo → visão do estudante', () => {
+  it('preserva fórmula inline no enunciado do chamado', () => {
+    const html = roundTrip(
+      'Para cada número real $x \\neq 0$, definimos a matriz ' +
+        '$A(x) = \\begin{pmatrix} -x-1 & \\frac{1}{x} \\\\ -x & \\frac{1}{x}+1 \\end{pmatrix}$. ' +
+        'Assinale o que for correto.'
+    );
+
+    expect(html).toContain('data-type="math-inline"');
+    renderAsStudent(html);
+
+    const inline = screen.getAllByTestId('inline-math');
+    expect(inline).toHaveLength(2);
+    expect(inline[0]).toHaveTextContent('x \\neq 0');
+    // A matriz continua inline: nada de quebra de linha inesperada.
+    expect(inline[1]).toHaveTextContent('\\begin{pmatrix}');
+    expect(screen.queryByTestId('block-math')).not.toBeInTheDocument();
+    expect(screen.getByTestId('student')).toHaveTextContent(
+      'Assinale o que for correto.'
+    );
+  });
+
+  it('mantém $$...$$ como bloco dos dois lados', () => {
+    const html = roundTrip(
+      'Somando: $$A(x) + A(-x) = \\begin{pmatrix} -2 & 0 \\\\ 0 & 2 \\end{pmatrix} \\neq \\begin{pmatrix} 0 & 0 \\\\ 0 & 0 \\end{pmatrix}$$'
+    );
+
+    expect(html).toContain('data-display-mode="true"');
+    // O par interno nunca pode ser reivindicado como fórmula inline.
+    expect(html).not.toContain('$');
+
+    renderAsStudent(html);
+    expect(screen.getByTestId('block-math')).toHaveTextContent('\\neq');
+    expect(screen.queryByTestId('inline-math')).not.toBeInTheDocument();
+  });
+
+  it('não converte valores monetários em nenhuma das pontas', () => {
+    const statement =
+      'Guardava moedas de R$1,00 e de R$0,50. Havia 530 moedas e um total de R$370,00.';
+    const html = roundTrip(statement);
+
+    expect(html).not.toContain('data-type="math-inline"');
+
+    renderAsStudent(html);
+    const student = screen.getByTestId('student');
+    expect(student).toHaveTextContent('R$1,00');
+    expect(student).toHaveTextContent('R$0,50');
+    expect(student).toHaveTextContent('R$370,00');
+    expect(screen.queryByTestId('inline-math')).not.toBeInTheDocument();
+  });
+
+  it('sobrevive a um segundo ciclo de edição sem corromper a fórmula', () => {
+    // O `\begin{pmatrix}` dentro de `data-latex` não pode ser reprocessado.
+    const first = roundTrip('$\\begin{pmatrix} a & b \\end{pmatrix}$');
+    const second = roundTrip(first);
+
+    expect(second).toBe(first);
+
+    renderAsStudent(second);
+    expect(screen.getByTestId('inline-math')).toHaveTextContent(
+      '\\begin{pmatrix} a & b \\end{pmatrix}'
+    );
+  });
+
+  it('converte ambiente LaTeX solto em bloco, igual ao renderizador', () => {
+    const html = roundTrip('A = \\begin{pmatrix} 1 & 2 \\end{pmatrix}');
+
+    expect(html).toContain('data-display-mode="true"');
+
+    renderAsStudent(html);
+    expect(screen.getByTestId('block-math')).toHaveTextContent(
+      '\\begin{pmatrix} 1 & 2 \\end{pmatrix}'
+    );
+  });
+});

--- a/src/utils/latexMath.test.ts
+++ b/src/utils/latexMath.test.ts
@@ -1,0 +1,217 @@
+import {
+  BLOCK_INPUT_RULE,
+  INLINE_INPUT_RULE,
+  buildMathSpan,
+  createLatexEnvPattern,
+  createMathSpanPattern,
+  findDollarMath,
+  isCurrencyAmount,
+  isCurrencyDollar,
+  looksLikeMath,
+  readMathSpanAttributes,
+  replaceDollarMath,
+} from './latexMath';
+
+describe('buildMathSpan', () => {
+  it('serializa fórmula inline sem o atributo de display', () => {
+    expect(buildMathSpan('x^2')).toBe(
+      '<span data-type="math-inline" data-latex="x^2"></span>'
+    );
+  });
+
+  it('marca fórmula em bloco com data-display-mode', () => {
+    expect(buildMathSpan('\\frac{a}{b}', true)).toBe(
+      '<span data-type="math-inline" data-display-mode="true" data-latex="\\frac{a}{b}"></span>'
+    );
+  });
+
+  it('escapa aspas duplas no atributo', () => {
+    expect(buildMathSpan('a "b" c')).toContain(
+      'data-latex="a &quot;b&quot; c"'
+    );
+  });
+});
+
+describe('readMathSpanAttributes', () => {
+  it('lê latex e display independentemente da ordem dos atributos', () => {
+    expect(
+      readMathSpanAttributes(
+        '<span data-latex="x^2" class="foo" data-display-mode="true" data-type="math-inline"></span>'
+      )
+    ).toEqual({ latex: 'x^2', display: true });
+  });
+
+  it('retorna latex vazio quando o atributo não existe', () => {
+    expect(
+      readMathSpanAttributes('<span data-type="math-inline"></span>')
+    ).toEqual({ latex: '', display: false });
+  });
+});
+
+describe('createMathSpanPattern', () => {
+  it('casa o span canônico do editor', () => {
+    const html =
+      'antes <span data-type="math-inline" data-latex="x^2"></span> depois';
+    expect(html.match(createMathSpanPattern())).toHaveLength(1);
+  });
+
+  it('devolve uma regex nova a cada chamada (sem lastIndex compartilhado)', () => {
+    expect(createMathSpanPattern()).not.toBe(createMathSpanPattern());
+  });
+});
+
+describe('createLatexEnvPattern', () => {
+  it('casa um ambiente completo pelo nome de abertura', () => {
+    const source = 'A = \\begin{pmatrix} 1 & 2 \\\\ 3 & 4 \\end{pmatrix} fim';
+    const matches = source.match(createLatexEnvPattern());
+    expect(matches).toHaveLength(1);
+    expect(matches?.[0]).toContain('\\begin{pmatrix}');
+    expect(matches?.[0]).toContain('\\end{pmatrix}');
+  });
+});
+
+describe('isCurrencyAmount', () => {
+  it.each([
+    ['R', '1,00 e de R'],
+    [' R', ' 15,00 pelo custo fixo e mais R'],
+    ['US', ' 3,50 e depois US'],
+  ])('reconhece moeda quando antes="%s"', (before, captured) => {
+    expect(isCurrencyAmount(before, captured)).toBe(true);
+  });
+
+  it('reconhece número seguido de prosa mesmo sem sigla antes', () => {
+    expect(isCurrencyAmount('e ', '1,00 e de R')).toBe(true);
+  });
+
+  it('não acusa moeda quando a fórmula não começa com dígito', () => {
+    expect(isCurrencyAmount(' R', 'x \\neq 0')).toBe(false);
+  });
+
+  it('não acusa moeda quando há comando LaTeX no conteúdo', () => {
+    expect(isCurrencyAmount(' R', '2 \\cdot 3')).toBe(false);
+  });
+
+  it('não acusa moeda em equação que começa com número', () => {
+    expect(isCurrencyAmount('o ', '1 + 2 = 3')).toBe(false);
+  });
+});
+
+describe('isCurrencyDollar', () => {
+  it('usa os dois caracteres anteriores à posição do cifrão', () => {
+    const source = 'moedas de R$1,00 e de R$0,50';
+    expect(isCurrencyDollar(source, source.indexOf('$'), '1,00 e de R')).toBe(
+      true
+    );
+  });
+
+  it('funciona quando o cifrão está no início da string', () => {
+    expect(isCurrencyDollar('$x^2$', 0, 'x^2')).toBe(false);
+  });
+});
+
+describe('looksLikeMath', () => {
+  it.each(['x = 1', 'a + b', '1 < 2', 'f0', 'abc', '\\frac{1}{2}', 'x^2'])(
+    'aceita %s como matemática',
+    (expression) => {
+      expect(looksLikeMath(expression)).toBe(true);
+    }
+  );
+
+  it('rejeita prosa com duas ou mais palavras', () => {
+    expect(looksLikeMath('valor muito alto')).toBe(false);
+  });
+
+  it('baixa o limiar para uma palavra quando há número decimal', () => {
+    expect(looksLikeMath('15,00 pelo')).toBe(false);
+    expect(looksLikeMath('15,00')).toBe(true);
+  });
+});
+
+describe('findDollarMath', () => {
+  it('retorna vazio para entrada vazia', () => {
+    expect(findDollarMath('')).toEqual([]);
+  });
+
+  it('encontra fórmula inline', () => {
+    expect(findDollarMath('o valor de $x^2$ aqui')).toEqual([
+      { start: 11, end: 16, latex: 'x^2', display: false },
+    ]);
+  });
+
+  it('resolve $$...$$ antes de $...$', () => {
+    // A regex única anterior casava o `$x$` interno e deixava cifrões órfãos.
+    const matches = findDollarMath('resultado $$x^2$$ fim');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ latex: 'x^2', display: true });
+  });
+
+  it('ignora cifrão escapado com \\$', () => {
+    expect(findDollarMath('custo de R\\$ 130,00 pelo ingresso')).toEqual([]);
+  });
+
+  it('atravessa o separador de linha \\\\ dentro da matriz', () => {
+    const source =
+      '$A = \\begin{pmatrix} -x-1 & \\frac{1}{x} \\\\ -x & \\frac{1}{x}+1 \\end{pmatrix}$';
+    const matches = findDollarMath(source);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].latex).toContain('\\end{pmatrix}');
+  });
+
+  it('não pareia cifrões de valores monetários', () => {
+    expect(
+      findDollarMath(
+        'Guardava moedas de R$1,00 e de R$0,50. Total de R$370,00.'
+      )
+    ).toEqual([]);
+  });
+
+  it('ainda encontra a fórmula que vem depois de um preço', () => {
+    // Rejeitar consumindo o trecho inteiro engoliria a fórmula seguinte.
+    const matches = findDollarMath('custou R$50,00 e vale $x^2$ pontos');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].latex).toBe('x^2');
+  });
+
+  it('ignora cifrão sem par', () => {
+    expect(findDollarMath('Preço: $50 dólares')).toEqual([]);
+  });
+
+  it('ignora $$ sem fechamento', () => {
+    expect(findDollarMath('inicio $$x^2 sem fim')).toEqual([]);
+  });
+
+  it('ignora $$ com conteúdo em branco', () => {
+    expect(findDollarMath('a $$   $$ b')).toEqual([]);
+  });
+
+  it('encontra várias fórmulas na mesma frase', () => {
+    const matches = findDollarMath('Área: $A = \\pi r^2$ e $$V = h$$');
+    expect(matches.map((m) => m.display)).toEqual([false, true]);
+  });
+});
+
+describe('replaceDollarMath', () => {
+  it('devolve a origem intacta quando não há matemática', () => {
+    expect(replaceDollarMath('sem formula', () => 'X')).toBe('sem formula');
+  });
+
+  it('substitui apenas as regiões matemáticas', () => {
+    expect(
+      replaceDollarMath('antes $x^2$ depois', ({ latex }) => `[${latex}]`)
+    ).toBe('antes [x^2] depois');
+  });
+});
+
+describe('input rules', () => {
+  it('a regra de bloco casa $$...$$ ancorado no cursor', () => {
+    expect(BLOCK_INPUT_RULE.exec('texto $$x^2$$')?.[1]).toBe('x^2');
+  });
+
+  it('a regra inline casa $...$ sem exigir espaço depois', () => {
+    expect(INLINE_INPUT_RULE.exec('texto $x^2$')?.[1]).toBe('x^2');
+  });
+
+  it('a regra inline não reivindica o par interno de $$...$$', () => {
+    expect(INLINE_INPUT_RULE.exec('texto $$x^2$$')).toBeNull();
+  });
+});

--- a/src/utils/latexMath.test.ts
+++ b/src/utils/latexMath.test.ts
@@ -184,6 +184,14 @@ describe('findDollarMath', () => {
     expect(findDollarMath('a $$   $$ b')).toEqual([]);
   });
 
+  it('ignora $...$ com conteúdo em branco', () => {
+    expect(findDollarMath('a $   $ b')).toEqual([]);
+  });
+
+  it('ignora prosa entre cifrões', () => {
+    expect(findDollarMath('comprou $valor muito alto$ reais')).toEqual([]);
+  });
+
   it('encontra várias fórmulas na mesma frase', () => {
     const matches = findDollarMath('Área: $A = \\pi r^2$ e $$V = h$$');
     expect(matches.map((m) => m.display)).toEqual([false, true]);

--- a/src/utils/latexMath.ts
+++ b/src/utils/latexMath.ts
@@ -1,0 +1,250 @@
+/**
+ * Canonical LaTeX delimiter handling shared by the two sides of the pipeline:
+ *
+ * - the write path (`RichEditor`, which turns `$...$` / `$$...$$` into TipTap
+ *   `mathInline` nodes and serializes them back as `<span data-type="math-inline">`)
+ * - the display path (`HtmlMathRenderer`, which turns the stored HTML into
+ *   KaTeX renders for the student/teacher surfaces)
+ *
+ * Both used to implement their own delimiter scanning with different regexes and
+ * different currency heuristics, so a formula could render in the editor and
+ * vanish (or change from inline to block) in "Ver como estudante". Everything
+ * that decides "is this math, and is it inline or display?" lives here now.
+ */
+
+/** `data-type` value the editor writes for a math node. */
+export const MATH_SPAN_TYPE = 'math-inline';
+
+/** Attribute that flags a math node as display (block) math. */
+export const MATH_DISPLAY_ATTR = 'data-display-mode';
+
+/**
+ * Matches a `<span data-type="math-inline" ...>` element, including a possible
+ * (always empty in practice) body. Attribute order is not fixed — TipTap's
+ * `mergeAttributes` decides it — so the LaTeX itself is pulled from the matched
+ * tag with {@link readMathSpanAttributes} instead of a capture group.
+ */
+export const createMathSpanPattern = (): RegExp =>
+  new RegExp(
+    String.raw`<span\b[^>]*\bdata-type="${MATH_SPAN_TYPE}"[^>]*>[\s\S]*?<\/span>`,
+    'g'
+  );
+
+/**
+ * Matches a standalone LaTeX environment (`\begin{pmatrix}...\end{pmatrix}`).
+ * Returned as a factory so callers never share `lastIndex` state.
+ */
+export const createLatexEnvPattern = (): RegExp =>
+  /\\begin\{([^}]+)\}[\s\S]*?\\end\{\1\}/g;
+
+/** Reads `data-latex` / `data-display-mode` out of a matched math span tag. */
+export const readMathSpanAttributes = (
+  spanHtml: string
+): { latex: string; display: boolean } => {
+  const latexMatch = /\bdata-latex="([^"]*)"/.exec(spanHtml);
+  return {
+    latex: latexMatch ? latexMatch[1] : '',
+    display: new RegExp(String.raw`\b${MATH_DISPLAY_ATTR}="true"`).test(
+      spanHtml
+    ),
+  };
+};
+
+/**
+ * Serializes a math node back to the canonical span the editor persists.
+ *
+ * Only `"` is escaped: the input already comes from an HTML string, so its `&`
+ * is either a bare alignment character (valid inside an attribute) or an
+ * already-encoded entity that must not be double-encoded into `&amp;amp;`.
+ */
+export const buildMathSpan = (latex: string, display = false): string => {
+  const escaped = latex.replaceAll('"', '&quot;');
+  const displayAttr = display ? ` ${MATH_DISPLAY_ATTR}="true"` : '';
+  return `<span data-type="${MATH_SPAN_TYPE}"${displayAttr} data-latex="${escaped}"></span>`;
+};
+
+/**
+ * Letters that immediately precede `$` in the currency sigils used across the
+ * Brazilian question bank: `R$` (real), `US$` / `U$` (dollar).
+ */
+const CURRENCY_SIGIL_PATTERN = /(?:R|US|U)$/;
+
+/** Any construct that only appears in real LaTeX, never in a price. */
+const LATEX_COMMAND_PATTERN = /[\\^_{}]/;
+
+/**
+ * True when a `$` opens a monetary amount rather than a math block.
+ *
+ * The failure this guards against: `"Guardava moedas de R$1,00 e de R$0,50"`
+ * has two `$`, so a naive pairing sends `"1,00 e de R"` to KaTeX and renders
+ * `R 1,00edeR 0,50`. Prose alone is not enough to detect it — `"1,00 e de R"`
+ * has no word of 3+ letters, so the {@link looksLikeMath} heuristic passes it.
+ *
+ * @param before - the (up to) two characters preceding the `$`
+ * @param captured - the text between this `$` and the next one
+ */
+export const isCurrencyAmount = (before: string, captured: string): boolean => {
+  // Math expressions do not start a currency amount, and a real command
+  // anywhere in the block settles it regardless of what precedes the `$`.
+  if (!/^\s*\d/.test(captured)) return false;
+  if (LATEX_COMMAND_PATTERN.test(captured)) return false;
+
+  // `R$ 15,00 ...` / `US$ 3,50 ...`
+  if (CURRENCY_SIGIL_PATTERN.test(before)) return true;
+
+  // `$1,00 e de R$` — a number followed by prose. Two letters are enough here
+  // ("e de" would slip past the 3-letter word count used for generic prose).
+  return /[a-zA-Z]{2,}/.test(captured);
+};
+
+/** Position-based wrapper over {@link isCurrencyAmount}. */
+export const isCurrencyDollar = (
+  source: string,
+  dollarIndex: number,
+  captured: string
+): boolean =>
+  isCurrencyAmount(
+    source.slice(Math.max(0, dollarIndex - 2), dollarIndex),
+    captured
+  );
+
+/**
+ * Heuristic that flags a string as "likely real math" vs prose. Used to reject
+ * `$...$` blocks that wrap regular text — typically an author typing `$` as a
+ * currency symbol, which pairs unrelated occurrences and sends Portuguese prose
+ * to KaTeX (rendering every letter as a math variable).
+ *
+ * - Backslash commands / sub-super / grouping braces → definitely math.
+ * - Otherwise it is PROSE once it holds enough real words (runs of 3+ letters).
+ *   `x = 1`, `a + b`, `1 < 2`, `f0` and even a lone `abc` stay math.
+ * - The word threshold drops to one when the block also contains a decimal
+ *   number, since `"1,00 e vale"` is a price far more often than an equation.
+ */
+export const looksLikeMath = (str: string): boolean => {
+  if (LATEX_COMMAND_PATTERN.test(str)) return true;
+  const words = str.match(/[a-zA-Z]{3,}/g);
+  if (!words) return true;
+  const proseThreshold = /\d+[.,]\d/.test(str) ? 1 : 2;
+  return words.length < proseThreshold;
+};
+
+/** A `$...$` or `$$...$$` region located inside a source string. */
+export interface DollarMathMatch {
+  /** Index of the first `$` of the opening delimiter. */
+  start: number;
+  /** Index just past the last `$` of the closing delimiter. */
+  end: number;
+  /** Raw LaTeX between the delimiters. */
+  latex: string;
+  /** `true` for `$$...$$`, which renders as centered display math. */
+  display: boolean;
+}
+
+/**
+ * Finds the next occurrence of `token` that is not preceded by a backslash.
+ * Escapes are consumed two characters at a time, so `\$` never closes a block
+ * and the `\\` row separator inside a matrix is stepped over safely.
+ */
+const indexOfUnescaped = (
+  source: string,
+  token: string,
+  from: number
+): number => {
+  let index = from;
+  while (index < source.length) {
+    if (source[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (source.startsWith(token, index)) return index;
+    index += 1;
+  }
+  return -1;
+};
+
+/**
+ * Scans `source` left to right and returns every dollar-delimited math region.
+ *
+ * `$$...$$` is always tested before `$...$`, which is what the old single regex
+ * got wrong: it matched the inner `$x$` of `$$x$$` and left orphan dollars
+ * behind. A rejected candidate (currency or prose) only advances the cursor by
+ * one character, so a real formula later in the same sentence is still found —
+ * consuming the whole rejected span would swallow it.
+ */
+export const findDollarMath = (source: string): DollarMathMatch[] => {
+  const matches: DollarMathMatch[] = [];
+  if (!source) return matches;
+
+  let index = 0;
+  while (index < source.length) {
+    if (source[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (source[index] !== '$') {
+      index += 1;
+      continue;
+    }
+
+    if (source.startsWith('$$', index)) {
+      const close = indexOfUnescaped(source, '$$', index + 2);
+      const latex = close === -1 ? '' : source.slice(index + 2, close);
+      if (close !== -1 && latex.trim()) {
+        matches.push({ start: index, end: close + 2, latex, display: true });
+        index = close + 2;
+      } else {
+        index += 2;
+      }
+      continue;
+    }
+
+    const close = indexOfUnescaped(source, '$', index + 1);
+    if (close === -1) break;
+
+    const latex = source.slice(index + 1, close);
+    if (
+      latex.trim() &&
+      !isCurrencyDollar(source, index, latex) &&
+      looksLikeMath(latex)
+    ) {
+      matches.push({ start: index, end: close + 1, latex, display: false });
+      index = close + 1;
+    } else {
+      index += 1;
+    }
+  }
+
+  return matches;
+};
+
+/**
+ * Rewrites every dollar-delimited math region of `source` using `replacer`,
+ * leaving the surrounding text untouched.
+ */
+export const replaceDollarMath = (
+  source: string,
+  replacer: (match: DollarMathMatch) => string
+): string => {
+  const matches = findDollarMath(source);
+  if (matches.length === 0) return source;
+
+  let output = '';
+  let cursor = 0;
+  for (const match of matches) {
+    output += source.slice(cursor, match.start) + replacer(match);
+    cursor = match.end;
+  }
+  return output + source.slice(cursor);
+};
+
+/**
+ * Input-rule regex for `$$formula$$`, anchored at the caret so it fires the
+ * moment the closing delimiter is typed.
+ */
+export const BLOCK_INPUT_RULE = /\$\$([^$]+)\$\$$/;
+
+/**
+ * Input-rule regex for `$formula$`. The lookbehind keeps it from claiming the
+ * second `$` of a `$$` opener, so block math is never split into inline math.
+ */
+export const INLINE_INPUT_RULE = /(?<!\$)\$([^$\n]+)\$$/;

--- a/src/utils/latexMath.ts
+++ b/src/utils/latexMath.ts
@@ -124,7 +124,9 @@ export const looksLikeMath = (str: string): boolean => {
   if (LATEX_COMMAND_PATTERN.test(str)) return true;
   const words = str.match(/[a-zA-Z]{3,}/g);
   if (!words) return true;
-  const proseThreshold = /\d+[.,]\d/.test(str) ? 1 : 2;
+  // A single digit before the separator is enough to spot a decimal; `\d+`
+  // here only added super-linear backtracking on long digit runs.
+  const proseThreshold = /\d[.,]\d/.test(str) ? 1 : 2;
   return words.length < proseThreshold;
 };
 
@@ -162,14 +164,47 @@ const indexOfUnescaped = (
   return -1;
 };
 
+/** Reads a `$$...$$` region starting at `index`, or `null` if there is none. */
+const matchBlockMath = (
+  source: string,
+  index: number
+): DollarMathMatch | null => {
+  const close = indexOfUnescaped(source, '$$', index + 2);
+  if (close === -1) return null;
+
+  const latex = source.slice(index + 2, close);
+  if (!latex.trim()) return null;
+
+  return { start: index, end: close + 2, latex, display: true };
+};
+
+/**
+ * Reads a `$...$` region starting at `index`, or `null` when there is no
+ * closing delimiter or the pair is a currency/prose false positive.
+ */
+const matchInlineMath = (
+  source: string,
+  index: number
+): DollarMathMatch | null => {
+  const close = indexOfUnescaped(source, '$', index + 1);
+  if (close === -1) return null;
+
+  const latex = source.slice(index + 1, close);
+  if (!latex.trim()) return null;
+  if (isCurrencyDollar(source, index, latex)) return null;
+  if (!looksLikeMath(latex)) return null;
+
+  return { start: index, end: close + 1, latex, display: false };
+};
+
 /**
  * Scans `source` left to right and returns every dollar-delimited math region.
  *
  * `$$...$$` is always tested before `$...$`, which is what the old single regex
  * got wrong: it matched the inner `$x$` of `$$x$$` and left orphan dollars
- * behind. A rejected candidate (currency or prose) only advances the cursor by
- * one character, so a real formula later in the same sentence is still found —
- * consuming the whole rejected span would swallow it.
+ * behind. A rejected candidate (currency or prose) only advances the cursor
+ * past its opening delimiter, so a real formula later in the same sentence is
+ * still found — consuming the whole rejected span would swallow it.
  */
 export const findDollarMath = (source: string): DollarMathMatch[] => {
   const matches: DollarMathMatch[] = [];
@@ -186,31 +221,16 @@ export const findDollarMath = (source: string): DollarMathMatch[] => {
       continue;
     }
 
-    if (source.startsWith('$$', index)) {
-      const close = indexOfUnescaped(source, '$$', index + 2);
-      const latex = close === -1 ? '' : source.slice(index + 2, close);
-      if (close !== -1 && latex.trim()) {
-        matches.push({ start: index, end: close + 2, latex, display: true });
-        index = close + 2;
-      } else {
-        index += 2;
-      }
-      continue;
-    }
+    const isBlock = source.startsWith('$$', index);
+    const match = isBlock
+      ? matchBlockMath(source, index)
+      : matchInlineMath(source, index);
 
-    const close = indexOfUnescaped(source, '$', index + 1);
-    if (close === -1) break;
-
-    const latex = source.slice(index + 1, close);
-    if (
-      latex.trim() &&
-      !isCurrencyDollar(source, index, latex) &&
-      looksLikeMath(latex)
-    ) {
-      matches.push({ start: index, end: close + 1, latex, display: false });
-      index = close + 1;
+    if (match) {
+      matches.push(match);
+      index = match.end;
     } else {
-      index += 1;
+      index += isBlock ? 2 : 1;
     }
   }
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -371,6 +371,7 @@ export default defineConfig({
     'utils/calendarActivityUtils/index': 'src/utils/calendarActivityUtils.ts', // filterActivitiesFromDate, getActivityDateKey, getCalendarActivityStatus
     'utils/chatUtils/index': 'src/utils/chatUtils.ts', // getChatUserInfo, getChatWsUrl
     'utils/htmlLineBreaks/index': 'src/utils/htmlLineBreaks.ts', // normalizeLineBreaksInHtml
+    'utils/latexMath/index': 'src/utils/latexMath.ts', // buildMathSpan, findDollarMath, isCurrencyDollar, looksLikeMath, replaceDollarMath
     'utils/domainUtils/index': 'src/utils/domainUtils.ts', // resolveRootHostname, extractSubdomainSlug, buildLoginUrlWithReturnTo
     'utils/examFilterHelpers/index': 'src/utils/examFilterHelpers.ts', // EXAM_STATUS_OPTIONS
     'utils/lessonAvailabilityUtils/index':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inserting and editing both inline (`$...$`) and block (`$$...$$`) formulas.
  * Added a “Block formula” option with an updated preview in the formula dialog.
  * LaTeX formulas can now be recognized from typed or pasted content.
  * Preserved formulas when converting between editor content and rendered views.

* **Bug Fixes**
  * Improved handling of escaped characters, complex LaTeX, and existing math markup.
  * Prevented currency values such as `R$1,00` from being incorrectly interpreted as formulas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->