### PR TITLE
AE-2978 - feat(theme): add per-app themes, light-only themes and a theme lock

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -165,18 +165,27 @@ export default Button;
  * poderem variar por estado — no `outline` a aresta cai de 4px→2px no pressed.
  * O `link` é só texto (sem sombra/borda); apenas o foco adiciona a borda
  * `secondary-600`. `disabled` não veio na arte (padrão mínimo da lib).
+ *
+ * A aresta do `outline` era o hex #F9CB3B cravado, que é exatamente o
+ * `primary-500` do tema do aluno — virou token, então acompanha o tema em vez
+ * de ficar dourada sobre um botão de outra cor.
+ *
+ * O #D4A82E do `solid` continua literal: é um tom de bisel da arte, não bate
+ * com nenhum passo da rampa (o vizinho mais próximo, `primary-700` #C29506, é
+ * visivelmente mais escuro e saturado). Trocar mudaria o desenho do botão, então
+ * fica para a designer decidir se vira token ou se o valor é outro.
  */
 const PAPOLE_VARIANT_CLASSES = {
   solid:
     'bg-primary-500 border-4 border-primary-200 text-primary-900 hover:bg-primary-600 focus-visible:outline-none focus-visible:border-secondary-600 active:bg-primary-700 active:border-2 active:text-primary-100 disabled:opacity-40 disabled:cursor-not-allowed [box-shadow:0px_4px_0px_0px_#D4A82E,0px_0px_4px_0px_#00000021]',
   outline:
-    'bg-transparent border-4 border-primary-200 text-primary-900 hover:bg-primary-100 focus-visible:outline-none focus-visible:border-secondary-600 active:bg-primary-200 active:border-2 active:border-primary-700 disabled:opacity-40 disabled:cursor-not-allowed [box-shadow:0px_4px_0px_0px_#F9CB3B,0px_0px_4px_0px_#00000021] active:[box-shadow:0px_2px_0px_0px_#F9CB3B,0px_0px_4px_0px_#00000021]',
+    'bg-transparent border-4 border-primary-200 text-primary-900 hover:bg-primary-100 focus-visible:outline-none focus-visible:border-secondary-600 active:bg-primary-200 active:border-2 active:border-primary-700 disabled:opacity-40 disabled:cursor-not-allowed [box-shadow:0px_4px_0px_0px_var(--color-primary-500),0px_0px_4px_0px_#00000021] active:[box-shadow:0px_2px_0px_0px_var(--color-primary-500),0px_0px_4px_0px_#00000021]',
   // Inverso do outline p/ fundo escuro (ex.: SAIR no menu de perfil): texto
   // claro (primary-100) por cima; no hover/pressed preenche dourado e escurece o
   // texto p/ manter contraste; foco com borda clara (secondary-300). Valores por
   // estado são uma proposta coerente — ajustar na story se necessário.
   'outline-inverse':
-    'bg-transparent border-4 border-primary-200 text-primary-100 hover:bg-primary-100 hover:text-primary-900 focus-visible:outline-none focus-visible:border-secondary-300 active:bg-primary-200 active:text-primary-900 active:border-2 active:border-primary-700 disabled:opacity-40 disabled:cursor-not-allowed [box-shadow:0px_4px_0px_0px_#F9CB3B,0px_0px_4px_0px_#00000021] active:[box-shadow:0px_2px_0px_0px_#F9CB3B,0px_0px_4px_0px_#00000021]',
+    'bg-transparent border-4 border-primary-200 text-primary-100 hover:bg-primary-100 hover:text-primary-900 focus-visible:outline-none focus-visible:border-secondary-300 active:bg-primary-200 active:text-primary-900 active:border-2 active:border-primary-700 disabled:opacity-40 disabled:cursor-not-allowed [box-shadow:0px_4px_0px_0px_var(--color-primary-500),0px_0px_4px_0px_#00000021] active:[box-shadow:0px_2px_0px_0px_var(--color-primary-500),0px_0px_4px_0px_#00000021]',
   link: 'bg-transparent border-4 border-transparent text-primary-900 hover:text-primary-700 focus-visible:outline-none focus-visible:border-secondary-600 active:text-primary-800 disabled:opacity-40 disabled:cursor-not-allowed',
 } as const;
 

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -3874,7 +3874,7 @@ describe('CardReadingFluency', () => {
     it('applies the default background color', () => {
       render(<CardReadingFluency data-testid="card-papole" />);
       expect(screen.getByTestId('card-papole')).toHaveStyle({
-        backgroundColor: '#a3d9b1',
+        backgroundColor: 'var(--color-scent-2)',
       });
     });
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1915,7 +1915,9 @@ const CardReadingFluency = forwardRef<HTMLDivElement, CardReadingFluencyProps>(
   (
     {
       state = 'new',
-      color = '#a3d9b1',
+      // Scent color 2 (verde) do tema do aluno. Era o hex #a3d9b1 cravado, que
+      // deixava o default do componente fora do tema.
+      color = 'var(--color-scent-2)',
       image,
       label = 'Reading Fluency',
       activityTitle,

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -30,8 +30,10 @@ import type { ThemeMode } from '@/hooks/useTheme';
 const mockUseTheme = {
   themeMode: 'system' as ThemeMode,
   isDark: false,
+  isThemeLocked: false,
   setTheme: jest.fn(),
   toggleTheme: jest.fn(),
+  lockTheme: jest.fn(),
 };
 
 jest.mock('@/hooks/useTheme', () => ({
@@ -1280,6 +1282,25 @@ describe('ProfileToggleTheme component', () => {
     jest.clearAllMocks();
     mockUseTheme.themeMode = 'system';
     mockUseTheme.isDark = false;
+    mockUseTheme.isThemeLocked = false;
+  });
+
+  it('hides the appearance entry when the theme is locked', () => {
+    mockUseTheme.isThemeLocked = true;
+
+    render(
+      <DropdownMenu>
+        <ProfileMenuTrigger />
+        <DropdownMenuContent variant="profile">
+          <ProfileToggleTheme />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Deixar a entrada visível daria um modal que salva e não muda nada.
+    expect(screen.queryByText('Aparência')).not.toBeInTheDocument();
   });
 
   it('renders ProfileToggleTheme with correct content', () => {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -908,7 +908,7 @@ const ProfileToggleTheme = ({
   store: externalStore,
   ...props
 }: HTMLAttributes<HTMLDivElement> & { store?: DropdownStoreApi }) => {
-  const { themeMode, setTheme } = useTheme();
+  const { themeMode, setTheme, isThemeLocked } = useTheme();
   const [modalThemeToggle, setModalThemeToggle] = useState(false);
   const [selectedTheme, setSelectedTheme] = useState<ThemeMode>(themeMode);
 
@@ -934,6 +934,10 @@ const ProfileToggleTheme = ({
     setModalThemeToggle(false);
     setOpen(false); // Close dropdown after canceling
   };
+
+  // Tema travado pelo produto (ex.: Fluência Leitora): esconde a entrada do
+  // menu inteira. Deixá-la visível daria um modal que salva e não muda nada.
+  if (isThemeLocked) return null;
 
   return (
     <>

--- a/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -6,8 +6,10 @@ import type { ThemeMode } from '@/hooks/useTheme';
 const mockUseTheme = {
   themeMode: 'system' as ThemeMode,
   isDark: false,
+  isThemeLocked: false,
   setTheme: jest.fn(),
   toggleTheme: jest.fn(),
+  lockTheme: jest.fn(),
 };
 
 jest.mock('@/hooks/useTheme', () => ({
@@ -45,6 +47,20 @@ describe('ThemeToggle', () => {
     jest.clearAllMocks();
     mockUseTheme.themeMode = 'system';
     mockUseTheme.isDark = false;
+    mockUseTheme.isThemeLocked = false;
+  });
+
+  describe('Theme locked by the product', () => {
+    it('renders nothing when the theme is locked', () => {
+      mockUseTheme.isThemeLocked = true;
+
+      const { container } = render(<ThemeToggle />);
+
+      // Um seletor visível não mudaria nada e ainda marcaria como selecionado
+      // um modo diferente do que está na tela.
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByTestId('theme-escuro')).not.toBeInTheDocument();
+    });
   });
 
   describe('Default variant', () => {

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -14,7 +14,7 @@ export const ThemeToggle = ({
   variant = 'default',
   onToggle,
 }: ThemeToggleProps) => {
-  const { themeMode, setTheme } = useTheme();
+  const { themeMode, setTheme, isThemeLocked } = useTheme();
   const [tempTheme, setTempTheme] = useState<ThemeMode>(themeMode);
 
   // Update temp theme when themeMode changes externally
@@ -66,6 +66,11 @@ export const ThemeToggle = ({
   };
 
   const currentTheme = variant === 'with-save' ? tempTheme : themeMode;
+
+  // Tema travado pelo produto: não há escolha a oferecer. Renderizar os botões
+  // mostraria um seletor que não muda nada — e ainda marcaria como selecionado
+  // um modo que não é o que está na tela.
+  if (isThemeLocked) return null;
 
   return (
     <div className="flex flex-row gap-2 sm:gap-4 py-2">

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -74,7 +74,12 @@ describe('useTheme', () => {
     });
 
     // Reset Zustand store to initial state
-    useThemeStore.setState({ themeMode: 'system', isDark: false });
+    useThemeStore.setState({
+      themeMode: 'system',
+      isDark: false,
+      lockedMode: null,
+      lightOnly: false,
+    });
   });
 
   afterEach(() => {
@@ -204,6 +209,66 @@ describe('useTheme', () => {
 
       // Should call setAttribute when system theme changes
       expect(mockSetAttribute).toHaveBeenCalled();
+    });
+  });
+
+  describe('lockTheme', () => {
+    it('should expose isThemeLocked reflecting the store', () => {
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isThemeLocked).toBe(false);
+
+      act(() => {
+        result.current.lockTheme('light');
+      });
+
+      expect(result.current.isThemeLocked).toBe(true);
+
+      act(() => {
+        result.current.lockTheme(null);
+      });
+
+      expect(result.current.isThemeLocked).toBe(false);
+    });
+
+    it('should force light while keeping the user preference on dark', () => {
+      mockDataset.theme = 'enem-parana-light';
+      mockDataset.originalTheme = 'enem-parana-light';
+
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setTheme('dark');
+        result.current.lockTheme('light');
+      });
+
+      expect(result.current.isDark).toBe(false);
+      expect(result.current.themeMode).toBe('dark');
+      expect(mockSetAttribute).toHaveBeenLastCalledWith(
+        'data-theme',
+        'enem-parana-light'
+      );
+    });
+  });
+
+  describe('setAppTheme', () => {
+    it('should apply the app theme and report it as locked', () => {
+      mockDataset.theme = 'papole-light';
+      mockDataset.originalTheme = 'papole-light';
+
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.setAppTheme('aluno');
+      });
+
+      // Tema light-only: não há escolha a oferecer, o seletor some.
+      expect(result.current.isThemeLocked).toBe(true);
+      expect(result.current.isDark).toBe(false);
+      expect(mockSetAttribute).toHaveBeenCalledWith(
+        'data-theme',
+        'papole-aluno-light'
+      );
     });
   });
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -13,8 +13,12 @@ export const useTheme = () => {
   const {
     themeMode,
     isDark,
+    lockedMode,
+    lightOnly,
     toggleTheme,
     setTheme,
+    lockTheme,
+    setAppTheme,
     initializeTheme,
     handleSystemThemeChange,
   } = useThemeStore();
@@ -77,6 +81,23 @@ export const useTheme = () => {
     isDark,
     toggleTheme,
     setTheme,
+    /**
+     * Trava o tema num modo (ex.: `lockTheme('light')` na Fluência Leitora) ou
+     * libera com `lockTheme(null)`. Não sobrescreve a preferência do usuário.
+     */
+    lockTheme,
+    /**
+     * Troca o tema da instituição pelo tema próprio deste app, quando houver.
+     * Chamar no boot, antes do primeiro render.
+     */
+    setAppTheme,
+    /**
+     * `true` quando não há escolha de tema a oferecer: ou o produto está
+     * impondo um modo (`lockTheme`), ou o tema não tem variante dark. Quem
+     * renderiza seletor de tema deve esconder o controle — senão o usuário
+     * escolhe e nada acontece.
+     */
+    isThemeLocked: lockedMode !== null || lightOnly,
     branding,
   };
 };

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,7 +1,11 @@
 import { useEffect, useMemo } from 'react';
-import { useThemeStore, ThemeMode } from '../store/themeStore';
+import {
+  useThemeStore,
+  ThemeMode,
+  LockableThemeMode,
+} from '../store/themeStore';
 
-export type { ThemeMode };
+export type { ThemeMode, LockableThemeMode };
 
 /**
  * Hook para gerenciar temas e branding institucional

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,11 +1,7 @@
 import { useEffect, useMemo } from 'react';
-import {
-  useThemeStore,
-  ThemeMode,
-  LockableThemeMode,
-} from '../store/themeStore';
+import { useThemeStore } from '../store/themeStore';
 
-export type { ThemeMode, LockableThemeMode };
+export type { ThemeMode, LockableThemeMode } from '../store/themeStore';
 
 /**
  * Hook para gerenciar temas e branding institucional

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,12 @@ export type { BaseApiClient } from './types/api';
 
 // Theme Store
 export { useThemeStore } from './store/themeStore';
-export type { ThemeStore, ThemeState, ThemeActions } from './store/themeStore';
+export type {
+  ThemeStore,
+  ThemeState,
+  ThemeActions,
+  LockableThemeMode,
+} from './store/themeStore';
 
 // Storage Keys
 export { KEYS, FEATURE_FLAGS_KEYS } from './utils/keys';

--- a/src/store/themeStore.test.ts
+++ b/src/store/themeStore.test.ts
@@ -97,7 +97,12 @@ describe('themeStore', () => {
     globalThis.localStorage.removeItem('theme-store');
 
     // Clear Zustand store
-    useThemeStore.setState({ themeMode: 'system', isDark: false });
+    useThemeStore.setState({
+      themeMode: 'system',
+      isDark: false,
+      lockedMode: null,
+      lightOnly: false,
+    });
   });
 
   afterEach(() => {
@@ -233,6 +238,185 @@ describe('themeStore', () => {
         'data-theme',
         'enem-parana-light'
       );
+    });
+  });
+
+  describe('setAppTheme', () => {
+    it('should swap the institution theme for the app theme', () => {
+      mockDataset.theme = 'papole-light';
+      mockDataset.originalTheme = 'papole-light';
+
+      const { setAppTheme } = useThemeStore.getState();
+
+      setAppTheme('aluno');
+
+      expect(mockDataset.originalTheme).toBe('papole-aluno-light');
+      expect(mockDataset.theme).toBe('papole-aluno-light');
+    });
+
+    it('should read the received theme from data-theme on boot', () => {
+      // No boot o index.html só tem `data-theme`; o original ainda não existe.
+      mockDataset.theme = 'papole-light';
+      delete mockDataset.originalTheme;
+
+      const { setAppTheme } = useThemeStore.getState();
+
+      setAppTheme('aluno');
+
+      expect(mockDataset.originalTheme).toBe('papole-aluno-light');
+    });
+
+    it('should leave institutions without an app theme untouched', () => {
+      mockDataset.theme = 'enem-parana-light';
+      mockDataset.originalTheme = 'enem-parana-light';
+
+      const { setAppTheme } = useThemeStore.getState();
+
+      setAppTheme('aluno');
+
+      expect(mockDataset.originalTheme).toBe('enem-parana-light');
+      expect(mockDataset.theme).toBe('enem-parana-light');
+    });
+
+    it('should leave other apps untouched', () => {
+      mockDataset.theme = 'papole-light';
+      mockDataset.originalTheme = 'papole-light';
+
+      const { setAppTheme } = useThemeStore.getState();
+
+      setAppTheme('professor');
+
+      expect(mockDataset.originalTheme).toBe('papole-light');
+    });
+
+    it('should flag the app theme as light-only', () => {
+      mockDataset.theme = 'papole-light';
+      mockDataset.originalTheme = 'papole-light';
+
+      const { setAppTheme } = useThemeStore.getState();
+
+      setAppTheme('aluno');
+
+      expect(useThemeStore.getState().lightOnly).toBe(true);
+    });
+  });
+
+  describe('light-only themes', () => {
+    beforeEach(() => {
+      mockDataset.theme = 'papole-aluno-light';
+      mockDataset.originalTheme = 'papole-aluno-light';
+    });
+
+    it('should stay light when dark is requested', () => {
+      const { setTheme } = useThemeStore.getState();
+
+      setTheme('dark');
+
+      // Sem isso cairia no fallback `base-dark`, que é o dark neutro azulado.
+      expect(mockDataset.theme).toBe('papole-aluno-light');
+      expect(useThemeStore.getState().isDark).toBe(false);
+    });
+
+    it('should stay light when the system prefers dark', () => {
+      mockMediaQueryList.matches = true;
+
+      const { setTheme } = useThemeStore.getState();
+
+      setTheme('system');
+
+      expect(mockDataset.theme).toBe('papole-aluno-light');
+      expect(useThemeStore.getState().isDark).toBe(false);
+    });
+  });
+
+  describe('lockTheme', () => {
+    it('should force the locked mode over the user themeMode', () => {
+      const { setTheme, lockTheme } = useThemeStore.getState();
+
+      setTheme('dark');
+      lockTheme('light');
+
+      expect(useThemeStore.getState().lockedMode).toBe('light');
+      expect(useThemeStore.getState().isDark).toBe(false);
+      expect(mockDocumentElement.setAttribute).toHaveBeenLastCalledWith(
+        'data-theme',
+        'enem-parana-light'
+      );
+    });
+
+    it('should keep the user preference untouched while locked', () => {
+      const { setTheme, lockTheme } = useThemeStore.getState();
+
+      setTheme('dark');
+      lockTheme('light');
+
+      // O usuário escolheu dark; a trava só se sobrepõe na renderização.
+      expect(useThemeStore.getState().themeMode).toBe('dark');
+    });
+
+    it('should restore the user preference when released', () => {
+      const { setTheme, lockTheme } = useThemeStore.getState();
+
+      setTheme('dark');
+      lockTheme('light');
+      lockTheme(null);
+
+      expect(useThemeStore.getState().lockedMode).toBeNull();
+      expect(useThemeStore.getState().isDark).toBe(true);
+      expect(mockDocumentElement.setAttribute).toHaveBeenLastCalledWith(
+        'data-theme',
+        'enem-parana-dark'
+      );
+    });
+
+    it('should ignore setTheme changes on the DOM while locked', () => {
+      const { lockTheme, setTheme } = useThemeStore.getState();
+
+      lockTheme('light');
+      mockSetAttribute.mockClear();
+      setTheme('dark');
+
+      expect(useThemeStore.getState().themeMode).toBe('dark');
+      expect(useThemeStore.getState().isDark).toBe(false);
+      expect(mockDocumentElement.setAttribute).toHaveBeenCalledWith(
+        'data-theme',
+        'enem-parana-light'
+      );
+    });
+
+    it('should ignore system theme changes while locked', () => {
+      const { lockTheme, handleSystemThemeChange } = useThemeStore.getState();
+
+      lockTheme('light');
+      mockSetAttribute.mockClear();
+      mockMediaQueryList.matches = true;
+      handleSystemThemeChange();
+
+      expect(useThemeStore.getState().isDark).toBe(false);
+      expect(mockDocumentElement.setAttribute).not.toHaveBeenCalled();
+    });
+
+    it('should be idempotent', () => {
+      const { lockTheme } = useThemeStore.getState();
+
+      lockTheme('light');
+      mockSetAttribute.mockClear();
+      lockTheme('light');
+
+      expect(mockDocumentElement.setAttribute).not.toHaveBeenCalled();
+    });
+
+    it('should not persist the lock', () => {
+      const { lockTheme } = useThemeStore.getState();
+
+      lockTheme('light');
+
+      // A trava é decisão de runtime (feature flag), não preferência do
+      // usuário — e o cookie é compartilhado entre login e todos os apps.
+      expect(document.cookie).not.toContain('lockedMode');
+      expect(
+        globalThis.localStorage.getItem('theme-store') ?? ''
+      ).not.toContain('lockedMode');
     });
   });
 

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -4,6 +4,8 @@ import { themeCookieStorage } from './themeStorage';
 
 export type ThemeMode = 'light' | 'dark' | 'system';
 
+export type LockableThemeMode = Exclude<ThemeMode, 'system'>;
+
 /**
  * Theme store state interface
  */
@@ -25,7 +27,7 @@ export interface ThemeState {
    * (fica de fora do `partialize`): a preferência do usuário continua no cookie
    * e volta a valer sozinha quando a trava sai.
    */
-  lockedMode: ThemeMode | null;
+  lockedMode: LockableThemeMode | null;
   /**
    * `true` quando o tema aplicado não tem variante dark (ver
    * `LIGHT_ONLY_THEMES`). Quem renderiza seletor de tema deve escondê-lo — não
@@ -54,7 +56,7 @@ export interface ThemeActions {
    * Trava o tema num modo, ignorando o `themeMode` do usuário até ser liberado
    * com `lockTheme(null)`. Idempotente.
    */
-  lockTheme: (mode: ThemeMode | null) => void;
+  lockTheme: (mode: LockableThemeMode | null) => void;
   /**
    * Troca o tema recebido da instituição pelo tema próprio deste app, quando
    * houver (ver `APP_THEME_MAP`). Chamar no boot, ANTES do primeiro render —
@@ -230,7 +232,7 @@ export const useThemeStore = create<ThemeStore>()(
           applyTheme(mode);
         },
 
-        lockTheme: (mode: ThemeMode | null) => {
+        lockTheme: (mode: LockableThemeMode | null) => {
           const { lockedMode, themeMode, applyTheme } = get();
           if (lockedMode === mode) return;
 

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -16,6 +16,22 @@ export interface ThemeState {
    * Whether the current theme is dark
    */
   isDark: boolean;
+  /**
+   * Modo imposto pelo produto, que se sobrepõe ao `themeMode` sem sobrescrevê-lo.
+   * `null` = sem trava (o usuário manda).
+   *
+   * Existe para variantes cujo visual só foi desenhado em um dos modos — hoje a
+   * Fluência Leitora, que tem arte própria só em light. NÃO é persistido
+   * (fica de fora do `partialize`): a preferência do usuário continua no cookie
+   * e volta a valer sozinha quando a trava sai.
+   */
+  lockedMode: ThemeMode | null;
+  /**
+   * `true` quando o tema aplicado não tem variante dark (ver
+   * `LIGHT_ONLY_THEMES`). Quem renderiza seletor de tema deve escondê-lo — não
+   * há escolha a oferecer.
+   */
+  lightOnly: boolean;
 }
 
 /**
@@ -34,6 +50,17 @@ export interface ThemeActions {
    * Set a specific theme mode
    */
   setTheme: (mode: ThemeMode) => void;
+  /**
+   * Trava o tema num modo, ignorando o `themeMode` do usuário até ser liberado
+   * com `lockTheme(null)`. Idempotente.
+   */
+  lockTheme: (mode: ThemeMode | null) => void;
+  /**
+   * Troca o tema recebido da instituição pelo tema próprio deste app, quando
+   * houver (ver `APP_THEME_MAP`). Chamar no boot, ANTES do primeiro render —
+   * senão a tela pisca com a paleta da instituição antes de trocar.
+   */
+  setAppTheme: (app: string) => void;
   /**
    * Set the white-label theme from institution branding
    */
@@ -67,25 +94,56 @@ const DARK_THEME_MAP: Record<string, string> = {
 };
 
 /**
+ * Temas que existem SÓ em light — a arte não tem versão escura e não é pra ter.
+ * Sem isso o modo dark cairia no fallback `base-dark`, que é o dark neutro
+ * (azulado) e não tem nada a ver com a paleta do produto.
+ */
+const LIGHT_ONLY_THEMES = new Set<string>(['papole-aluno-light']);
+
+/**
+ * Mapa de app → (tema da instituição → tema daquele app).
+ *
+ * A entrega injeta UMA string de tema por instituição no `<!--THEME_COLOR-->`
+ * de todos os apps. Quando um produto tem arte própria — o aluno do Papolê, que
+ * é a Fluência Leitora e tem um Figma inteiro separado — o app troca o tema
+ * recebido pelo seu no boot, via `setAppTheme`.
+ *
+ * Instituição sem entrada aqui não muda nada: continua com o tema recebido.
+ */
+const APP_THEME_MAP: Record<string, Record<string, string>> = {
+  aluno: {
+    'papole-light': 'papole-aluno-light',
+  },
+};
+
+/**
  * Resolve o seletor CSS dark concreto com base no tema institucional (light)
- * salvo em `data-original-theme`. Fallback: 'base-dark', que também responde
- * ao seletor legado [data-theme='dark'] preservando compat com apps antigos.
+ * salvo em `data-original-theme`. Temas light-only devolvem eles mesmos.
+ * Fallback: 'base-dark', que também responde ao seletor legado
+ * [data-theme='dark'] preservando compat com apps antigos.
  */
 const resolveDarkTheme = (originalTheme: string | undefined): string => {
   if (!originalTheme) return 'base-dark';
+  if (LIGHT_ONLY_THEMES.has(originalTheme)) return originalTheme;
   return DARK_THEME_MAP[originalTheme] ?? 'base-dark';
 };
 
 /**
- * Apply theme to DOM based on mode
+ * Apply theme to DOM based on mode.
+ *
+ * Devolve `isDark` já resolvido: num tema light-only o dark não acontece, então
+ * `isDark` é falso mesmo com o modo em 'dark'. Isso importa porque componentes
+ * trocam imagem e cor de matéria por esse booleano — se ele mentir, a tela sai
+ * clara com asset escuro em cima.
  */
 const applyThemeToDOM = (mode: ThemeMode): boolean => {
   const htmlElement = document.documentElement;
   const originalTheme = htmlElement.dataset.originalTheme;
 
   if (mode === 'dark') {
-    htmlElement.dataset.theme = resolveDarkTheme(originalTheme);
-    return true;
+    const darkTheme = resolveDarkTheme(originalTheme);
+    htmlElement.dataset.theme = darkTheme;
+    return darkTheme !== originalTheme;
   } else if (mode === 'light') {
     if (originalTheme) {
       htmlElement.dataset.theme = originalTheme;
@@ -96,8 +154,9 @@ const applyThemeToDOM = (mode: ThemeMode): boolean => {
       '(prefers-color-scheme: dark)'
     ).matches;
     if (isSystemDark) {
-      htmlElement.dataset.theme = resolveDarkTheme(originalTheme);
-      return true;
+      const darkTheme = resolveDarkTheme(originalTheme);
+      htmlElement.dataset.theme = darkTheme;
+      return darkTheme !== originalTheme;
     } else if (originalTheme) {
       htmlElement.dataset.theme = originalTheme;
       return false;
@@ -130,11 +189,22 @@ export const useThemeStore = create<ThemeStore>()(
         // Initial state
         themeMode: 'system',
         isDark: false,
+        lockedMode: null,
+        lightOnly: false,
 
         // Actions
         applyTheme: (mode: ThemeMode) => {
-          const isDark = applyThemeToDOM(mode);
-          set({ isDark });
+          // A trava vence o modo pedido: é o produto dizendo que aquela tela só
+          // existe num dos modos. O `themeMode` continua intacto no store.
+          const { lockedMode } = get();
+          const isDark = applyThemeToDOM(lockedMode ?? mode);
+          const originalTheme = document.documentElement.dataset.originalTheme;
+          set({
+            isDark,
+            lightOnly: originalTheme
+              ? LIGHT_ONLY_THEMES.has(originalTheme)
+              : false,
+          });
         },
 
         toggleTheme: () => {
@@ -158,6 +228,34 @@ export const useThemeStore = create<ThemeStore>()(
           const { applyTheme } = get();
           set({ themeMode: mode });
           applyTheme(mode);
+        },
+
+        lockTheme: (mode: ThemeMode | null) => {
+          const { lockedMode, themeMode, applyTheme } = get();
+          if (lockedMode === mode) return;
+
+          set({ lockedMode: mode });
+          // Reaplica: com trava vai para `mode`; ao liberar, volta para a
+          // preferência do usuário que estava guardada em `themeMode`.
+          applyTheme(themeMode);
+        },
+
+        setAppTheme: (app: string) => {
+          const htmlElement = document.documentElement;
+          // No boot o `data-original-theme` ainda não existe — o tema que a
+          // entrega injetou está no `data-theme` do index.html.
+          const received =
+            htmlElement.dataset.originalTheme ?? htmlElement.dataset.theme;
+          const appTheme = received
+            ? APP_THEME_MAP[app]?.[received]
+            : undefined;
+
+          // Instituição sem tema próprio para este app: nada a fazer.
+          if (!appTheme) return;
+
+          htmlElement.dataset.originalTheme = appTheme;
+          htmlElement.dataset.theme = appTheme;
+          get().applyTheme(get().themeMode);
         },
 
         setWhiteLabelTheme: (theme: string | null) => {
@@ -203,7 +301,9 @@ export const useThemeStore = create<ThemeStore>()(
         },
 
         handleSystemThemeChange: () => {
-          const { themeMode, applyTheme } = get();
+          const { themeMode, applyTheme, lockedMode } = get();
+          // Com trava, o SO não manda: a tela fica no modo imposto.
+          if (lockedMode) return;
           // Only respond to system changes when in system mode
           if (themeMode === 'system') {
             applyTheme('system');
@@ -216,7 +316,9 @@ export const useThemeStore = create<ThemeStore>()(
         storage: createJSONStorage(() => themeCookieStorage),
         partialize: (state) => ({
           themeMode: state.themeMode,
-        }), // Só persiste o themeMode, não o isDark
+        }), // Só persiste o themeMode — nem o isDark, nem o lockedMode. A trava
+        // é decisão de runtime do produto (feature flag), não preferência do
+        // usuário, e o cookie é compartilhado entre login e todos os apps.
       }
     ),
     {

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,6 +28,7 @@
 @import './themes/analytica/dark.css';
 @import './themes/papole/light.css';
 @import './themes/papole/dark.css';
+@import './themes/papole/aluno-light.css';
 
 /*
  * Regras globais do AccessibilityWidget (classes em <html> para
@@ -54,6 +55,7 @@
 
 /* Safelist para cores customizadas */
 @source inline("{bg,text,border}-{exam-1,exam-2,exam-3,exam-4}");
+@source inline("{bg,text,border}-{scent-1,scent-2,scent-3,scent-4}");
 @source inline("{bg,text,border}-{subject-1,subject-2,subject-3,subject-4,subject-5,subject-6,subject-7,subject-8,subject-9,subject-10,subject-11,subject-12,subject-13,subject-14,subject-15,subject-16}");
 @source inline("{bg,text,border}-{typography-1,typography-2}");
 

--- a/src/themes/papole/aluno-light.css
+++ b/src/themes/papole/aluno-light.css
@@ -23,7 +23,8 @@
    *
    * Grupos herdados de propósito dos defaults de ../tokens.css (a designer não
    * os definiu): tertiary, border, success, warning, info, indicator,
-   * subject/exam, question-type, map e sombras.
+   * subject/exam, question-type, map e sombras. As Scent colors, que a designer
+   * definiu, também moram lá — ver o comentário no fim deste arquivo.
    */
   [data-theme='papole-aluno-light'] {
     color-scheme: light;
@@ -103,12 +104,12 @@
     --color-text-950: #171610;
 
     /*
-     * Scent colors — grupo novo, exclusivo deste tema. Quatro cores chapadas,
-     * sem rampa, como vieram do Figma (nomes e valores da designer).
+     * Scent colors (cards de atividade da Fluência Leitora) NÃO são declaradas
+     * aqui: elas vivem no @theme de ../tokens.css, com os valores desta arte.
+     * É de lá que saem os utilitários `bg-scent-N` e a garantia de que
+     * `var(--color-scent-N)` resolve mesmo fora deste tema — um card renderizado
+     * sob outro tema ficaria sem fundo. Sobrescrever aqui só faria sentido se
+     * outra instituição pedisse cores próprias para esses cards.
      */
-    --color-scent-1: #8c8cec;
-    --color-scent-2: #a4d6a3;
-    --color-scent-3: #ef99a4;
-    --color-scent-4: #326fc3;
   }
 }

--- a/src/themes/papole/aluno-light.css
+++ b/src/themes/papole/aluno-light.css
@@ -1,0 +1,114 @@
+@layer base {
+  /*
+   * Papolê — tema do ALUNO (light).
+   *
+   * O Papolê tem DUAS paletas, e é de propósito:
+   * - `papole-light` (../papole/light.css): verde institucional, usado pelo
+   *   professor, gestor, backoffice e login. É o tema da instituição.
+   * - este: âmbar/dourado + verde, a arte do produto do aluno (Fluência
+   *   Leitora), que a designer entregou num Figma separado.
+   *
+   * Como a entrega injeta UMA string de tema por instituição (o placeholder
+   * `<!--THEME_COLOR-->` do post-build.js de cada app), o app do aluno troca
+   * `papole-light` por `papole-aluno-light` no boot — ver `APP_THEME_MAP` em
+   * ../../store/themeStore.ts.
+   *
+   * LIGHT ONLY: não existe versão dark desta paleta e não é pra existir. O
+   * `LIGHT_ONLY_THEMES` do themeStore garante que o modo escuro não caia no
+   * base-dark por engano.
+   *
+   * A designer entregou só os passos 100–900 de cada grupo. O passo base (sem
+   * sufixo), o 50 e o 950 são DERIVADOS por nós estendendo a própria rampa, na
+   * mesma proporção dos últimos passos — vale revisão dela.
+   *
+   * Grupos herdados de propósito dos defaults de ../tokens.css (a designer não
+   * os definiu): tertiary, border, success, warning, info, indicator,
+   * subject/exam, question-type, map e sombras.
+   */
+  [data-theme='papole-aluno-light'] {
+    color-scheme: light;
+
+    /* Primary Colors — âmbar/dourado (base/50/950 derivados) */
+    --color-primary: #fffdf7;
+    --color-primary-50: #fefbf0;
+    --color-primary-100: #fef8e6;
+    --color-primary-200: #fdefc4;
+    --color-primary-300: #fce397;
+    --color-primary-400: #fad561;
+    --color-primary-500: #f9cb3b;
+    --color-primary-600: #f5bc08;
+    --color-primary-700: #c29506;
+    --color-primary-800: #8f6e04;
+    --color-primary-900: #604903;
+    --color-primary-950: #3d2e02;
+
+    /* Secondary Colors — verde Papolê (base/50/950 derivados) */
+    --color-secondary: #f9fdfb;
+    --color-secondary-50: #f4fcf7;
+    --color-secondary-100: #ecf9f0;
+    --color-secondary-200: #d1f0db;
+    --color-secondary-300: #afe4c0;
+    --color-secondary-400: #85d69f;
+    --color-secondary-500: #287842;
+    --color-secondary-600: #216236;
+    --color-secondary-700: #1a4e2b;
+    --color-secondary-800: #133a20;
+    --color-secondary-900: #0d2615;
+    --color-secondary-950: #07160c;
+
+    /* Error / dismiss (base/50/950 derivados) */
+    --color-error: #fef6f7;
+    --color-error-50: #fdf2f3;
+    --color-error-100: #fceeef;
+    --color-error-200: #f7d6da;
+    --color-error-300: #f3bfc5;
+    --color-error-400: #eea7af;
+    --color-error-500: #ea909a;
+    --color-error-600: #de5261;
+    --color-error-700: #c12536;
+    --color-error-800: #831925;
+    --color-error-900: #450d13;
+    --color-error-950: #2b080c;
+
+    /* Background Colors — creme (base/50/950 derivados) */
+    --color-background: #fffefc;
+    --color-background-50: #fefdfa;
+    --color-background-100: #fcfbf8;
+    --color-background-200: #f9f8f2;
+    --color-background-300: #f6f5ec;
+    --color-background-400: #f4f1e6;
+    --color-background-500: #f1eee0;
+    --color-background-600: #d2c99c;
+    --color-background-700: #b4a458;
+    --color-background-800: #756a35;
+    --color-background-900: #312c16;
+    --color-background-950: #1a170b;
+
+    /*
+     * Text Colors — o grupo que o Figma chama de "Typography" (na lib o nome do
+     * grupo é `text`; `typography-1/2` é outra coisa, são cores de destaque).
+     * base/50/950 derivados.
+     */
+    --color-text: #fdfdfb;
+    --color-text-50: #fbfbfa;
+    --color-text-100: #f8f8f7;
+    --color-text-200: #ecebe9;
+    --color-text-300: #d9d8d4;
+    --color-text-400: #bcbab3;
+    --color-text-500: #9a988d;
+    --color-text-600: #7c7a6e;
+    --color-text-700: #5f5d54;
+    --color-text-800: #41403a;
+    --color-text-900: #262522;
+    --color-text-950: #171610;
+
+    /*
+     * Scent colors — grupo novo, exclusivo deste tema. Quatro cores chapadas,
+     * sem rampa, como vieram do Figma (nomes e valores da designer).
+     */
+    --color-scent-1: #8c8cec;
+    --color-scent-2: #a4d6a3;
+    --color-scent-3: #ef99a4;
+    --color-scent-4: #326fc3;
+  }
+}

--- a/src/themes/themeContrast.test.ts
+++ b/src/themes/themeContrast.test.ts
@@ -109,3 +109,22 @@ describe('contrato de contraste dos temas', () => {
     }
   );
 });
+
+/*
+ * As Scent colors precisam viver no @theme do tokens.css, não dentro de um
+ * `[data-theme=…]`. É o @theme que gera os utilitários (`bg-scent-1`) e que faz
+ * `var(--color-scent-N)` resolver em qualquer tema. Declaradas só num tema, o
+ * utilitário não existe e o `var()` vira transparente nos demais — que é como
+ * elas entraram, e o card de atividade da Fluência Leitora ficava sem fundo
+ * fora do tema do aluno.
+ */
+describe('scent colors', () => {
+  it.each([1, 2, 3, 4])(
+    '--color-scent-%i é declarada no tokens.css',
+    (index) => {
+      expect(readToken(TOKENS_FILE, `--color-scent-${index}`)).toMatch(
+        /^#[0-9a-fA-F]{3,8}$/
+      );
+    }
+  );
+});

--- a/src/themes/themeContrast.test.ts
+++ b/src/themes/themeContrast.test.ts
@@ -60,8 +60,20 @@ const themeDirs = readdirSync(THEMES_DIR, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name);
 
+/*
+ * Um caso por ARQUIVO de tema, não por par light/dark fixo: além de
+ * `light.css`/`dark.css`, um tema pode ter variantes próprias de um app — o
+ * `papole/aluno-light.css` é o tema da Fluência Leitora. Enumerar os arquivos
+ * faz variante nova entrar no teste sozinha.
+ */
 const cases = themeDirs.flatMap((theme) =>
-  (['light', 'dark'] as const).map((mode) => ({ theme, mode }))
+  readdirSync(join(THEMES_DIR, theme))
+    .filter((entry) => entry.endsWith('.css'))
+    .map((entry) => ({
+      theme,
+      mode: entry.replace(/\.css$/, ''),
+      file: join(THEMES_DIR, theme, entry),
+    }))
 );
 
 describe('contrato de contraste dos temas', () => {
@@ -71,10 +83,7 @@ describe('contrato de contraste dos temas', () => {
 
   it.each(cases)(
     '$theme/$mode: --color-primary contrasta com --color-primary-800',
-    ({ theme, mode }) => {
-      const file = join(THEMES_DIR, theme, `${mode}.css`);
-      if (!existsSync(file)) return;
-
+    ({ theme, mode, file }) => {
       // Quando o tema não declara o token, ele herda o default do tokens.css.
       const foreground =
         readToken(file, '--color-primary') ??

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -186,6 +186,20 @@
   --color-typography-1: #b00c9e;
   --color-typography-2: #745a07;
 
+  /*
+   * Scent Colors — quatro cores chapadas (sem rampa) que pintam os cards de
+   * atividade da Fluência Leitora. Vieram do Figma do aluno do Papolê, mas ficam
+   * aqui no @theme, como `subject-*` e `exam-*`: é o @theme que gera os
+   * utilitários (`bg-scent-1` e afins) e que garante que `var(--color-scent-N)`
+   * resolva em QUALQUER tema. Declaradas só dentro de um `[data-theme=…]`, elas
+   * não geravam utilitário nenhum e o `var()` caía em transparente fora do tema
+   * do aluno. Um tema pode sobrescrevê-las como faz com os subjects.
+   */
+  --color-scent-1: #8c8cec;
+  --color-scent-2: #a4d6a3;
+  --color-scent-3: #ef99a4;
+  --color-scent-4: #326fc3;
+
   /* Question Type Colors */
   --color-question-type-multiple-choice: #6B21A8;
   --color-question-type-fill-blank: #0D4E6E;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Papole student light theme with updated colors and light-only behavior.
  * Added app-specific theme selection and runtime theme locking.
  * Theme controls are hidden when theme changes are locked.
* **Style**
  * Updated button outlines and reading-fluency cards to use theme-based colors.
  * Added support for additional scent color tokens.
* **Tests**
  * Expanded coverage for theme locking, app themes, light-only mode, and theme color accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->