### PR TITLE
AE-2974 - fix(theme): complete papole-dark and restore Papolê's green primary

### DIFF
--- a/src/themes/papole/dark.css
+++ b/src/themes/papole/dark.css
@@ -1,22 +1,26 @@
 @layer base {
   /*
-   * Papolê (dark) — verde institucional, variante escura definida pela
-   * designer (não é derivada por nós).
+   * Papolê (dark) — verde institucional.
    *
-   * Assim como no light, a plataforma só define a rampa primary; os demais
-   * grupos são herdados dos defaults de ../tokens.css.
+   * Assim como no light, a plataforma define APENAS a rampa primary; todos os
+   * demais grupos vêm do enem-parana-dark, conforme a designer confirmou ("o
+   * Papolê só tem de diferente o primary, o resto puxa do enem paraná"). Aqui
+   * eles precisam ser DECLARADOS, não herdados: o `@theme` do ../tokens.css é a
+   * baseline LIGHT, então o que não estiver neste arquivo cai em valor claro.
    *
-   * Os passos 100–900 são idênticos ao light (a cor de marca continua
-   * reconhecível); dos extremos, `50` vira um tom escuro e `950` um tom claro
-   * — mesmo padrão de ../parana/dark.css.
+   * Era exatamente esse o bug: o arquivo tinha só os 12 tokens do primary, e
+   * com `data-theme="papole-dark"` ativo a página renderizava branca
+   * (`--color-background` = #fff, `--color-text` = #fefeff, bordas #e6e6e6) com
+   * o botão verde-claro do `primary-950` e texto branco por cima — 1.82:1.
+   * Os grupos abaixo são cópia literal de ../parana/dark.css.
    *
-   * DESVIO INTENCIONAL da tabela da designer: ela define "Papolê 0" do dark
-   * como #194D2A. O passo base não é só o topo da rampa — é o foreground de
-   * tudo que tem fundo `primary-800` (barra do AppHeader, ícones de sino,
+   * DESVIO INTENCIONAL: a tabela da designer define o "Papolê 0" do dark como
+   * #194D2A. O passo base não é só o topo da rampa — é o foreground de tudo que
+   * é pintado sobre `primary-800` (barra do AppHeader e os ícones de sino,
    * calendário e perfil). Como o `primary-800` do Papolê continua escuro no
-   * dark (#1f5e34), usar #194D2A daria contraste 1.27:1 e sumiria com o
-   * conteúdo da barra. Mantemos o base igual ao light, exatamente como
-   * parana/base fazem nos temas em que o header não inverte → 7.56:1.
+   * dark (#1f5e34), usar #194D2A daria 1.27:1 e sumiria com o conteúdo da
+   * barra. Mantemos o base igual ao do light, exatamente como parana/base fazem
+   * nos temas em que o header não inverte → 7.56:1. Ver themeContrast.test.ts.
    */
   [data-theme='papole-dark'] {
     color-scheme: dark;
@@ -34,5 +38,195 @@
     --color-primary-800: #1f5e34;
     --color-primary-900: #1c552f;
     --color-primary-950: #79d296;
+
+    /* Secondary Colors */
+    --color-secondary: #141414;
+    --color-secondary-50: #171717;
+    --color-secondary-100: #1f1f1f;
+    --color-secondary-200: #272727;
+    --color-secondary-300: #2c2c2c;
+    --color-secondary-400: #383939;
+    --color-secondary-500: #3f4040;
+    --color-secondary-600: #565656;
+    --color-secondary-700: #656565;
+    --color-secondary-800: #878787;
+    --color-secondary-900: #969696;
+    --color-secondary-950: #a4a4a4;
+
+    /* Tertiary Colors */
+    --color-tertiary: #543112;
+    --color-tertiary-50: #6c3d13;
+    --color-tertiary-100: #824917;
+    --color-tertiary-200: #b4621a;
+    --color-tertiary-300: #d7751f;
+    --color-tertiary-400: #e78128;
+    --color-tertiary-500: #fb9d4b;
+    --color-tertiary-600: #fdb474;
+    --color-tertiary-700: #fed1aa;
+    --color-tertiary-800: #ffe9d5;
+    --color-tertiary-900: #fff2e5;
+    --color-tertiary-950: #fffaf5;
+
+    /* Text Colors */
+    --color-text: #171717;
+    --color-text-50: #262627;
+    --color-text-100: #404040;
+    --color-text-200: #525252;
+    --color-text-300: #737373;
+    --color-text-400: #8c8c8c;
+    --color-text-500: #a3a3a3;
+    --color-text-600: #d4d4d4;
+    --color-text-700: #dbdbdc;
+    --color-text-800: #e5e5e5;
+    --color-text-900: #f5f5f5;
+    --color-text-950: #fefeff;
+
+    /* Background Colors */
+    --color-background: #121212;
+    --color-background-50: #272625;
+    --color-background-100: #414040;
+    --color-background-200: #535252;
+    --color-background-300: #747474;
+    --color-background-400: #8e8e8e;
+    --color-background-500: #a2a3a3;
+    --color-background-600: #d5d4d4;
+    --color-background-700: #e5e4e4;
+    --color-background-800: #f2f1f1;
+    --color-background-900: #f6f6f6;
+    --color-background-950: #ffffff;
+    --color-background-muted: #333333;
+
+    /* Border Colors */
+    --color-border: #1a1717;
+    --color-border-50: #272624;
+    --color-border-100: #414141;
+    --color-border-200: #535252;
+    --color-border-300: #737474;
+    --color-border-400: #8c8d8d;
+    --color-border-500: #a5a3a3;
+    --color-border-600: #d3d3d3;
+    --color-border-700: #dddcdb;
+    --color-border-800: #e6e6e6;
+    --color-border-900: #f3f3f3;
+    --color-border-950: #fdfefe;
+
+    /* Success Colors */
+    --color-success: #1b3224;
+    --color-success-50: #14532d;
+    --color-success-100: #166534;
+    --color-success-200: #206f3e;
+    --color-success-300: #2a7948;
+    --color-success-400: #348352;
+    --color-success-500: #489766;
+    --color-success-600: #66b584;
+    --color-success-700: #84d3a2;
+    --color-success-800: #a2f1c0;
+    --color-success-900: #caffe8;
+    --color-success-950: #e4fff4;
+    --color-success-background: #1c2b21;
+
+    /* Error Colors */
+    --color-error: #531313;
+    --color-error-50: #7f1d1d;
+    --color-error-100: #991b1b;
+    --color-error-200: #b91c1c;
+    --color-error-300: #dc2626;
+    --color-error-400: #e63535;
+    --color-error-500: #ef4444;
+    --color-error-600: #f96160;
+    --color-error-700: #e55b5a;
+    --color-error-800: #fecaca;
+    --color-error-900: #fee2e2;
+    --color-error-950: #fee9e9;
+    --color-error-background: #422b2b;
+
+    /* Warning Colors */
+    --color-warning: #542d12;
+    --color-warning-50: #6c3813;
+    --color-warning-100: #824417;
+    --color-warning-200: #b45a1a;
+    --color-warning-300: #d76c1f;
+    --color-warning-400: #e77828;
+    --color-warning-500: #fb954b;
+    --color-warning-600: #fdad74;
+    --color-warning-700: #fecdaa;
+    --color-warning-800: #ffe7d5;
+    --color-warning-900: #fff4ed;
+    --color-warning-950: #fff9f5;
+    --color-warning-background: #412f23;
+
+    /* Info Colors */
+    --color-info: #032638;
+    --color-info-50: #05405d;
+    --color-info-100: #075a83;
+    --color-info-200: #0973a8;
+    --color-info-300: #0b8dcd;
+    --color-info-400: #0da6f2;
+    --color-info-500: #32b4f4;
+    --color-info-600: #57c2f6;
+    --color-info-700: #7ccff8;
+    --color-info-800: #a2ddfa;
+    --color-info-900: #c7ebfc;
+    --color-info-950: #ecf8fe;
+    --color-info-background: #1a282e;
+
+    /* Indicator Colors */
+    --color-indicator-primary: #f7f7f7;
+    --color-indicator-info: #a1c7f5;
+    --color-indicator-error: #e84645;
+    --color-indicator-positive: #bc9406;
+    --color-indicator-negative: #d08181;
+
+    /* Subject and Exam Colors */
+    --color-exam-1: #125381;
+    --color-exam-2: #801973;
+    --color-exam-3: #b88c00;
+    --color-exam-4: #298a49;
+    --color-subject-1: #0066b8;
+    --color-subject-2: #b46108;
+    --color-subject-3: #2a8c8d;
+    --color-subject-4: #286137;
+    --color-subject-5: #5e8d17;
+    --color-subject-6: #3181ab;
+    --color-subject-7: #5d81b5;
+    --color-subject-8: #a31a3a;
+    --color-subject-9: #6f15b7;
+    --color-subject-10: #c0114f;
+    --color-subject-11: #bb9902;
+    --color-subject-12: #8a24a3;
+    --color-subject-13: #ae4323;
+    --color-subject-14: #9da319;
+    --color-subject-15: #688c93;
+    --color-subject-16: #4ea76f;
+    --color-typography-1: #fccff6;
+    --color-typography-2: #f9e5a4;
+
+    /* Question Type Colors */
+    --color-question-type-multiple-choice: #A855F7;
+    --color-question-type-fill-blank: #22D3EE;
+    --color-question-type-image: #EAB308;
+    --color-question-type-matching: #C084FC;
+
+    /* Map Choropleth Colors — diverging red→blue scale (0 = attention/red, 1 = highlight/blue) */
+    --color-map-highlight: #66b584;
+    --color-map-above-avg: #f8cc2e;
+    --color-map-below-avg: #fb954b;
+    --color-map-attention: #b91c1c;
+    --color-map-stroke-city: #ffffff;
+    --color-map-stroke-nre: #ffffff;
+
+    --color-map-unmanaged-region: #3f3f46;
+    /* Hard Shadow Colors */
+    --shadow-hard-shadow-1: -2px 2px 8px rgba(255, 255, 255, 0.1);
+    --shadow-hard-shadow-2: 0px 3px 10px rgba(255, 255, 255, 0.1);
+    --shadow-hard-shadow-3: 2px 2px 8px rgba(255, 255, 255, 0.1);
+    --shadow-hard-shadow-4: 0px -3px 10px rgba(255, 255, 255, 0.1);
+    --shadow-hard-shadow-5: 0px 2px 10px rgba(255, 255, 255, 0.05);
+
+    /* Soft Shadow Colors */
+    --shadow-soft-shadow-1: 0px 0px 10px rgba(255, 255, 255, 0.05);
+    --shadow-soft-shadow-2: 0px 0px 20px rgba(255, 255, 255, 0.05);
+    --shadow-soft-shadow-3: 0px 0px 30px rgba(255, 255, 255, 0.05);
+    --shadow-soft-shadow-4: 0px 0px 40px rgba(255, 255, 255, 0.1);
   }
 }

