### PR TITLE
AE-2953: add image resizing to questions creation/editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@tiptap/core": "^3.0.0",
     "@tiptap/extension-color": "^3.0.0",
     "@tiptap/extension-highlight": "^3.0.0",
-    "@tiptap/extension-image": "^3.0.0",
+    "@tiptap/extension-image": "^3.24.0",
     "@tiptap/extension-link": "^3.0.0",
     "@tiptap/extension-placeholder": "^3.0.0",
     "@tiptap/extension-subscript": "^3.0.0",

--- a/src/components/RichEditor/RichEditor.test.tsx
+++ b/src/components/RichEditor/RichEditor.test.tsx
@@ -41,6 +41,13 @@ interface MockChainResult {
   run: jest.Mock;
 }
 
+/**
+ * Every chained call returns a brand new mock, so the per-instance `setImage`
+ * spy is unreachable from a test. This shared spy records the arguments the
+ * editor was actually asked to insert.
+ */
+const setImageSpy = jest.fn();
+
 const createMockChain = (): MockChainResult => ({
   focus: jest.fn(() => createMockChain()),
   toggleBold: jest.fn(() => createMockChain()),
@@ -59,7 +66,10 @@ const createMockChain = (): MockChainResult => ({
   extendMarkRange: jest.fn(() => createMockChain()),
   setLink: jest.fn(() => createMockChain()),
   unsetLink: jest.fn(() => createMockChain()),
-  setImage: jest.fn(() => createMockChain()),
+  setImage: jest.fn((options: Record<string, unknown>) => {
+    setImageSpy(options);
+    return createMockChain();
+  }),
   insertContent: jest.fn(() => createMockChain()),
   setContent: jest.fn(() => createMockChain()),
   run: jest.fn(),
@@ -444,11 +454,40 @@ describe('RichEditor', () => {
 });
 
 describe('Imagem', () => {
+  /**
+   * The dialog measures the image before inserting it, and jsdom never loads
+   * one. This stub settles the measurement synchronously so the tests do not
+   * wait on the internal timeout.
+   */
+  let stubbedNaturalWidth: number | null = null;
+  const originalImage = globalThis.Image;
+
   beforeEach(() => {
     jest.clearAllMocks();
     // An earlier test sets useEditor to null to cover the "no editor" branch,
     // and mockReturnValue survives clearAllMocks.
     (useEditor as jest.Mock).mockReturnValue(mockEditor);
+
+    stubbedNaturalWidth = null;
+    class FakeImage {
+      naturalWidth = 0;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_value: string) {
+        if (stubbedNaturalWidth === null) {
+          this.onerror?.();
+          return;
+        }
+        this.naturalWidth = stubbedNaturalWidth;
+        this.onload?.();
+      }
+    }
+    globalThis.Image = FakeImage as unknown as typeof globalThis.Image;
+  });
+
+  afterEach(() => {
+    globalThis.Image = originalImage;
   });
 
   it('deve abrir o ImageDialog ao clicar no botão de imagem', () => {
@@ -472,13 +511,15 @@ describe('Imagem', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('deve inserir a imagem no editor ao confirmar uma URL', () => {
-    render(<RichEditor />);
-
+  /**
+   * Fills the dialog with a URL and confirms it.
+   * @param url - Image URL to type into the dialog
+   */
+  const insertUrl = (url: string) => {
     fireEvent.click(screen.getByTitle('Inserir imagem'));
     fireEvent.change(
       screen.getByPlaceholderText('https://exemplo.com/imagem.png'),
-      { target: { value: 'https://cdn.exemplo.com/a.png' } }
+      { target: { value: url } }
     );
     // The toolbar button carries the same accessible name, so scope the query
     // to the dialog.
@@ -487,11 +528,46 @@ describe('Imagem', () => {
         name: 'Inserir imagem',
       })
     );
+  };
 
-    expect(mockEditor.chain).toHaveBeenCalled();
+  it('deve inserir a imagem no editor ao confirmar uma URL', async () => {
+    render(<RichEditor />);
+
+    insertUrl('https://cdn.exemplo.com/a.png');
+
+    await waitFor(() => expect(mockEditor.chain).toHaveBeenCalled());
     expect(
       screen.queryByRole('heading', { name: 'Inserir imagem' })
     ).not.toBeInTheDocument();
+  });
+
+  it('deve inserir sem largura quando a imagem já cabe no padrão', async () => {
+    stubbedNaturalWidth = 320;
+    render(<RichEditor />);
+
+    insertUrl('https://cdn.exemplo.com/pequena.png');
+
+    await waitFor(() =>
+      expect(setImageSpy).toHaveBeenCalledWith({
+        src: 'https://cdn.exemplo.com/pequena.png',
+        alt: '',
+      })
+    );
+  });
+
+  it('deve inserir com largura limitada quando a imagem é muito grande', async () => {
+    stubbedNaturalWidth = 1600;
+    render(<RichEditor />);
+
+    insertUrl('https://cdn.exemplo.com/enem.png');
+
+    await waitFor(() =>
+      expect(setImageSpy).toHaveBeenCalledWith({
+        src: 'https://cdn.exemplo.com/enem.png',
+        alt: '',
+        width: 640,
+      })
+    );
   });
 });
 

--- a/src/components/RichEditor/RichEditorCore.tsx
+++ b/src/components/RichEditor/RichEditorCore.tsx
@@ -136,9 +136,13 @@ export function RichEditor({
     setFormulaOpen(false);
   };
 
-  const insertImage = (src: string, alt: string) => {
+  const insertImage = (src: string, alt: string, width?: number) => {
     if (!src || !editor) return;
-    editor.chain().focus().setImage({ src, alt }).run();
+    editor
+      .chain()
+      .focus()
+      .setImage({ src, alt, ...(width ? { width } : {}) })
+      .run();
     setImageOpen(false);
   };
 
@@ -154,8 +158,14 @@ export function RichEditor({
 
   if (!editor) return null;
 
+  // `data-analytica-rich-editor` scopes the image resize handle styles shipped
+  // in the library's global stylesheet, so they cannot leak into another Tiptap
+  // instance living in the consumer app.
   return (
-    <div className="border border-border-200 rounded-xl overflow-hidden bg-background-0">
+    <div
+      data-analytica-rich-editor
+      className="border border-border-200 rounded-xl overflow-hidden bg-background-0"
+    >
       {/* Toolbar */}
       <div className="flex items-center gap-0.5 border-b border-border-200 bg-background-50 px-2 py-1.5 flex-wrap">
         {/* Headings */}

--- a/src/components/RichEditor/components/ImageDialog.test.tsx
+++ b/src/components/RichEditor/components/ImageDialog.test.tsx
@@ -377,6 +377,32 @@ describe('ImageDialog', () => {
       expect(onInsert).not.toHaveBeenCalled();
     });
 
+    it('não deve inserir duas vezes ao confirmar a URL durante a medição', async () => {
+      deferImageLoad = true;
+      stubbedNaturalWidth = 1600;
+      const { onInsert } = setup();
+
+      fireEvent.change(
+        screen.getByPlaceholderText('https://exemplo.com/imagem.png'),
+        { target: { value: 'https://cdn.exemplo.com/lenta.png' } }
+      );
+      const confirmar = screen.getByRole('button', { name: 'Inserir imagem' });
+      // O botão fica desabilitado durante a medição, então cliques repetidos
+      // não podem inserir a mesma imagem de novo.
+      fireEvent.click(confirmar);
+      fireEvent.click(confirmar);
+      expect(confirmar).toBeDisabled();
+      fireEvent.click(confirmar);
+
+      settlePendingImages();
+      await waitFor(() => expect(onInsert).toHaveBeenCalledTimes(1));
+      expect(onInsert).toHaveBeenCalledWith(
+        'https://cdn.exemplo.com/lenta.png',
+        '',
+        640
+      );
+    });
+
     it('não deve inserir a URL se o diálogo for fechado durante a medição', async () => {
       deferImageLoad = true;
       stubbedNaturalWidth = 1600;

--- a/src/components/RichEditor/components/ImageDialog.test.tsx
+++ b/src/components/RichEditor/components/ImageDialog.test.tsx
@@ -22,6 +22,37 @@ const imageFile = (name = 'foto.png', size = 1024) => {
   return file;
 };
 
+/**
+ * jsdom never loads images, so the natural-width measurement would sit on its
+ * timeout in every test. This stub decides the outcome synchronously when the
+ * dialog assigns `src`.
+ */
+let stubbedNaturalWidth: number | null = null;
+const originalImage = globalThis.Image;
+
+beforeEach(() => {
+  stubbedNaturalWidth = null;
+  class FakeImage {
+    naturalWidth = 0;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    set src(_value: string) {
+      if (stubbedNaturalWidth === null) {
+        this.onerror?.();
+        return;
+      }
+      this.naturalWidth = stubbedNaturalWidth;
+      this.onload?.();
+    }
+  }
+  globalThis.Image = FakeImage as unknown as typeof globalThis.Image;
+});
+
+afterEach(() => {
+  globalThis.Image = originalImage;
+});
+
 describe('ImageDialog', () => {
   it('deve expor o limite de 5MB alinhado ao backend', () => {
     expect(MAX_IMAGE_SIZE).toBe(5 * 1024 * 1024);
@@ -35,7 +66,7 @@ describe('ImageDialog', () => {
       expect(screen.queryByText('Enviar arquivo')).not.toBeInTheDocument();
     });
 
-    it('deve inserir a URL digitada', () => {
+    it('deve inserir a URL digitada', async () => {
       const { onInsert } = setup();
 
       fireEvent.change(
@@ -44,9 +75,12 @@ describe('ImageDialog', () => {
       );
       fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
 
-      expect(onInsert).toHaveBeenCalledWith(
-        'https://cdn.exemplo.com/foto.png',
-        ''
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/foto.png',
+          '',
+          undefined
+        )
       );
     });
 
@@ -77,10 +111,83 @@ describe('ImageDialog', () => {
       await waitFor(() =>
         expect(onInsert).toHaveBeenCalledWith(
           'https://cdn.exemplo.com/enviada.png',
-          ''
+          '',
+          undefined
         )
       );
       expect(onUploadImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('deve limitar a largura na inserção quando a imagem é maior que o padrão', async () => {
+      stubbedNaturalWidth = 1600;
+      const onUploadImage = jest
+        .fn()
+        .mockResolvedValue('https://cdn.exemplo.com/enem.png');
+      const { onInsert } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/enem.png',
+          '',
+          640
+        )
+      );
+    });
+
+    it('não deve definir largura quando a imagem já cabe no padrão', async () => {
+      stubbedNaturalWidth = 320;
+      const onUploadImage = jest
+        .fn()
+        .mockResolvedValue('https://cdn.exemplo.com/pequena.png');
+      const { onInsert } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/pequena.png',
+          '',
+          undefined
+        )
+      );
+    });
+
+    it('deve inserir sem largura quando a medição falha', async () => {
+      // stubbedNaturalWidth continua null: a imagem dispara onerror.
+      const onUploadImage = jest
+        .fn()
+        .mockResolvedValue('https://cdn.exemplo.com/inacessivel.png');
+      const { onInsert } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/inacessivel.png',
+          '',
+          undefined
+        )
+      );
     });
 
     it('deve exibir erro e não inserir quando o upload falha', async () => {
@@ -113,7 +220,7 @@ describe('ImageDialog', () => {
       expect(onUploadImage).not.toHaveBeenCalled();
     });
 
-    it('deve permitir alternar para o modo URL', () => {
+    it('deve permitir alternar para o modo URL', async () => {
       const onUploadImage = jest.fn();
       const { onInsert } = setup({ onUploadImage });
 
@@ -124,9 +231,12 @@ describe('ImageDialog', () => {
       );
       fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
 
-      expect(onInsert).toHaveBeenCalledWith(
-        'https://cdn.exemplo.com/url.png',
-        ''
+      await waitFor(() =>
+        expect(onInsert).toHaveBeenCalledWith(
+          'https://cdn.exemplo.com/url.png',
+          '',
+          undefined
+        )
       );
       expect(onUploadImage).not.toHaveBeenCalled();
     });
@@ -152,7 +262,8 @@ describe('ImageDialog', () => {
       await waitFor(() =>
         expect(onInsert).toHaveBeenCalledWith(
           'https://cdn.exemplo.com/enviada.png',
-          'Gráfico de barras'
+          'Gráfico de barras',
+          undefined
         )
       );
     });

--- a/src/components/RichEditor/components/ImageDialog.test.tsx
+++ b/src/components/RichEditor/components/ImageDialog.test.tsx
@@ -28,22 +28,41 @@ const imageFile = (name = 'foto.png', size = 1024) => {
  * dialog assigns `src`.
  */
 let stubbedNaturalWidth: number | null = null;
+/** When true the measurement stays pending until `settlePendingImages` runs. */
+let deferImageLoad = false;
+let pendingImages: { settle: () => void }[] = [];
 const originalImage = globalThis.Image;
+
+const settlePendingImages = () => {
+  pendingImages.forEach((image) => image.settle());
+  pendingImages = [];
+};
 
 beforeEach(() => {
   stubbedNaturalWidth = null;
+  deferImageLoad = false;
+  pendingImages = [];
+
   class FakeImage {
     naturalWidth = 0;
     onload: (() => void) | null = null;
     onerror: (() => void) | null = null;
 
-    set src(_value: string) {
+    private settleNow() {
       if (stubbedNaturalWidth === null) {
         this.onerror?.();
         return;
       }
       this.naturalWidth = stubbedNaturalWidth;
       this.onload?.();
+    }
+
+    set src(_value: string) {
+      if (deferImageLoad) {
+        pendingImages.push({ settle: () => this.settleNow() });
+        return;
+      }
+      this.settleNow();
     }
   }
   globalThis.Image = FakeImage as unknown as typeof globalThis.Image;
@@ -356,6 +375,50 @@ describe('ImageDialog', () => {
       await waitFor(() => expect(onUploadImage).toHaveBeenCalled());
 
       expect(onInsert).not.toHaveBeenCalled();
+    });
+
+    it('não deve inserir a URL se o diálogo for fechado durante a medição', async () => {
+      deferImageLoad = true;
+      stubbedNaturalWidth = 1600;
+      const { onInsert, onClose } = setup();
+
+      fireEvent.change(
+        screen.getByPlaceholderText('https://exemplo.com/imagem.png'),
+        { target: { value: 'https://cdn.exemplo.com/lenta.png' } }
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalled();
+
+      settlePendingImages();
+      await waitFor(() => expect(onInsert).not.toHaveBeenCalled());
+    });
+
+    it('não deve inserir o upload se o diálogo for fechado durante a medição', async () => {
+      deferImageLoad = true;
+      stubbedNaturalWidth = 1600;
+      const onUploadImage = jest
+        .fn()
+        .mockResolvedValue('https://cdn.exemplo.com/enviada.png');
+      const { onInsert, onClose } = setup({ onUploadImage });
+
+      selectFile(imageFile());
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: 'Inserir imagem' })
+        ).toBeEnabled()
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Inserir imagem' }));
+
+      // Espera o upload resolver e a medição ficar pendente.
+      await waitFor(() => expect(pendingImages).toHaveLength(1));
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalled();
+
+      settlePendingImages();
+      await waitFor(() => expect(onInsert).not.toHaveBeenCalled());
     });
 
     it('não deve exibir erro de upload após o fechamento', async () => {

--- a/src/components/RichEditor/components/ImageDialog.tsx
+++ b/src/components/RichEditor/components/ImageDialog.tsx
@@ -6,6 +6,7 @@ import Modal from '../../Modal/Modal';
 import Text from '../../Text/Text';
 import { LinkIcon } from '@phosphor-icons/react/dist/csr/Link';
 import { UploadSimpleIcon } from '@phosphor-icons/react/dist/csr/UploadSimple';
+import { DEFAULT_MAX_INSERT_WIDTH, measureNaturalWidth } from './imageSize';
 
 /**
  * Matches the 5MB cap enforced by the backend pre-signed URL schema.
@@ -18,7 +19,7 @@ type InputMode = 'file' | 'url';
 interface ImageDialogProps {
   readonly open: boolean;
   readonly onClose: () => void;
-  readonly onInsert: (src: string, alt: string) => void;
+  readonly onInsert: (src: string, alt: string, width?: number) => void;
   /**
    * Optional callback to upload an image file and get back its public URL.
    * If provided, the file upload tab is enabled; otherwise only URL input is
@@ -84,10 +85,31 @@ export function ImageDialog({
     setError('');
   };
 
+  /**
+   * Resolves the width to insert with. Exam board images are uploaded at their
+   * original scan resolution, so anything wider than the default cap is clamped
+   * up front. Images already within the cap get no width attribute at all,
+   * leaving existing content untouched.
+   * @param src - Public URL of the image about to be inserted
+   * @returns The width in pixels, or undefined when no clamping is needed
+   */
+  const resolveInsertWidth = async (
+    src: string
+  ): Promise<number | undefined> => {
+    const naturalWidth = await measureNaturalWidth(src);
+    return naturalWidth && naturalWidth > DEFAULT_MAX_INSERT_WIDTH
+      ? DEFAULT_MAX_INSERT_WIDTH
+      : undefined;
+  };
+
   const handleInsert = async () => {
     if (inputMode === 'url') {
-      if (!url.trim()) return;
-      onInsert(url.trim(), alt.trim());
+      const trimmedUrl = url.trim();
+      if (!trimmedUrl) return;
+      const token = uploadTokenRef.current;
+      const width = await resolveInsertWidth(trimmedUrl);
+      if (token !== uploadTokenRef.current) return;
+      onInsert(trimmedUrl, alt.trim(), width);
       resetState();
       return;
     }
@@ -103,7 +125,9 @@ export function ImageDialog({
       // which would break as soon as the page unloads.
       const uploadedUrl = await onUploadImage(file);
       if (token !== uploadTokenRef.current) return;
-      onInsert(uploadedUrl, alt.trim());
+      const width = await resolveInsertWidth(uploadedUrl);
+      if (token !== uploadTokenRef.current) return;
+      onInsert(uploadedUrl, alt.trim(), width);
       resetState();
     } catch (err) {
       if (token !== uploadTokenRef.current) return;

--- a/src/components/RichEditor/components/ImageDialog.tsx
+++ b/src/components/RichEditor/components/ImageDialog.tsx
@@ -43,9 +43,17 @@ export function ImageDialog({
   const [url, setUrl] = useState('');
   const [alt, setAlt] = useState('');
   const [isUploading, setIsUploading] = useState(false);
+  /**
+   * True while the image is being measured. The URL branch has no upload to
+   * wait on, so without this the confirm button would stay enabled during the
+   * measurement and a second click would insert the same image twice.
+   */
+  const [isMeasuring, setIsMeasuring] = useState(false);
   const [error, setError] = useState('');
   /** Bumped on close so a resolving upload can tell it has been superseded. */
   const uploadTokenRef = useRef(0);
+
+  const isBusy = isUploading || isMeasuring;
 
   const resetState = () => {
     setInputMode(onUploadImage ? 'file' : 'url');
@@ -53,6 +61,7 @@ export function ImageDialog({
     setUrl('');
     setAlt('');
     setIsUploading(false);
+    setIsMeasuring(false);
     setError('');
   };
 
@@ -102,15 +111,29 @@ export function ImageDialog({
       : undefined;
   };
 
+  /** Inserts an image already available at `src`, measuring it first. */
+  const insertMeasured = async (src: string) => {
+    const token = uploadTokenRef.current;
+    const width = await resolveInsertWidth(src);
+    if (token !== uploadTokenRef.current) return;
+    onInsert(src, alt.trim(), width);
+    resetState();
+  };
+
   const handleInsert = async () => {
     if (inputMode === 'url') {
       const trimmedUrl = url.trim();
       if (!trimmedUrl) return;
-      const token = uploadTokenRef.current;
-      const width = await resolveInsertWidth(trimmedUrl);
-      if (token !== uploadTokenRef.current) return;
-      onInsert(trimmedUrl, alt.trim(), width);
-      resetState();
+
+      // Marked busy before the first await so the confirm button is disabled
+      // while measuring — otherwise a second click would insert the same image
+      // twice, since the URL branch has no upload to keep it disabled.
+      setIsMeasuring(true);
+      try {
+        await insertMeasured(trimmedUrl);
+      } finally {
+        setIsMeasuring(false);
+      }
       return;
     }
 
@@ -125,10 +148,7 @@ export function ImageDialog({
       // which would break as soon as the page unloads.
       const uploadedUrl = await onUploadImage(file);
       if (token !== uploadTokenRef.current) return;
-      const width = await resolveInsertWidth(uploadedUrl);
-      if (token !== uploadTokenRef.current) return;
-      onInsert(uploadedUrl, alt.trim(), width);
-      resetState();
+      await insertMeasured(uploadedUrl);
     } catch (err) {
       if (token !== uploadTokenRef.current) return;
       setError(err instanceof Error ? err.message : 'Erro ao enviar a imagem.');
@@ -158,7 +178,7 @@ export function ImageDialog({
             variant="solid"
             action="primary"
             onClick={handleInsert}
-            disabled={!canInsert || isUploading}
+            disabled={!canInsert || isBusy}
           >
             {isUploading ? 'Enviando...' : 'Inserir imagem'}
           </Button>

--- a/src/components/RichEditor/components/extensions.test.ts
+++ b/src/components/RichEditor/components/extensions.test.ts
@@ -1,6 +1,7 @@
-import { generateHTML, generateJSON } from '@tiptap/core';
+import { generateHTML, generateJSON, Node } from '@tiptap/core';
 import { createRichEditorExtensions } from './extensions';
 import { normalizeLineBreaksInHtml, processLatexInHtml } from './utils';
+import { MIN_IMAGE_HEIGHT, MIN_IMAGE_WIDTH } from './imageSize';
 
 /**
  * These tests exercise the real Tiptap schema (not a mock) because the bug they
@@ -144,6 +145,77 @@ describe('createRichEditorExtensions', () => {
       expect(html).toContain('<ul>');
       expect(html).toContain('um');
       expect(html).toContain('dois');
+    });
+  });
+});
+
+describe('configuração de redimensionamento da imagem', () => {
+  const imageExtension = extensions.find(
+    (extension) => extension.name === 'image'
+  ) as Node;
+
+  it('deve habilitar as alças de redimensionamento', () => {
+    const { resize } = imageExtension.options;
+
+    expect(resize).toEqual({
+      enabled: true,
+      directions: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
+      minWidth: MIN_IMAGE_WIDTH,
+      minHeight: MIN_IMAGE_HEIGHT,
+      alwaysPreserveAspectRatio: true,
+    });
+  });
+
+  it('deve travar a proporção e recusar base64', () => {
+    expect(imageExtension.options.allowBase64).toBe(false);
+    expect(imageExtension.options.inline).toBe(false);
+  });
+
+  describe('node view tolerante a imagem quebrada', () => {
+    /**
+     * Invokes the extension's addNodeView with a controlled parent, since a
+     * real editor view cannot be instantiated under jsdom.
+     * @param parentNodeView - Stand-in for the upstream resizable node view
+     * @returns Whatever the extension's node view factory produced
+     */
+    const buildNodeView = (parentNodeView: unknown) => {
+      const factory = imageExtension.config.addNodeView?.call({
+        parent: () => parentNodeView,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return factory ? (factory as any)({}) : null;
+    };
+
+    it('não deve montar node view quando o pai não existe', () => {
+      expect(buildNodeView(undefined)).toBeNull();
+    });
+
+    it('deve devolver o node view do pai quando o dom não é um elemento', () => {
+      const parentResult = { dom: document.createTextNode('x') };
+
+      expect(buildNodeView(() => parentResult)).toBe(parentResult);
+    });
+
+    it('deve revelar o container quando a imagem falha ao carregar', () => {
+      const container = document.createElement('div');
+      const image = document.createElement('img');
+      container.appendChild(image);
+      // Estado inicial do node view do Tiptap: escondido até o load.
+      container.style.visibility = 'hidden';
+      container.style.pointerEvents = 'none';
+
+      buildNodeView(() => ({ dom: container }));
+      image.dispatchEvent(new Event('error'));
+
+      expect(container.style.visibility).toBe('');
+      expect(container.style.pointerEvents).toBe('');
+    });
+
+    it('não deve quebrar quando o container não tem imagem', () => {
+      const container = document.createElement('div');
+
+      expect(() => buildNodeView(() => ({ dom: container }))).not.toThrow();
     });
   });
 });

--- a/src/components/RichEditor/components/extensions.test.ts
+++ b/src/components/RichEditor/components/extensions.test.ts
@@ -50,6 +50,78 @@ describe('createRichEditorExtensions', () => {
     });
   });
 
+  describe('largura das imagens', () => {
+    it('deve preservar a largura definida pelo autor', () => {
+      const html = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" width="400">'
+      );
+
+      expect(html).toContain('width="400"');
+    });
+
+    it('deve normalizar largura com unidade px para um número', () => {
+      const html = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" width="400px">'
+      );
+
+      // O node view concatena "px" no valor guardado, então "400px" viraria
+      // "400pxpx" se o atributo entrasse cru no schema.
+      expect(html).toContain('width="400"');
+      expect(html).not.toContain('400px');
+    });
+
+    it('deve descartar largura percentual sem perder a imagem', () => {
+      const html = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" width="50%">'
+      );
+
+      expect(html).toContain('https://cdn.exemplo.com/foto.png');
+      expect(html).not.toContain('width=');
+    });
+
+    it('deve ler a largura do style inline quando não há atributo', () => {
+      const html = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" style="width: 320px">'
+      );
+
+      expect(html).toContain('width="320"');
+    });
+
+    it('não deve emitir altura mesmo quando o HTML de origem tem height', () => {
+      const html = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" width="400" height="300">'
+      );
+
+      expect(html).toContain('width="400"');
+      expect(html).not.toContain('height=');
+    });
+
+    it('não deve inventar largura em imagem que não tem nenhuma', () => {
+      const html = roundTrip('<img src="https://cdn.exemplo.com/foto.png">');
+
+      expect(html).not.toContain('width=');
+    });
+
+    it('deve estabilizar a largura após dois salvamentos', () => {
+      const afterFirstSave = roundTrip(
+        '<img src="https://cdn.exemplo.com/foto.png" width="400">'
+      );
+      const afterSecondSave = roundTrip(afterFirstSave);
+
+      expect(afterSecondSave).toEqual(afterFirstSave);
+    });
+
+    it('deve manter fórmula LaTeX adjacente à imagem redimensionada', () => {
+      const html = roundTrip(
+        '<p>Considere <span data-type="math-inline" data-latex="x^2"></span>:</p>' +
+          '<img src="https://cdn.exemplo.com/foto.png" width="400">'
+      );
+
+      expect(html).toContain('data-latex="x^2"');
+      expect(html).toContain('width="400"');
+    });
+  });
+
   describe('formatações existentes', () => {
     it('deve preservar formatações de texto ao carregar HTML', () => {
       const html = roundTrip(

--- a/src/components/RichEditor/components/extensions.ts
+++ b/src/components/RichEditor/components/extensions.ts
@@ -10,6 +10,67 @@ import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import Image from '@tiptap/extension-image';
 import { MathNode } from './MathNode';
+import {
+  MIN_IMAGE_HEIGHT,
+  MIN_IMAGE_WIDTH,
+  parseImageWidth,
+} from './imageSize';
+
+/**
+ * Image node with drag-to-resize handles.
+ *
+ * The stock extension already declares `width`/`height` attributes, but their
+ * default parser keeps the raw HTML value. That breaks the resizable node view,
+ * which appends `px` to whatever is stored — a legacy `width="400px"` would
+ * become `400pxpx`. Parsing to a number up front keeps every source consistent.
+ *
+ * `height` is deliberately never persisted: the editor stylesheet and
+ * HtmlMathRenderer both force `height: auto`, so a stored height exists only to
+ * be overridden. Worse, when `max-width` clips a too-wide image while an inline
+ * height survives, the node view measures the clipped box and commits a
+ * distorted aspect ratio on the next drag.
+ */
+const ResizableImage = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (element: HTMLElement) => parseImageWidth(element),
+        renderHTML: (attributes: Record<string, unknown>) =>
+          typeof attributes.width === 'number'
+            ? { width: attributes.width }
+            : {},
+      },
+      height: {
+        default: null,
+        parseHTML: () => null,
+        rendered: false,
+      },
+    };
+  },
+
+  addNodeView() {
+    const parentNodeView = this.parent?.();
+    if (!parentNodeView) return null;
+
+    return (props) => {
+      const nodeView = parentNodeView(props);
+      const container = nodeView.dom;
+      if (!(container instanceof HTMLElement)) return nodeView;
+
+      // The upstream node view hides the container until `load` fires. An
+      // expired storage URL therefore leaves an invisible, unselectable node —
+      // worse than the browser's broken-image icon. Reveal it on failure.
+      const image = container.querySelector('img');
+      image?.addEventListener('error', () => {
+        container.style.visibility = '';
+        container.style.pointerEvents = '';
+      });
+      return nodeView;
+    };
+  },
+});
 
 /**
  * Extension list backing the RichEditor.
@@ -31,7 +92,19 @@ export function createRichEditorExtensions(placeholder: string) {
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
     Link.configure({ openOnClick: false }),
     Placeholder.configure({ placeholder }),
-    Image.configure({ inline: false, allowBase64: false }),
+    ResizableImage.configure({
+      inline: false,
+      allowBase64: false,
+      resize: {
+        enabled: true,
+        // Corner handles only: edge handles span the whole side and read as a
+        // border rather than a grip.
+        directions: ['top-left', 'top-right', 'bottom-left', 'bottom-right'],
+        minWidth: MIN_IMAGE_WIDTH,
+        minHeight: MIN_IMAGE_HEIGHT,
+        alwaysPreserveAspectRatio: true,
+      },
+    }),
     MathNode,
   ];
 }

--- a/src/components/RichEditor/components/extensions.ts
+++ b/src/components/RichEditor/components/extensions.ts
@@ -57,16 +57,18 @@ const ResizableImage = Image.extend({
     return (props) => {
       const nodeView = parentNodeView(props);
       const container = nodeView.dom;
-      if (!(container instanceof HTMLElement)) return nodeView;
 
-      // The upstream node view hides the container until `load` fires. An
-      // expired storage URL therefore leaves an invisible, unselectable node —
-      // worse than the browser's broken-image icon. Reveal it on failure.
-      const image = container.querySelector('img');
-      image?.addEventListener('error', () => {
-        container.style.visibility = '';
-        container.style.pointerEvents = '';
-      });
+      if (container instanceof HTMLElement) {
+        // The upstream node view hides the container until `load` fires. An
+        // expired storage URL therefore leaves an invisible, unselectable node —
+        // worse than the browser's broken-image icon. Reveal it on failure.
+        const image = container.querySelector('img');
+        image?.addEventListener('error', () => {
+          container.style.visibility = '';
+          container.style.pointerEvents = '';
+        });
+      }
+
       return nodeView;
     };
   },

--- a/src/components/RichEditor/components/imageSize.test.ts
+++ b/src/components/RichEditor/components/imageSize.test.ts
@@ -191,6 +191,18 @@ describe('measureNaturalWidth', () => {
     await expect(promise).resolves.toBeNull();
   });
 
+  it('deve ignorar um segundo disparo do mesmo handler', async () => {
+    stubImage(1600);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/foto.png');
+
+    // Guarda a referência: o primeiro disparo zera `onload` na instância.
+    const loadHandler = instances[0].onload;
+    loadHandler?.();
+    loadHandler?.();
+
+    await expect(promise).resolves.toBe(1600);
+  });
+
   it('deve resolver null quando o src é vazio', async () => {
     stubImage(1600);
 

--- a/src/components/RichEditor/components/imageSize.test.ts
+++ b/src/components/RichEditor/components/imageSize.test.ts
@@ -1,0 +1,209 @@
+import {
+  DEFAULT_MAX_INSERT_WIDTH,
+  MIN_IMAGE_HEIGHT,
+  MIN_IMAGE_WIDTH,
+  measureNaturalWidth,
+  parseImageWidth,
+} from './imageSize';
+
+const imageWith = (attributes: Record<string, string>): HTMLElement => {
+  const element = document.createElement('img');
+  Object.entries(attributes).forEach(([name, value]) => {
+    element.setAttribute(name, value);
+  });
+  return element;
+};
+
+describe('constantes de tamanho', () => {
+  it('deve manter o piso de altura menor que o de largura', () => {
+    // Banners largos e baixos precisam encolher sem esbarrar na altura mínima.
+    expect(MIN_IMAGE_HEIGHT).toBeLessThan(MIN_IMAGE_WIDTH);
+  });
+
+  it('deve limitar a inserção a uma largura maior que o mínimo', () => {
+    expect(DEFAULT_MAX_INSERT_WIDTH).toBeGreaterThan(MIN_IMAGE_WIDTH);
+  });
+});
+
+describe('parseImageWidth', () => {
+  it('deve ler a largura do atributo width', () => {
+    expect(parseImageWidth(imageWith({ width: '400' }))).toBe(400);
+  });
+
+  it('deve aceitar o atributo width com unidade px', () => {
+    expect(parseImageWidth(imageWith({ width: '400px' }))).toBe(400);
+  });
+
+  it('deve arredondar largura fracionada', () => {
+    expect(parseImageWidth(imageWith({ width: '399.6px' }))).toBe(400);
+  });
+
+  it('deve recusar largura percentual', () => {
+    expect(parseImageWidth(imageWith({ width: '50%' }))).toBeNull();
+  });
+
+  it('deve recusar largura em unidade não suportada', () => {
+    expect(parseImageWidth(imageWith({ width: '20em' }))).toBeNull();
+  });
+
+  it('deve recusar largura zero ou negativa', () => {
+    expect(parseImageWidth(imageWith({ width: '0' }))).toBeNull();
+    expect(parseImageWidth(imageWith({ width: '-100' }))).toBeNull();
+  });
+
+  it('deve recusar valor inválido', () => {
+    expect(parseImageWidth(imageWith({ width: 'auto' }))).toBeNull();
+  });
+
+  it('deve retornar null quando não há largura nenhuma', () => {
+    expect(parseImageWidth(imageWith({}))).toBeNull();
+  });
+
+  it('deve ler a largura do style inline como fallback', () => {
+    expect(parseImageWidth(imageWith({ style: 'width: 320px' }))).toBe(320);
+  });
+
+  it('deve ler a largura do style mesmo com outras propriedades antes', () => {
+    expect(
+      parseImageWidth(imageWith({ style: 'display:block; width:250px;' }))
+    ).toBe(250);
+  });
+
+  it('deve ignorar max-width no style inline', () => {
+    expect(
+      parseImageWidth(imageWith({ style: 'max-width: 320px' }))
+    ).toBeNull();
+  });
+
+  it('deve ignorar largura percentual no style inline', () => {
+    expect(parseImageWidth(imageWith({ style: 'width: 50%' }))).toBeNull();
+  });
+
+  it('deve priorizar o atributo width sobre o style inline', () => {
+    expect(
+      parseImageWidth(imageWith({ width: '400', style: 'width: 320px' }))
+    ).toBe(400);
+  });
+});
+
+describe('measureNaturalWidth', () => {
+  type FakeImage = {
+    src: string;
+    naturalWidth: number;
+    onload: (() => void) | null;
+    onerror: (() => void) | null;
+  };
+
+  let instances: FakeImage[] = [];
+  const originalImage = globalThis.Image;
+
+  /**
+   * Replaces the global Image constructor with a fake whose load result the
+   * test drives by hand.
+   * @param naturalWidth - Width the fake image reports once loaded
+   */
+  const stubImage = (naturalWidth = 0) => {
+    instances = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).Image = function FakeImageConstructor(this: FakeImage) {
+      this.src = '';
+      this.naturalWidth = naturalWidth;
+      this.onload = null;
+      this.onerror = null;
+      instances.push(this);
+    };
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    globalThis.Image = originalImage;
+  });
+
+  it('deve resolver com a largura natural quando a imagem carrega', async () => {
+    stubImage(1600);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/foto.png');
+
+    instances[0].onload?.();
+
+    await expect(promise).resolves.toBe(1600);
+  });
+
+  it('deve atribuir o src recebido à imagem medida', async () => {
+    stubImage(800);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/foto.png');
+
+    expect(instances[0].src).toBe('https://cdn.exemplo.com/foto.png');
+
+    instances[0].onload?.();
+    await promise;
+  });
+
+  it('deve resolver null quando a imagem falha ao carregar', async () => {
+    stubImage(1600);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/quebrada.png');
+
+    instances[0].onerror?.();
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('deve resolver null quando a largura natural é zero', async () => {
+    stubImage(0);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/foto.png');
+
+    instances[0].onload?.();
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('deve resolver null quando estoura o tempo limite', async () => {
+    stubImage(1600);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/lenta.png');
+
+    jest.advanceTimersByTime(3000);
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('deve ignorar carregamento tardio após o tempo limite', async () => {
+    stubImage(1600);
+    const promise = measureNaturalWidth('https://cdn.exemplo.com/lenta.png');
+
+    jest.advanceTimersByTime(3000);
+    instances[0].onload?.();
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('deve respeitar um tempo limite customizado', async () => {
+    stubImage(1600);
+    const promise = measureNaturalWidth(
+      'https://cdn.exemplo.com/foto.png',
+      100
+    );
+
+    jest.advanceTimersByTime(100);
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('deve resolver null quando o src é vazio', async () => {
+    stubImage(1600);
+
+    await expect(measureNaturalWidth('')).resolves.toBeNull();
+    expect(instances).toHaveLength(0);
+  });
+
+  it('deve resolver null quando o ambiente não tem Image', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).Image = undefined;
+
+    await expect(
+      measureNaturalWidth('https://cdn.exemplo.com/foto.png')
+    ).resolves.toBeNull();
+  });
+});

--- a/src/components/RichEditor/components/imageSize.test.ts
+++ b/src/components/RichEditor/components/imageSize.test.ts
@@ -51,6 +51,11 @@ describe('parseImageWidth', () => {
     expect(parseImageWidth(imageWith({ width: '-100' }))).toBeNull();
   });
 
+  it('deve recusar largura que arredonda para zero', () => {
+    // `width="0"` deixaria a imagem invisível.
+    expect(parseImageWidth(imageWith({ width: '0.4px' }))).toBeNull();
+  });
+
   it('deve recusar valor inválido', () => {
     expect(parseImageWidth(imageWith({ width: 'auto' }))).toBeNull();
   });
@@ -77,6 +82,25 @@ describe('parseImageWidth', () => {
 
   it('deve ignorar largura percentual no style inline', () => {
     expect(parseImageWidth(imageWith({ style: 'width: 50%' }))).toBeNull();
+  });
+
+  it('deve respeitar a última declaração de width repetida no style', () => {
+    // O CSS aplica `50%`; ler a primeira ocorrência daria 320 e divergiria
+    // do que o navegador renderiza.
+    expect(
+      parseImageWidth(imageWith({ style: 'width: 320px; width: 50%' }))
+    ).toBeNull();
+  });
+
+  it('deve usar a última declaração válida de width no style', () => {
+    expect(
+      parseImageWidth(imageWith({ style: 'width: 50%; width: 320px' }))
+    ).toBe(320);
+  });
+
+  it('deve ignorar declaração de width malformada no style', () => {
+    expect(parseImageWidth(imageWith({ style: 'width: ;' }))).toBeNull();
+    expect(parseImageWidth(imageWith({ style: 'width: abc' }))).toBeNull();
   });
 
   it('deve priorizar o atributo width sobre o style inline', () => {

--- a/src/components/RichEditor/components/imageSize.ts
+++ b/src/components/RichEditor/components/imageSize.ts
@@ -79,7 +79,7 @@ export const measureNaturalWidth = (
   src: string,
   timeoutMs: number = MEASURE_TIMEOUT_MS
 ): Promise<number | null> => {
-  if (!src || typeof globalThis.Image === 'undefined') {
+  if (!src || globalThis.Image === undefined) {
     return Promise.resolve(null);
   }
 

--- a/src/components/RichEditor/components/imageSize.ts
+++ b/src/components/RichEditor/components/imageSize.ts
@@ -25,9 +25,6 @@ export const DEFAULT_MAX_INSERT_WIDTH = 640;
 /** Milliseconds to wait for an image to load before giving up on measuring it. */
 const MEASURE_TIMEOUT_MS = 3000;
 
-/** Matches a pixel width in an inline style, e.g. `width: 320px`. */
-const STYLE_WIDTH_PATTERN = /(?:^|;)\s*width\s*:\s*(\d+(?:\.\d+)?)px/i;
-
 /**
  * Converts a raw width value into a usable number of pixels.
  * Percentages and other units are rejected: the resizable node view appends
@@ -43,10 +40,10 @@ const toPixelWidth = (value: string | null): number | null => {
   const match = /^(\d+(?:\.\d+)?)(px)?$/i.exec(trimmed);
   if (!match) return null;
 
-  const parsed = Number.parseFloat(match[1]);
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
-
-  return Math.round(parsed);
+  // Rounding is checked instead of the parsed value: `0.4px` is positive but
+  // rounds to zero, and a `width="0"` would make the image vanish.
+  const rounded = Math.round(Number.parseFloat(match[1]));
+  return rounded > 0 ? rounded : null;
 };
 
 /**
@@ -60,11 +57,10 @@ export const parseImageWidth = (element: HTMLElement): number | null => {
   const fromAttribute = toPixelWidth(element.getAttribute('width'));
   if (fromAttribute !== null) return fromAttribute;
 
-  const inlineStyle = element.getAttribute('style');
-  if (!inlineStyle) return null;
-
-  const styleMatch = STYLE_WIDTH_PATTERN.exec(inlineStyle);
-  return styleMatch ? toPixelWidth(styleMatch[1]) : null;
+  // `element.style.width` is the declaration the browser actually applies, so a
+  // duplicated `width: 320px; width: 50%` resolves to `50%` and is rejected —
+  // matching the source instead of the first value that happens to parse.
+  return toPixelWidth(element.style.width);
 };
 
 /**

--- a/src/components/RichEditor/components/imageSize.ts
+++ b/src/components/RichEditor/components/imageSize.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared sizing rules for resizable images inside the RichEditor.
+ *
+ * Both the Tiptap image extension and the image insertion dialog need the same
+ * numbers, so they live here instead of being duplicated on each side.
+ */
+
+/** Smallest width a resize handle may produce, in pixels. */
+export const MIN_IMAGE_WIDTH = 48;
+
+/**
+ * Smallest height a resize handle may produce, in pixels.
+ * Lower than the width floor so wide, short banners can still be shrunk without
+ * the height constraint fighting the width.
+ */
+export const MIN_IMAGE_HEIGHT = 24;
+
+/**
+ * Width applied on insert when the source image is wider than this.
+ * Exam boards upload figures at their original scan resolution, which would
+ * otherwise fill the whole statement.
+ */
+export const DEFAULT_MAX_INSERT_WIDTH = 640;
+
+/** Milliseconds to wait for an image to load before giving up on measuring it. */
+const MEASURE_TIMEOUT_MS = 3000;
+
+/** Matches a pixel width in an inline style, e.g. `width: 320px`. */
+const STYLE_WIDTH_PATTERN = /(?:^|;)\s*width\s*:\s*(\d+(?:\.\d+)?)px/i;
+
+/**
+ * Converts a raw width value into a usable number of pixels.
+ * Percentages and other units are rejected: the resizable node view appends
+ * `px` to whatever it is given, so a stored `50%` would become `50%px`.
+ * @param value - Raw attribute or style value
+ * @returns The width in pixels, or null when it cannot be used
+ */
+const toPixelWidth = (value: string | null): number | null => {
+  if (!value) return null;
+
+  const trimmed = value.trim();
+  // Accepts "400" and "400px" only. Anything else (%, em, vw, calc) is dropped.
+  const match = /^(\d+(?:\.\d+)?)(px)?$/i.exec(trimmed);
+  if (!match) return null;
+
+  const parsed = Number.parseFloat(match[1]);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+
+  return Math.round(parsed);
+};
+
+/**
+ * Reads a usable pixel width from an `<img>` element.
+ * The `width` attribute wins; an inline `width: Npx` style is used as fallback
+ * so images pasted from other editors keep their intended size.
+ * @param element - The image element being parsed by Tiptap
+ * @returns The width in pixels, or null when the image has no usable width
+ */
+export const parseImageWidth = (element: HTMLElement): number | null => {
+  const fromAttribute = toPixelWidth(element.getAttribute('width'));
+  if (fromAttribute !== null) return fromAttribute;
+
+  const inlineStyle = element.getAttribute('style');
+  if (!inlineStyle) return null;
+
+  const styleMatch = STYLE_WIDTH_PATTERN.exec(inlineStyle);
+  return styleMatch ? toPixelWidth(styleMatch[1]) : null;
+};
+
+/**
+ * Loads an image off-DOM to discover its natural width.
+ * Never rejects: a broken URL or a slow CDN resolves to null so the caller can
+ * insert the image without a width instead of blocking on the network.
+ * @param src - Public URL of the image
+ * @param timeoutMs - How long to wait before giving up
+ * @returns The natural width in pixels, or null when it cannot be measured
+ */
+export const measureNaturalWidth = (
+  src: string,
+  timeoutMs: number = MEASURE_TIMEOUT_MS
+): Promise<number | null> => {
+  if (!src || typeof globalThis.Image === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    const image = new globalThis.Image();
+    let settled = false;
+
+    const finish = (width: number | null) => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout(timeoutId);
+      image.onload = null;
+      image.onerror = null;
+      resolve(width);
+    };
+
+    const timeoutId = globalThis.setTimeout(() => finish(null), timeoutMs);
+
+    image.onload = () => finish(image.naturalWidth || null);
+    image.onerror = () => finish(null);
+    image.src = src;
+  });
+};

--- a/src/components/RichEditor/richEditor.css
+++ b/src/components/RichEditor/richEditor.css
@@ -1,0 +1,106 @@
+/*
+ * RichEditor — imagens redimensionáveis.
+ *
+ * O ResizableNodeView do Tiptap monta as alças como `div`s sem nenhum estilo
+ * (0x0, sem fundo, invisíveis), então este arquivo é obrigatório pro recurso
+ * existir na tela. É também aqui que a imagem passa a caber no editor: a lib
+ * não usa o plugin de tipografia do Tailwind, então as classes `prose`
+ * aplicadas em `editorProps` são inertes e nada limita a largura.
+ *
+ * Importado por `src/styles.css` (que todo consumidor carrega). CSS sidecar
+ * por componente não é entregue automaticamente — mesmo motivo do
+ * `AccessibilityWidget/accessibility.css`.
+ */
+
+[data-analytica-rich-editor] .ProseMirror img {
+  max-width: 100%;
+  /*
+   * !important porque o node view escreve `style.height` em px durante o
+   * arraste. Se a imagem for arrastada além da largura do editor, `max-width`
+   * corta a largura mas a altura inline continuaria valendo — a figura ficaria
+   * esticada, inclusive na proporção que o node view mede e commita depois.
+   */
+  height: auto !important;
+  border-radius: 0.375rem;
+}
+
+[data-analytica-rich-editor] .ProseMirror [data-resize-container] {
+  max-width: 100%;
+  margin: 0.5rem 0;
+}
+
+[data-analytica-rich-editor] .ProseMirror [data-resize-wrapper] {
+  max-width: 100%;
+  line-height: 0;
+}
+
+[data-analytica-rich-editor]
+  .ProseMirror
+  [data-resize-container].ProseMirror-selectednode
+  [data-resize-wrapper] {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+  border-radius: 0.375rem;
+}
+
+[data-analytica-rich-editor] .ProseMirror [data-resize-handle] {
+  width: 0.75rem;
+  height: 0.75rem;
+  /*
+   * Margem uniforme centraliza cada alça no seu canto: as bordas opostas ficam
+   * em `auto` e não deslocam elementos posicionados de forma absoluta.
+   */
+  margin: -0.375rem;
+  border-radius: 9999px;
+  border: 2px solid var(--color-background-0);
+  background-color: var(--color-primary-500);
+  opacity: 0;
+  transition: opacity 120ms ease-in-out;
+  /* O nó de imagem é draggable: sem isto a alça dispara um drag HTML5. */
+  -webkit-user-drag: none;
+  user-select: none;
+  touch-action: none;
+  z-index: 1;
+}
+
+/* Área de toque maior que o alvo visual. */
+[data-analytica-rich-editor] .ProseMirror [data-resize-handle]::after {
+  content: '';
+  position: absolute;
+  inset: -0.5rem;
+}
+
+[data-analytica-rich-editor]
+  .ProseMirror
+  [data-resize-container]:hover
+  [data-resize-handle],
+[data-analytica-rich-editor]
+  .ProseMirror
+  [data-resize-container].ProseMirror-selectednode
+  [data-resize-handle],
+[data-analytica-rich-editor]
+  .ProseMirror
+  [data-resize-container][data-resize-state='true']
+  [data-resize-handle] {
+  opacity: 1;
+}
+
+[data-analytica-rich-editor] .ProseMirror [data-resize-handle='top-left'],
+[data-analytica-rich-editor] .ProseMirror [data-resize-handle='bottom-right'] {
+  cursor: nwse-resize;
+}
+
+[data-analytica-rich-editor] .ProseMirror [data-resize-handle='top-right'],
+[data-analytica-rich-editor] .ProseMirror [data-resize-handle='bottom-left'] {
+  cursor: nesw-resize;
+}
+
+/* Sem hover não há como descobrir as alças: deixa sempre visíveis e maiores. */
+@media (hover: none) {
+  [data-analytica-rich-editor] .ProseMirror [data-resize-handle] {
+    opacity: 1;
+    width: 1rem;
+    height: 1rem;
+    margin: -0.5rem;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -39,6 +39,13 @@
  */
 @import './components/AccessibilityWidget/accessibility.css';
 
+/*
+ * Alças de redimensionamento das imagens do RichEditor. Pelo mesmo motivo do
+ * arquivo acima: o consumidor só importa `analytica-frontend-lib/styles.css`,
+ * então CSS sidecar por componente não chegaria até ele.
+ */
+@import './components/RichEditor/richEditor.css';
+
 /* Safelist compacto para todas as cores do tema */
 @source inline("{bg,text,border}-{primary,secondary,tertiary,text,background,border,success,error,warning,info}-{50,{100..900..100},950}");
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -416,6 +416,10 @@ export default defineConfig({
     '@tiptap/extension-superscript',
     '@tiptap/extension-link',
     '@tiptap/extension-placeholder',
+    // Must stay external like the rest: it pulls ResizableNodeView from
+    // @tiptap/core, and bundling it would pair a vendored copy with whatever
+    // core the consumer resolves.
+    '@tiptap/extension-image',
     'xlsx',
   ],
   target: 'es2022',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image resizing in the rich-text editor with draggable handles and minimum dimensions.
  * Automatically limits oversized inserted images while preserving suitable widths for smaller images.
  * Improved image display behavior, including responsive sizing and clearer selection states.
  * Handles image loading failures and unavailable dimensions gracefully.

* **Bug Fixes**
  * Prevented image heights and percentage widths from being incorrectly preserved during editing and saving.
  * Improved image sizing consistency across repeated editor updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->