### PR TITLE
fix(categoryDataUtils): filter out inactive students

### DIFF
--- a/src/utils/categoryDataUtils.test.ts
+++ b/src/utils/categoryDataUtils.test.ts
@@ -258,7 +258,7 @@ describe('categoryDataUtils', () => {
     it('should keep students whose active flag is missing', async () => {
       // A response without the field must not hide the whole class: only an
       // explicit `active: false` removes a student.
-      const studentWithoutFlag = {
+      const studentWithoutFlag: Student = {
         id: 'student-1',
         name: 'Sem flag',
         email: 'semflag@example.com',
@@ -270,7 +270,7 @@ describe('categoryDataUtils', () => {
         school: { id: 'school-1', name: 'School 1' },
         schoolYear: { id: 'year-1', name: '2024' },
         class: { id: 'class-1', name: 'Class A' },
-      } as unknown as Student;
+      };
 
       const apiClient = createMockApiClient({
         post: jest.fn().mockResolvedValue({

--- a/src/utils/categoryDataUtils.test.ts
+++ b/src/utils/categoryDataUtils.test.ts
@@ -214,6 +214,79 @@ describe('categoryDataUtils', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('should drop inactive students from the result', async () => {
+      const activeStudent: Student = {
+        id: 'student-1',
+        name: 'Ativa',
+        email: 'ativa@example.com',
+        active: true,
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+        userInstitutionId: 'ui-1',
+        institutionId: 'inst-1',
+        profileId: 'profile-1',
+        school: { id: 'school-1', name: 'School 1' },
+        schoolYear: { id: 'year-1', name: '2024' },
+        class: { id: 'class-1', name: 'Class A' },
+      };
+      const inactiveStudent: Student = {
+        ...activeStudent,
+        id: 'student-2',
+        name: 'Inativo',
+        email: 'inativo@example.com',
+        active: false,
+        userInstitutionId: 'ui-2',
+      };
+
+      const apiClient = createMockApiClient({
+        post: jest.fn().mockResolvedValue({
+          data: {
+            message: 'Success',
+            data: { students: [activeStudent, inactiveStudent] },
+          },
+        }),
+      });
+
+      const result = await fetchStudentsByFilters(apiClient, {
+        classIds: ['class-1'],
+      });
+
+      expect(result).toEqual([activeStudent]);
+    });
+
+    it('should keep students whose active flag is missing', async () => {
+      // A response without the field must not hide the whole class: only an
+      // explicit `active: false` removes a student.
+      const studentWithoutFlag = {
+        id: 'student-1',
+        name: 'Sem flag',
+        email: 'semflag@example.com',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+        userInstitutionId: 'ui-1',
+        institutionId: 'inst-1',
+        profileId: 'profile-1',
+        school: { id: 'school-1', name: 'School 1' },
+        schoolYear: { id: 'year-1', name: '2024' },
+        class: { id: 'class-1', name: 'Class A' },
+      } as unknown as Student;
+
+      const apiClient = createMockApiClient({
+        post: jest.fn().mockResolvedValue({
+          data: {
+            message: 'Success',
+            data: { students: [studentWithoutFlag] },
+          },
+        }),
+      });
+
+      const result = await fetchStudentsByFilters(apiClient, {
+        classIds: ['class-1'],
+      });
+
+      expect(result).toEqual([studentWithoutFlag]);
+    });
   });
 
   describe('loadCategoriesData', () => {

--- a/src/utils/categoryDataUtils.ts
+++ b/src/utils/categoryDataUtils.ts
@@ -34,7 +34,12 @@ export interface Student {
   id: string;
   email: string;
   name: string;
-  active: boolean;
+  /**
+   * Opcional porque a resposta de `/students/filters` nem sempre traz o campo
+   * (deploy antigo, projeção parcial). Quem consome deve tratar a ausência como
+   * "não se sabe" — veja o `!== false` em `fetchStudentsByFilters`.
+   */
+  active?: boolean;
   createdAt: string;
   updatedAt: string;
   userInstitutionId: string;

--- a/src/utils/categoryDataUtils.ts
+++ b/src/utils/categoryDataUtils.ts
@@ -107,7 +107,13 @@ export async function fetchStudentsByFilters(
       }),
   });
 
-  return response.data.data.students || [];
+  // Só aluno ativo pode receber atividade/aula recomendada/aviso, então um aluno
+  // desativado não deve sequer aparecer na lista de destinatários. O teste é
+  // `!== false` (e não `=== true`) para que uma resposta sem o campo não esconda
+  // a turma inteira: apenas quem o backend afirma estar inativo é removido.
+  return (response.data.data.students || []).filter(
+    (student) => student.active !== false
+  );
 }
 
 /**

--- a/src/utils/studentTypes.ts
+++ b/src/utils/studentTypes.ts
@@ -6,7 +6,12 @@ export interface StudentWithNestedData {
   id: string;
   email: string;
   name: string;
-  active: boolean;
+  /**
+   * Opcional pelo mesmo motivo do `Student` em `categoryDataUtils`: a resposta
+   * de `/students/filters` nem sempre traz o campo, e os dois tipos descrevem o
+   * mesmo payload — se um exigir e o outro não, deixam de ser atribuíveis.
+   */
+  active?: boolean;
   createdAt: string;
   updatedAt: string;
   userInstitutionId: string;


### PR DESCRIPTION
## O que muda

`fetchStudentsByFilters` passa a filtrar alunos inativos antes de devolver a lista de destinatários.

Apenas aluno ativo pode receber atividade, aula recomendada ou aviso, então um aluno desativado não deve sequer aparecer na lista. O teste é `!== false` (e não `=== true`) para que uma resposta sem o campo não esconda a turma inteira — só é removido quem o backend afirma estar inativo.

## Contexto

Esse commit tinha ido direto pro `main` por engano (publicado como v1.5.46) e foi revertido em `b9e927c4`. Este PR reintroduz a mudança pelo fluxo normal de review.

## Testes

Cobertura adicionada em `src/utils/categoryDataUtils.test.ts` para aluno inativo, aluno sem o campo `active` e lista vazia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inactive students are now excluded from filtered student results.
  * Students without an activity status continue to appear as expected.

* **Tests**
  * Added coverage to verify filtering behavior for inactive and unspecified student statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->