--- a/src/themes/papole/light.css
+++ b/src/themes/papole/light.css
@@ -1,15 +1,21 @@
 @layer base {
   /*
-   * Papolê (light) — primary âmbar/dourado + secondary verde institucional.
+   * Papolê (light) — verde institucional.
    *
-   * Grupos definidos pelo Papolê: primary, secondary, error, background e text
-   * (rampas 100–900 da designer). Os demais grupos (tertiary, border, success,
-   * warning, info, indicator, subject/exam, question-type, map e sombras) são
-   * herdados dos defaults de ../tokens.css de propósito.
+   * A plataforma usa APENAS uma rampa primary própria; todos os demais grupos
+   * (secondary, tertiary, text, background, border, success, error, warning,
+   * info, indicator, subject/exam, question-type, map e sombras) são herdados
+   * dos defaults de ../tokens.css de propósito — que é exatamente o que o
+   * enem-parana-light usa nesses grupos (conferido: os valores batem 1:1).
    *
-   * Observação: a designer forneceu só 100–900 destes grupos; os passos base
-   * (sem sufixo), 50, 950 e variantes especiais (ex.: -background, -muted)
-   * continuam herdados de ../tokens.css.
+   * Mapeamento: o token "Papolê 0" da designer corresponde ao passo base da
+   * lib (`--color-primary`, sem sufixo); 50–950 são 1:1.
+   *
+   * O commit 046517a5 tinha trocado esta rampa por âmbar e adicionado rampas
+   * próprias de secondary/error/background/text. Ambas as coisas foram
+   * revertidas: o âmbar pintava de amarelo a barra do header e os botões
+   * sólidos do produto inteiro, e a designer confirmou que o Papolê difere
+   * do enem-paraná só no primary.
    */
   [data-theme='papole-light'] {
     color-scheme: light;
@@ -17,59 +23,15 @@
     /* Primary Colors — verde Papolê */
     --color-primary: #f9fdfb;
     --color-primary-50: #ceefd9;
-    --color-primary-100: #FEF8E6;
-    --color-primary-200: #FDEFC4;
-    --color-primary-300: #FCE397;
-    --color-primary-400: #FAD561;
-    --color-primary-500: #F9CB3B;
-    --color-primary-600: #F5BC08;
-    --color-primary-700: #C29506;
-    --color-primary-800: #8F6E04;
-    --color-primary-900: #604903;
+    --color-primary-100: #a4e1b7;
+    --color-primary-200: #79d296;
+    --color-primary-300: #4ec474;
+    --color-primary-400: #36a35a;
+    --color-primary-500: #287842;
+    --color-primary-600: #256f3d;
+    --color-primary-700: #226738;
+    --color-primary-800: #1f5e34;
+    --color-primary-900: #1c552f;
     --color-primary-950: #194d2a;
-
-    /* Secondary Colors — verde Papolê */
-    --color-secondary-100: #ECF9F0;
-    --color-secondary-200: #D1F0DB;
-    --color-secondary-300: #AFE4C0;
-    --color-secondary-400: #85D69F;
-    --color-secondary-500: #287842;
-    --color-secondary-600: #216236;
-    --color-secondary-700: #1A4E2B;
-    --color-secondary-800: #133A20;
-    --color-secondary-900: #0D2615;
-
-    /* Error Colors */
-    --color-error-100: #FCEEEF;
-    --color-error-200: #F7D6DA;
-    --color-error-300: #F3BFC5;
-    --color-error-400: #EEA7AF;
-    --color-error-500: #EA909A;
-    --color-error-600: #DE5261;
-    --color-error-700: #C12536;
-    --color-error-800: #831925;
-    --color-error-900: #450D13;
-
-    /* Background Colors */
-    --color-background-100: #FCFBF8;
-    --color-background-200: #F9F8F2;
-    --color-background-300: #F6F5EC;
-    --color-background-400: #F4F1E6;
-    --color-background-500: #F1EEE0;
-    --color-background-600: #D2C99C;
-    --color-background-700: #B4A458;
-    --color-background-800: #756A35;
-    --color-background-900: #312C16;
-
-    /* Text Colors */
-    --color-text-100: #F8F8F7;
-    --color-text-200: #ECEBE9;
-    --color-text-300: #D9D8D4;
-    --color-text-400: #BCBAB3;
-    --color-text-500: #9A988D;
-    --color-text-600: #7C7A6E;
-    --color-text-700: #5F5D54;
-    --color-text-800: #41403A;
-    --color-text-900: #262522;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Papolê dark theme with comprehensive color definitions for backgrounds, text, borders, status indicators, typography, maps, shadows, and other interface elements.
  - Refined dark-theme contrast behavior for improved visual consistency.
  - Updated the Papolê light theme to use a green primary color palette.
  - Simplified light-theme styling by using shared defaults for secondary, error, background, and text colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->