### PR TITLE
feat(MultiSearchSelect): adiciona select com busca e multipla selecao

### DIFF
--- a/src/components/MultiSearchSelect/MultiSearchSelect.stories.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.stories.tsx
@@ -1,0 +1,219 @@
+import type { Story } from '@ladle/react';
+import { useState } from 'react';
+import { MultiSearchSelect } from './MultiSearchSelect';
+import type { MultiSearchSelectOption } from './MultiSearchSelect';
+
+const sizes = ['small', 'medium', 'large'] as const;
+const variants = ['outlined', 'underlined', 'rounded'] as const;
+
+const classOptions: MultiSearchSelectOption[] = [
+  { value: 'c-1', label: 'A - NEM EPT IF TEC DESE SIST-ET IC' },
+  { value: 'c-2', label: 'A - NOVO ENSINO MEDIO-PROFISSIONAL' },
+  { value: 'c-3', label: 'B - ENSINO MEDIO FGB' },
+  { value: 'c-4', label: 'B - ENS MEDIO IF LGG/CHS L ING CCM' },
+  { value: 'c-5', label: 'C - ENSINO MEDIO' },
+];
+
+const fruitOptions: MultiSearchSelectOption[] = [
+  { value: 'apple', label: 'Maçã' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'orange', label: 'Laranja' },
+  { value: 'grape', label: 'Uva' },
+  { value: 'strawberry', label: 'Morango' },
+];
+
+export const Default: Story = () => {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Turmas"
+        values={values}
+        onValuesChange={setValues}
+        options={classOptions}
+        placeholder="Selecione as turmas"
+        searchPlaceholder="Buscar turma..."
+      />
+      <p className="mt-4 text-sm text-text-500">
+        Selecionadas: {values.length ? values.join(', ') : 'nenhuma'}
+      </p>
+    </div>
+  );
+};
+
+export const WithPreselectedValues: Story = () => {
+  const [values, setValues] = useState<string[]>(['c-1', 'c-3']);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Turmas"
+        values={values}
+        onValuesChange={setValues}
+        options={classOptions}
+      />
+    </div>
+  );
+};
+
+/** Chips beyond `maxVisibleChips` collapse into a counter. */
+export const ChipOverflow: Story = () => {
+  const [values, setValues] = useState<string[]>([
+    'c-1',
+    'c-2',
+    'c-3',
+    'c-4',
+    'c-5',
+  ]);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Turmas"
+        values={values}
+        onValuesChange={setValues}
+        options={classOptions}
+        maxVisibleChips={2}
+      />
+    </div>
+  );
+};
+
+/**
+ * A selected value missing from `options` is kept and labelled, never dropped —
+ * otherwise a still-loading list would silently discard a real binding.
+ */
+export const UnknownValue: Story = () => {
+  const [values, setValues] = useState<string[]>(['c-1', 'removed-id']);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Turmas"
+        values={values}
+        onValuesChange={setValues}
+        options={classOptions}
+        unknownValueLabel="Turma não encontrada"
+      />
+    </div>
+  );
+};
+
+export const WithHelperText: Story = () => {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Frutas"
+        values={values}
+        onValuesChange={setValues}
+        options={fruitOptions}
+        helperText="Escolha ao menos uma fruta"
+      />
+    </div>
+  );
+};
+
+export const WithError: Story = () => {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Frutas"
+        values={values}
+        onValuesChange={setValues}
+        options={fruitOptions}
+        errorMessage="Selecione ao menos uma fruta"
+      />
+    </div>
+  );
+};
+
+export const DisabledOptions: Story = () => {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <div className="w-96 p-4">
+      <MultiSearchSelect
+        label="Frutas"
+        values={values}
+        onValuesChange={setValues}
+        options={fruitOptions.map((option, index) => ({
+          ...option,
+          disabled: index % 2 === 1,
+        }))}
+      />
+    </div>
+  );
+};
+
+export const States: Story = () => {
+  const [values, setValues] = useState<string[]>(['apple']);
+
+  return (
+    <div className="flex w-96 flex-col gap-6 p-4">
+      <MultiSearchSelect
+        label="Desabilitado"
+        values={values}
+        onValuesChange={setValues}
+        options={fruitOptions}
+        disabled
+      />
+      <MultiSearchSelect
+        label="Carregando"
+        values={[]}
+        onValuesChange={setValues}
+        options={[]}
+        loading
+      />
+      <MultiSearchSelect
+        label="Sem opções"
+        values={[]}
+        onValuesChange={setValues}
+        options={[]}
+        emptyText="Nenhuma fruta encontrada"
+      />
+    </div>
+  );
+};
+
+export const Sizes: Story = () => {
+  const [values, setValues] = useState<string[]>(['apple', 'banana']);
+
+  return (
+    <div className="flex w-96 flex-col gap-6 p-4">
+      {sizes.map((size) => (
+        <MultiSearchSelect
+          key={size}
+          label={`Size: ${size}`}
+          values={values}
+          onValuesChange={setValues}
+          options={fruitOptions}
+          size={size}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const Variants: Story = () => {
+  const [values, setValues] = useState<string[]>(['apple']);
+
+  return (
+    <div className="flex w-96 flex-col gap-6 p-4">
+      {variants.map((variant) => (
+        <MultiSearchSelect
+          key={variant}
+          label={`Variant: ${variant}`}
+          values={values}
+          onValuesChange={setValues}
+          options={fruitOptions}
+          variant={variant}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/MultiSearchSelect/MultiSearchSelect.stories.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.stories.tsx
@@ -1,6 +1,7 @@
 import type { Story } from '@ladle/react';
 import { useState } from 'react';
 import { MultiSearchSelect } from './MultiSearchSelect';
+import Text from '../Text/Text';
 import type { MultiSearchSelectOption } from './MultiSearchSelect';
 
 const sizes = ['small', 'medium', 'large'] as const;
@@ -35,9 +36,9 @@ export const Default: Story = () => {
         placeholder="Selecione as turmas"
         searchPlaceholder="Buscar turma..."
       />
-      <p className="mt-4 text-sm text-text-500">
+      <Text size="sm" className="mt-4 text-text-500">
         Selecionadas: {values.length ? values.join(', ') : 'nenhuma'}
-      </p>
+      </Text>
     </div>
   );
 };

--- a/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
@@ -55,6 +55,20 @@ describe('MultiSearchSelect', () => {
       expect(screen.getByText('Turmas')).toBeInTheDocument();
     });
 
+    it('names the trigger after the label', () => {
+      setup();
+      expect(
+        screen.getByRole('combobox', { name: 'Turmas' })
+      ).toBeInTheDocument();
+    });
+
+    it('omits aria-labelledby when there is no label', () => {
+      setup({ label: undefined });
+      expect(screen.getByRole('combobox')).not.toHaveAttribute(
+        'aria-labelledby'
+      );
+    });
+
     it('renders one chip per selected value', () => {
       setup({ values: ['c-1', 'c-2'] });
 
@@ -540,6 +554,32 @@ describe('MultiSearchSelect', () => {
       const panel = screen.getByRole('listbox').parentElement as HTMLElement;
       expect(panel.style.bottom).toBe('104px');
       expect(panel.style.top).toBe('');
+    });
+
+    it.each([
+      ['scrolled past the bottom edge', { top: 900, bottom: 932 }],
+      ['scrolled past the top edge', { top: -200, bottom: -168 }],
+    ])('keeps a usable height when the trigger is %s', (_label, rect) => {
+      window.innerHeight = 800;
+      stubTriggerRect(rect);
+      setup();
+      openPanel();
+
+      const panel = screen.getByRole('listbox').parentElement as HTMLElement;
+      const maxHeight = Number.parseInt(panel.style.maxHeight, 10);
+
+      expect(maxHeight).toBeGreaterThan(0);
+      expect(maxHeight).toBeLessThanOrEqual(300);
+    });
+
+    it('caps the height at the documented maximum when there is plenty of room', () => {
+      window.innerHeight = 2000;
+      stubTriggerRect({ top: 100, bottom: 132 });
+      setup();
+      openPanel();
+
+      const panel = screen.getByRole('listbox').parentElement as HTMLElement;
+      expect(panel.style.maxHeight).toBe('300px');
     });
 
     it('keeps the panel glued to the trigger on scroll', () => {

--- a/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
@@ -1,0 +1,607 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentProps } from 'react';
+import { MultiSearchSelect } from './MultiSearchSelect';
+import type { MultiSearchSelectOption } from './types';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useId: () => 'test-id',
+}));
+
+// JSDOM implements neither of these, and the component relies on both
+Element.prototype.scrollIntoView = jest.fn();
+
+const OPTIONS: MultiSearchSelectOption[] = [
+  { value: 'c-1', label: 'A - NEM EPT' },
+  { value: 'c-2', label: 'B - ENS MEDIO' },
+  { value: 'c-3', label: 'C - ENS MEDIO' },
+];
+
+const SEARCH_PLACEHOLDER = 'Buscar turma...';
+
+const setup = (props?: Partial<ComponentProps<typeof MultiSearchSelect>>) => {
+  const onValuesChange = jest.fn();
+  const utils = render(
+    <MultiSearchSelect
+      label="Turmas"
+      values={[]}
+      onValuesChange={onValuesChange}
+      options={OPTIONS}
+      placeholder="Selecione as turmas"
+      searchPlaceholder={SEARCH_PLACEHOLDER}
+      {...props}
+    />
+  );
+  return { onValuesChange, ...utils };
+};
+
+const openPanel = () => fireEvent.click(screen.getByRole('combobox'));
+const searchField = () => screen.getByPlaceholderText(SEARCH_PLACEHOLDER);
+
+describe('MultiSearchSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('closed state', () => {
+    it('renders the placeholder when nothing is selected', () => {
+      setup();
+      expect(screen.getByText('Selecione as turmas')).toBeInTheDocument();
+    });
+
+    it('renders the label', () => {
+      setup();
+      expect(screen.getByText('Turmas')).toBeInTheDocument();
+    });
+
+    it('renders one chip per selected value', () => {
+      setup({ values: ['c-1', 'c-2'] });
+
+      expect(screen.getByText('A - NEM EPT')).toBeInTheDocument();
+      expect(screen.getByText('B - ENS MEDIO')).toBeInTheDocument();
+      expect(screen.queryByText('Selecione as turmas')).not.toBeInTheDocument();
+    });
+
+    it('collapses chips beyond maxVisibleChips into a counter', () => {
+      setup({ values: ['c-1', 'c-2', 'c-3'], maxVisibleChips: 2 });
+
+      expect(screen.getByText('A - NEM EPT')).toBeInTheDocument();
+      expect(screen.getByText('B - ENS MEDIO')).toBeInTheDocument();
+      expect(screen.queryByText('C - ENS MEDIO')).not.toBeInTheDocument();
+      expect(screen.getByText('+1')).toBeInTheDocument();
+    });
+
+    it('keeps a value missing from options and labels it as unknown', () => {
+      setup({
+        values: ['gone'],
+        unknownValueLabel: 'Turma não encontrada',
+      });
+
+      expect(screen.getByText('Turma não encontrada')).toBeInTheDocument();
+    });
+
+    it('removes only the clicked chip', () => {
+      const { onValuesChange } = setup({ values: ['c-1', 'c-2'] });
+
+      fireEvent.click(screen.getByLabelText('Remover A - NEM EPT'));
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-2']);
+    });
+
+    it('does not open the panel when a chip is removed', () => {
+      setup({ values: ['c-1'] });
+
+      fireEvent.click(screen.getByLabelText('Remover A - NEM EPT'));
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('keeps a key pressed on a chip from reaching the trigger', () => {
+      setup({ values: ['c-1'] });
+
+      fireEvent.keyDown(screen.getByLabelText('Remover A - NEM EPT'), {
+        key: 'Enter',
+      });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('lets an unknown value be removed', () => {
+      const { onValuesChange } = setup({
+        values: ['gone'],
+        unknownValueLabel: 'Turma não encontrada',
+      });
+
+      fireEvent.click(screen.getByLabelText('Remover Turma não encontrada'));
+
+      expect(onValuesChange).toHaveBeenCalledWith([]);
+    });
+
+    it('shows the loading text instead of chips', () => {
+      setup({ values: ['c-1'], loading: true, loadingText: 'Carregando...' });
+
+      expect(screen.getByText('Carregando...')).toBeInTheDocument();
+      expect(screen.queryByText('A - NEM EPT')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('opening', () => {
+    it('reveals the search box and the option list', () => {
+      setup();
+      openPanel();
+
+      expect(searchField()).toBeInTheDocument();
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      expect(screen.getAllByRole('option')).toHaveLength(3);
+    });
+
+    it('marks the listbox as multiselectable and focusable', () => {
+      setup();
+      openPanel();
+
+      const listbox = screen.getByRole('listbox');
+      expect(listbox).toHaveAttribute('aria-multiselectable');
+      expect(listbox).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('does not open when disabled', () => {
+      setup({ disabled: true });
+      openPanel();
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('does not open when loading', () => {
+      setup({ loading: true });
+      openPanel();
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('opens on Enter from the trigger', () => {
+      setup();
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('opens on ArrowDown from the trigger', () => {
+      setup();
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('ignores unrelated keys on the trigger', () => {
+      setup();
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'a' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('ignores keys on the trigger while disabled', () => {
+      setup({ disabled: true });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('closes when the trigger is clicked again', () => {
+      setup();
+      openPanel();
+      openPanel();
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('shows emptyText when there are no options', () => {
+      setup({ options: [], emptyText: 'Nenhuma turma encontrada' });
+      openPanel();
+
+      expect(screen.getByText('Nenhuma turma encontrada')).toBeInTheDocument();
+    });
+  });
+
+  describe('selection', () => {
+    it('appends the clicked value', () => {
+      const { onValuesChange } = setup({ values: ['c-1'] });
+      openPanel();
+
+      fireEvent.click(
+        within(screen.getByRole('listbox')).getByText('B - ENS MEDIO')
+      );
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-1', 'c-2']);
+    });
+
+    it('removes an already selected value', () => {
+      const { onValuesChange } = setup({ values: ['c-1', 'c-2'] });
+      openPanel();
+
+      fireEvent.click(
+        within(screen.getByRole('listbox')).getByText('A - NEM EPT')
+      );
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-2']);
+    });
+
+    it('keeps the panel open after toggling', () => {
+      setup();
+      openPanel();
+
+      fireEvent.click(
+        within(screen.getByRole('listbox')).getByText('A - NEM EPT')
+      );
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('marks selected options with aria-selected', () => {
+      setup({ values: ['c-2'] });
+      openPanel();
+
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveAttribute('aria-selected', 'false');
+      expect(options[1]).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('ignores clicks on disabled options', () => {
+      const { onValuesChange } = setup({
+        options: [{ value: 'c-1', label: 'A - NEM EPT', disabled: true }],
+      });
+      openPanel();
+
+      fireEvent.click(
+        within(screen.getByRole('listbox')).getByText('A - NEM EPT')
+      );
+
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('toggles a focused option with Enter', () => {
+      const { onValuesChange } = setup();
+      openPanel();
+
+      fireEvent.keyDown(screen.getAllByRole('option')[1], { key: 'Enter' });
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-2']);
+    });
+
+    it('toggles a focused option with Space', () => {
+      const { onValuesChange } = setup({ values: ['c-1'] });
+      openPanel();
+
+      fireEvent.keyDown(screen.getAllByRole('option')[0], { key: ' ' });
+
+      expect(onValuesChange).toHaveBeenCalledWith([]);
+    });
+
+    it('ignores other keys on a focused option', () => {
+      const { onValuesChange } = setup();
+      openPanel();
+
+      fireEvent.keyDown(screen.getAllByRole('option')[0], { key: 'a' });
+
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores keyboard activation on a disabled option', () => {
+      const { onValuesChange } = setup({
+        options: [{ value: 'c-1', label: 'A - NEM EPT', disabled: true }],
+      });
+      openPanel();
+
+      fireEvent.keyDown(screen.getAllByRole('option')[0], { key: 'Enter' });
+
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('search', () => {
+    it('filters options locally, case-insensitively', () => {
+      setup();
+      openPanel();
+
+      fireEvent.change(searchField(), { target: { value: 'ens medio' } });
+
+      expect(screen.getAllByRole('option')).toHaveLength(2);
+    });
+
+    it('keeps the query after a toggle', () => {
+      setup();
+      openPanel();
+
+      fireEvent.change(searchField(), { target: { value: 'ens medio' } });
+      fireEvent.click(
+        within(screen.getByRole('listbox')).getByText('B - ENS MEDIO')
+      );
+
+      expect(searchField()).toHaveValue('ens medio');
+    });
+
+    it('shows emptyText when nothing matches', () => {
+      setup({ emptyText: 'Nenhuma turma encontrada' });
+      openPanel();
+
+      fireEvent.change(searchField(), { target: { value: 'zzz' } });
+
+      expect(screen.getByText('Nenhuma turma encontrada')).toBeInTheDocument();
+    });
+
+    it('resets the query when the dropdown is reopened', () => {
+      setup();
+      openPanel();
+      fireEvent.change(searchField(), { target: { value: 'zzz' } });
+      openPanel();
+      openPanel();
+
+      expect(searchField()).toHaveValue('');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('toggles the highlighted option with ArrowDown then Enter', () => {
+      const { onValuesChange } = setup();
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'ArrowDown' });
+      fireEvent.keyDown(searchField(), { key: 'Enter' });
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-1']);
+    });
+
+    it('wraps around with ArrowUp', () => {
+      const { onValuesChange } = setup();
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'ArrowUp' });
+      fireEvent.keyDown(searchField(), { key: 'Enter' });
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-3']);
+    });
+
+    it('skips disabled options while arrowing', () => {
+      const { onValuesChange } = setup({
+        options: [
+          { value: 'c-1', label: 'A - NEM EPT', disabled: true },
+          { value: 'c-2', label: 'B - ENS MEDIO' },
+        ],
+      });
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'ArrowDown' });
+      fireEvent.keyDown(searchField(), { key: 'Enter' });
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-2']);
+    });
+
+    it('highlights nothing when every option is disabled', () => {
+      const { onValuesChange } = setup({
+        options: OPTIONS.map((option) => ({ ...option, disabled: true })),
+      });
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'ArrowDown' });
+      fireEvent.keyDown(searchField(), { key: 'Enter' });
+
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('does nothing on Enter without a highlighted option', () => {
+      const { onValuesChange } = setup();
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'Enter' });
+
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('removes the last chip on Backspace with an empty query', () => {
+      const { onValuesChange } = setup({ values: ['c-1', 'c-2'] });
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'Backspace' });
+
+      expect(onValuesChange).toHaveBeenCalledWith(['c-1']);
+    });
+
+    it('does not remove a chip on Backspace while typing', () => {
+      const { onValuesChange } = setup({ values: ['c-1'] });
+      openPanel();
+
+      fireEvent.change(searchField(), { target: { value: 'a' } });
+      fireEvent.keyDown(searchField(), { key: 'Backspace' });
+
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dismissal', () => {
+    it('closes on Escape from the search field', () => {
+      setup();
+      openPanel();
+
+      fireEvent.keyDown(searchField(), { key: 'Escape' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('closes on Escape from a focused option', () => {
+      setup();
+      openPanel();
+
+      fireEvent.keyDown(screen.getAllByRole('option')[0], { key: 'Escape' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('closes on Escape from the trigger', () => {
+      setup();
+      openPanel();
+
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    /**
+     * Modals in this library close on a document-level Escape listener, so a
+     * bubbling key would discard the surrounding form along with the dropdown.
+     */
+    it.each([
+      ['the search field', () => searchField()],
+      ['an option', () => screen.getAllByRole('option')[0]],
+      ['the trigger', () => screen.getByRole('combobox')],
+    ])('does not let Escape from %s bubble out', (_label, getTarget) => {
+      const onOuterEscape = jest.fn();
+
+      render(
+        <div
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') onOuterEscape();
+          }}
+        >
+          <MultiSearchSelect
+            label="Turmas"
+            values={[]}
+            onValuesChange={jest.fn()}
+            options={OPTIONS}
+            searchPlaceholder={SEARCH_PLACEHOLDER}
+          />
+        </div>
+      );
+
+      fireEvent.click(screen.getByRole('combobox'));
+      fireEvent.keyDown(getTarget(), { key: 'Escape' });
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(onOuterEscape).not.toHaveBeenCalled();
+    });
+
+    it('closes on a mousedown outside the trigger and panel', () => {
+      setup();
+      openPanel();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('stays open on a mousedown inside the panel', () => {
+      setup();
+      openPanel();
+
+      fireEvent.mouseDown(screen.getByRole('listbox'));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('positioning', () => {
+    const stubTriggerRect = (rect: Partial<DOMRect>) => {
+      jest
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          top: 0,
+          bottom: 0,
+          left: 0,
+          width: 200,
+          height: 32,
+          right: 200,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+          ...rect,
+        } as DOMRect);
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('opens below the trigger when there is room', () => {
+      window.innerHeight = 800;
+      stubTriggerRect({ top: 100, bottom: 132 });
+      setup();
+      openPanel();
+
+      const panel = screen.getByRole('listbox').parentElement as HTMLElement;
+      expect(panel.style.top).toBe('136px');
+      expect(panel.style.bottom).toBe('');
+    });
+
+    it('flips above the trigger when the space below is too tight', () => {
+      window.innerHeight = 800;
+      stubTriggerRect({ top: 700, bottom: 732 });
+      setup();
+      openPanel();
+
+      const panel = screen.getByRole('listbox').parentElement as HTMLElement;
+      expect(panel.style.bottom).toBe('104px');
+      expect(panel.style.top).toBe('');
+    });
+
+    it('keeps the panel glued to the trigger on scroll', () => {
+      window.innerHeight = 800;
+      stubTriggerRect({ top: 100, bottom: 132 });
+      setup();
+      openPanel();
+
+      stubTriggerRect({ top: 60, bottom: 92 });
+      fireEvent.scroll(window);
+
+      const panel = screen.getByRole('listbox').parentElement as HTMLElement;
+      expect(panel.style.top).toBe('96px');
+    });
+  });
+
+  describe('helper and error text', () => {
+    it('renders the helper text', () => {
+      setup({ helperText: 'Escolha ao menos uma' });
+      expect(screen.getByText('Escolha ao menos uma')).toBeInTheDocument();
+    });
+
+    it('renders the error message and flags the trigger as invalid', () => {
+      setup({ errorMessage: 'Campo obrigatório' });
+
+      expect(screen.getByText('Campo obrigatório')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+    });
+
+    it('hides the helper text when an error is present', () => {
+      setup({ helperText: 'Ajuda', errorMessage: 'Campo obrigatório' });
+
+      expect(screen.queryByText('Ajuda')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sizes and variants', () => {
+    it.each(['small', 'medium', 'large'] as const)(
+      'renders size %s',
+      (size) => {
+        setup({ size });
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      }
+    );
+
+    it.each(['outlined', 'underlined', 'rounded'] as const)(
+      'renders variant %s',
+      (variant) => {
+        setup({ variant });
+        expect(screen.getByRole('combobox')).toBeInTheDocument();
+      }
+    );
+
+    it('accepts a custom id', () => {
+      setup({ id: 'turmas-select' });
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'id',
+        'turmas-select'
+      );
+    });
+  });
+});

--- a/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ComponentProps } from 'react';
 import { MultiSearchSelect } from './MultiSearchSelect';
@@ -9,7 +9,7 @@ jest.mock('react', () => ({
   useId: () => 'test-id',
 }));
 
-// JSDOM implements neither of these, and the component relies on both
+// JSDOM does not implement scrollIntoView, and the component calls it
 Element.prototype.scrollIntoView = jest.fn();
 
 const OPTIONS: MultiSearchSelectOption[] = [
@@ -530,8 +530,13 @@ describe('MultiSearchSelect', () => {
         } as DOMRect);
     };
 
+    const originalInnerHeight = window.innerHeight;
+
+    // A plain assignment to window.innerHeight outlives restoreAllMocks, so it
+    // is put back by hand to keep the rest of the suite order-independent.
     afterEach(() => {
       jest.restoreAllMocks();
+      window.innerHeight = originalInnerHeight;
     });
 
     it('opens below the trigger when there is room', () => {
@@ -582,17 +587,51 @@ describe('MultiSearchSelect', () => {
       expect(panel.style.maxHeight).toBe('300px');
     });
 
-    it('keeps the panel glued to the trigger on scroll', () => {
+    /** Repositioning is throttled to one measurement per animation frame. */
+    const scrollAndFlushFrame = async (times = 1) => {
+      await act(async () => {
+        for (let i = 0; i < times; i++) fireEvent.scroll(window);
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+    };
+
+    it('keeps the panel glued to the trigger on scroll', async () => {
       window.innerHeight = 800;
       stubTriggerRect({ top: 100, bottom: 132 });
       setup();
       openPanel();
 
       stubTriggerRect({ top: 60, bottom: 92 });
-      fireEvent.scroll(window);
+      await scrollAndFlushFrame();
 
       const panel = screen.getByRole('listbox').parentElement as HTMLElement;
       expect(panel.style.top).toBe('96px');
+    });
+
+    it('measures the trigger once per frame when scroll events pile up', async () => {
+      window.innerHeight = 800;
+      stubTriggerRect({ top: 100, bottom: 132 });
+      setup();
+      openPanel();
+
+      const measure = HTMLElement.prototype.getBoundingClientRect as jest.Mock;
+      measure.mockClear();
+      await scrollAndFlushFrame(3);
+
+      expect(measure).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops a scheduled reposition when the panel closes', () => {
+      window.innerHeight = 800;
+      stubTriggerRect({ top: 100, bottom: 132 });
+      setup();
+      openPanel();
+
+      const cancelFrame = jest.spyOn(window, 'cancelAnimationFrame');
+      fireEvent.scroll(window);
+      fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Escape' });
+
+      expect(cancelFrame).toHaveBeenCalled();
     });
   });
 

--- a/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ComponentProps } from 'react';
 import { MultiSearchSelect } from './MultiSearchSelect';
@@ -588,11 +594,8 @@ describe('MultiSearchSelect', () => {
     });
 
     /** Repositioning is throttled to one measurement per animation frame. */
-    const scrollAndFlushFrame = async (times = 1) => {
-      await act(async () => {
-        for (let i = 0; i < times; i++) fireEvent.scroll(window);
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-      });
+    const scroll = (times = 1) => {
+      for (let i = 0; i < times; i++) fireEvent.scroll(window);
     };
 
     it('keeps the panel glued to the trigger on scroll', async () => {
@@ -602,10 +605,10 @@ describe('MultiSearchSelect', () => {
       openPanel();
 
       stubTriggerRect({ top: 60, bottom: 92 });
-      await scrollAndFlushFrame();
+      scroll();
 
       const panel = screen.getByRole('listbox').parentElement as HTMLElement;
-      expect(panel.style.top).toBe('96px');
+      await waitFor(() => expect(panel.style.top).toBe('96px'));
     });
 
     it('measures the trigger once per frame when scroll events pile up', async () => {
@@ -616,9 +619,9 @@ describe('MultiSearchSelect', () => {
 
       const measure = HTMLElement.prototype.getBoundingClientRect as jest.Mock;
       measure.mockClear();
-      await scrollAndFlushFrame(3);
+      scroll(3);
 
-      expect(measure).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(measure).toHaveBeenCalledTimes(1));
     });
 
     it('drops a scheduled reposition when the panel closes', () => {

--- a/src/components/MultiSearchSelect/MultiSearchSelect.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.tsx
@@ -34,6 +34,11 @@ import type { MultiSearchSelectOption, MultiSearchSelectProps } from './types';
  * Filtering is local, so there is no async search or pagination — pass an
  * already loaded option list.
  *
+ * Follows the W3C ARIA combobox pattern (`combobox` -> `listbox` -> `option`),
+ * the same one `SearchSelect` uses. No native element covers it: `select
+ * multiple` and `datalist` support neither removable chips, nor an inline
+ * search field, nor a checkbox per row.
+ *
  * @example
  * ```tsx
  * <MultiSearchSelect
@@ -79,6 +84,7 @@ export function MultiSearchSelect({
   const listboxId = `${selectId}-listbox`;
   const helperId = `${selectId}-helper`;
   const errorId = `${selectId}-error`;
+  const labelId = `${selectId}-label`;
 
   const { triggerRect, measureTrigger, dropdownStyles } = useDropdownPosition({
     open,
@@ -279,7 +285,7 @@ export function MultiSearchSelect({
         />
       </div>
 
-      <div
+      <div // NOSONAR — ARIA combobox pattern, no native tag fits (see JSDoc)
         ref={listRef}
         id={listboxId}
         role="listbox"
@@ -307,6 +313,7 @@ export function MultiSearchSelect({
     <div className={cn('w-full', className)}>
       {label && (
         <label
+          id={labelId}
           htmlFor={selectId}
           className={cn(
             'block font-bold text-text-900 mb-1.5',
@@ -317,6 +324,11 @@ export function MultiSearchSelect({
         </label>
       )}
 
+      {/*
+        `htmlFor` alone would not name this trigger: a `label` only associates
+        with labelable elements, which a `div` is not. `aria-labelledby` is what
+        gives it an accessible name.
+      */}
       <div
         ref={triggerRef}
         id={selectId}
@@ -325,6 +337,7 @@ export function MultiSearchSelect({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-controls={open ? listboxId : undefined}
+        aria-labelledby={label ? labelId : undefined}
         aria-invalid={!!errorMessage}
         aria-describedby={describedById}
         aria-disabled={!interactive}

--- a/src/components/MultiSearchSelect/MultiSearchSelect.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.tsx
@@ -1,0 +1,535 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { CaretDownIcon } from '@phosphor-icons/react/dist/csr/CaretDown';
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
+import Input from '../Input/Input';
+import Text from '../Text/Text';
+import { cn } from '../../utils/utils';
+import {
+  LABEL_SIZE_CLASSES,
+  OPEN_KEYS,
+  PADDING_CLASSES,
+  SIZE_CLASSES,
+  VARIANT_CLASSES,
+} from './constants';
+import { OptionList } from './OptionList';
+import { TriggerContent } from './TriggerContent';
+import { useDropdownPosition } from './useDropdownPosition';
+import type { MultiSearchSelectOption, MultiSearchSelectProps } from './types';
+
+/**
+ * Searchable multi-select: the sibling of `SearchSelect` for picking several
+ * values at once. Same sizing, borders, portalled dropdown and keyboard model,
+ * with removable chips in the trigger and a checkbox per option.
+ *
+ * Filtering is local, so there is no async search or pagination — pass an
+ * already loaded option list.
+ *
+ * @example
+ * ```tsx
+ * <MultiSearchSelect
+ *   label="Turmas"
+ *   values={classIds}
+ *   onValuesChange={setClassIds}
+ *   options={classes.map((c) => ({ value: c.id, label: c.name }))}
+ *   unknownValueLabel="Turma não encontrada"
+ * />
+ * ```
+ */
+export function MultiSearchSelect({
+  values,
+  onValuesChange,
+  options,
+  label,
+  placeholder = 'Selecione...',
+  searchPlaceholder = 'Buscar...',
+  emptyText = 'Nenhum resultado encontrado',
+  loadingText = 'Carregando...',
+  unknownValueLabel = 'Item não encontrado',
+  helperText,
+  errorMessage,
+  disabled = false,
+  loading = false,
+  size = 'small',
+  variant = 'outlined',
+  className,
+  id,
+  maxVisibleChips = 3,
+}: Readonly<MultiSearchSelectProps>) {
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const generatedId = useId();
+  const selectId = id ?? `multi-search-select-${generatedId}`;
+  const listboxId = `${selectId}-listbox`;
+  const helperId = `${selectId}-helper`;
+  const errorId = `${selectId}-error`;
+
+  const { triggerRect, measureTrigger, dropdownStyles } = useDropdownPosition({
+    open,
+    triggerRef,
+  });
+
+  const filteredOptions = useMemo(
+    () => filterOptions(options, searchQuery),
+    [options, searchQuery]
+  );
+
+  const selectedOptions = useMemo(
+    () => resolveSelectedOptions(values, options, unknownValueLabel),
+    [values, options, unknownValueLabel]
+  );
+
+  const interactive = !disabled && !loading;
+
+  const closeDropdown = useCallback((restoreFocus = false) => {
+    setOpen(false);
+    setSearchQuery('');
+    if (restoreFocus) triggerRef.current?.focus();
+  }, []);
+
+  const openDropdown = useCallback(() => {
+    measureTrigger();
+    setSearchQuery('');
+    setHighlightedIndex(-1);
+    setOpen(true);
+  }, [measureTrigger]);
+
+  const toggleOpen = useCallback(() => {
+    if (!interactive) return;
+    if (open) {
+      closeDropdown();
+      return;
+    }
+    openDropdown();
+  }, [interactive, open, closeDropdown, openDropdown]);
+
+  /**
+   * Toggling deliberately keeps the dropdown and the search query alive: picks
+   * usually come in runs of adjacent options.
+   */
+  const toggleValue = useCallback(
+    (optionValue: string) => {
+      const alreadySelected = values.includes(optionValue);
+      const next = alreadySelected
+        ? values.filter((value) => value !== optionValue)
+        : [...values, optionValue];
+      onValuesChange(next);
+    },
+    [values, onValuesChange]
+  );
+
+  const removeValue = useCallback(
+    (optionValue: string) => {
+      onValuesChange(values.filter((value) => value !== optionValue));
+    },
+    [values, onValuesChange]
+  );
+
+  useFocusOnOpen(open, searchInputRef);
+  useCloseOnOutsideClick(open, closeDropdown, triggerRef, contentRef);
+  useScrollHighlightIntoView(highlightedIndex, listRef);
+  useClampHighlight(
+    filteredOptions.length,
+    highlightedIndex,
+    setHighlightedIndex
+  );
+
+  const moveHighlight = useCallback(
+    (direction: 'next' | 'prev') => {
+      setHighlightedIndex((current) =>
+        findNextEnabledIndex(filteredOptions, current, direction)
+      );
+    },
+    [filteredOptions]
+  );
+
+  const toggleHighlighted = useCallback(() => {
+    const option = filteredOptions[highlightedIndex];
+    if (!option || option.disabled) return;
+    toggleValue(option.value);
+  }, [filteredOptions, highlightedIndex, toggleValue]);
+
+  /** An empty query turns Backspace into "drop the last chip". */
+  const canRemoveLastChip = searchQuery === '' && values.length > 0;
+
+  const removeLastValue = useCallback(() => {
+    onValuesChange(values.slice(0, -1));
+  }, [values, onValuesChange]);
+
+  /**
+   * Dismisses the dropdown without letting Escape reach the document.
+   *
+   * Modals in the design system close on a document-level Escape listener, so a
+   * bubbling key would discard the whole surrounding form.
+   *
+   * It is bound to every element that can hold focus while the dropdown is open
+   * — the trigger, the search field and the listbox, which the option rows sit
+   * inside — rather than to the panel wrapper, which carries no role.
+   */
+  const handleEscape = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      closeDropdown(true);
+    },
+    [closeDropdown]
+  );
+
+  const handleSearchKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        moveHighlight('next');
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        moveHighlight('prev');
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        toggleHighlighted();
+        return;
+      }
+      if (event.key === 'Backspace' && canRemoveLastChip) {
+        event.preventDefault();
+        removeLastValue();
+        return;
+      }
+      handleEscape(event);
+    },
+    [
+      moveHighlight,
+      toggleHighlighted,
+      removeLastValue,
+      canRemoveLastChip,
+      handleEscape,
+    ]
+  );
+
+  const handleTriggerKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!interactive) return;
+
+      if (OPEN_KEYS.includes(event.key) && !open) {
+        event.preventDefault();
+        openDropdown();
+        return;
+      }
+
+      handleEscape(event);
+    },
+    [interactive, open, openDropdown, handleEscape]
+  );
+
+  const describedById = resolveDescribedBy({
+    errorMessage,
+    errorId,
+    helperText,
+    helperId,
+  });
+
+  const activeDescendant =
+    highlightedIndex >= 0
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
+
+  const hasDescription = Boolean(helperText) || Boolean(errorMessage);
+
+  const dropdown = open && triggerRect && (
+    <div
+      ref={contentRef}
+      data-multi-search-select-id={selectId}
+      style={dropdownStyles}
+      className="bg-secondary rounded-md border border-border-100 shadow-lg overflow-hidden flex flex-col"
+    >
+      <div className="p-2 border-b border-border-100">
+        <Input
+          ref={searchInputRef}
+          type="text"
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-activedescendant={activeDescendant}
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          onKeyDown={handleSearchKeyDown}
+          placeholder={searchPlaceholder}
+          size="small"
+          variant="outlined"
+          iconRight={<MagnifyingGlassIcon size={16} />}
+          containerClassName="w-full"
+        />
+      </div>
+
+      <div
+        ref={listRef}
+        id={listboxId}
+        role="listbox"
+        aria-multiselectable
+        aria-label={label ?? 'Opções'}
+        tabIndex={-1}
+        onKeyDown={handleEscape}
+        className="flex-1 overflow-y-auto"
+      >
+        <OptionList
+          options={filteredOptions}
+          selectedValues={values}
+          highlightedIndex={highlightedIndex}
+          listboxId={listboxId}
+          loading={loading}
+          loadingText={loadingText}
+          emptyText={emptyText}
+          onToggle={toggleValue}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={cn('w-full', className)}>
+      {label && (
+        <label
+          htmlFor={selectId}
+          className={cn(
+            'block font-bold text-text-900 mb-1.5',
+            LABEL_SIZE_CLASSES[size]
+          )}
+        >
+          {label}
+        </label>
+      )}
+
+      <div
+        ref={triggerRef}
+        id={selectId}
+        role="combobox"
+        tabIndex={interactive ? 0 : -1}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={open ? listboxId : undefined}
+        aria-invalid={!!errorMessage}
+        aria-describedby={describedById}
+        aria-disabled={!interactive}
+        onClick={toggleOpen}
+        onKeyDown={handleTriggerKeyDown}
+        className={cn(
+          'flex w-full items-center justify-between gap-2 border-border-300 bg-background',
+          SIZE_CLASSES[size],
+          PADDING_CLASSES[size],
+          VARIANT_CLASSES[variant],
+          errorMessage && 'border-indicator-error',
+          interactive
+            ? 'cursor-pointer hover:bg-background-50 text-text-700'
+            : 'cursor-not-allowed opacity-50 text-text-400'
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <TriggerContent
+            selectedOptions={selectedOptions}
+            placeholder={placeholder}
+            loading={loading}
+            loadingText={loadingText}
+            disabled={disabled}
+            maxVisibleChips={maxVisibleChips}
+            onRemove={removeValue}
+          />
+        </div>
+        <CaretDownIcon
+          className={cn(
+            'h-4 w-4 opacity-50 transition-transform shrink-0',
+            open && 'rotate-180'
+          )}
+        />
+      </div>
+
+      {hasDescription && (
+        <div className="mt-1.5">
+          {helperText && !errorMessage && (
+            <Text id={helperId} size="sm" className="text-text-500">
+              {helperText}
+            </Text>
+          )}
+          {errorMessage && (
+            <Text id={errorId} size="sm" className="text-indicator-error">
+              {errorMessage}
+            </Text>
+          )}
+        </div>
+      )}
+
+      {typeof document !== 'undefined' && createPortal(dropdown, document.body)}
+    </div>
+  );
+}
+
+/** Case-insensitive local filter over the option captions. */
+function filterOptions(
+  options: MultiSearchSelectOption[],
+  searchQuery: string
+): MultiSearchSelectOption[] {
+  if (!searchQuery) return options;
+  const query = searchQuery.toLowerCase();
+  return options.filter((option) => option.label.toLowerCase().includes(query));
+}
+
+/**
+ * Maps every selected value to a renderable option.
+ *
+ * Values are never filtered against `options`: while the list is still loading,
+ * or after an entry is deleted elsewhere, dropping the value would silently
+ * discard a real binding. It falls back to a placeholder caption instead, so
+ * the value stays visible and removable.
+ */
+function resolveSelectedOptions(
+  values: string[],
+  options: MultiSearchSelectOption[],
+  unknownValueLabel: string
+): MultiSearchSelectOption[] {
+  return values.map(
+    (value) =>
+      options.find((option) => option.value === value) ?? {
+        value,
+        label: unknownValueLabel,
+      }
+  );
+}
+
+/**
+ * Walks the option list in one direction and returns the first enabled index,
+ * wrapping around. Returns -1 when every option is disabled or the list is
+ * empty.
+ */
+function findNextEnabledIndex(
+  options: MultiSearchSelectOption[],
+  currentIndex: number,
+  direction: 'next' | 'prev'
+): number {
+  const total = options.length;
+  if (total === 0) return -1;
+
+  const step = direction === 'next' ? 1 : -1;
+  const unsetStart = direction === 'next' ? -1 : total;
+  const startIndex = currentIndex >= 0 ? currentIndex : unsetStart;
+  let index = startIndex;
+
+  for (let attempt = 0; attempt < total; attempt++) {
+    index = (index + step + total) % total;
+    if (!options[index].disabled) return index;
+  }
+
+  return -1;
+}
+
+interface DescribedByParams {
+  errorMessage?: string;
+  errorId: string;
+  helperText?: string;
+  helperId: string;
+}
+
+/** The error takes precedence over the hint as the field's description. */
+function resolveDescribedBy({
+  errorMessage,
+  errorId,
+  helperText,
+  helperId,
+}: DescribedByParams): string | undefined {
+  if (errorMessage) return errorId;
+  if (helperText) return helperId;
+  return undefined;
+}
+
+/** Moves focus into the search field as soon as the dropdown opens. */
+function useFocusOnOpen(
+  open: boolean,
+  searchInputRef: RefObject<HTMLInputElement | null>
+) {
+  useEffect(() => {
+    if (!open) return;
+    const timer = setTimeout(() => searchInputRef.current?.focus(), 0);
+    return () => clearTimeout(timer);
+  }, [open, searchInputRef]);
+}
+
+/**
+ * Dismisses the dropdown on a click outside it.
+ *
+ * The trigger and the dropdown are checked separately because the dropdown is
+ * portalled and therefore not a DOM descendant of the trigger.
+ */
+function useCloseOnOutsideClick(
+  open: boolean,
+  close: () => void,
+  triggerRef: RefObject<HTMLElement | null>,
+  contentRef: RefObject<HTMLElement | null>
+) {
+  useEffect(() => {
+    if (!open) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const insideTrigger = triggerRef.current?.contains(target);
+      const insideContent = contentRef.current?.contains(target);
+      if (insideTrigger || insideContent) return;
+      close();
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [open, close, triggerRef, contentRef]);
+}
+
+/**
+ * Pulls the highlight back into range when a search narrows the option list,
+ * so `aria-activedescendant` never points at a row that no longer exists.
+ */
+function useClampHighlight(
+  optionCount: number,
+  highlightedIndex: number,
+  setHighlightedIndex: (index: number) => void
+) {
+  useEffect(() => {
+    if (highlightedIndex < optionCount) return;
+    setHighlightedIndex(Math.max(optionCount - 1, -1));
+  }, [optionCount, highlightedIndex, setHighlightedIndex]);
+}
+
+/** Keeps the keyboard-highlighted row visible in a long list. */
+function useScrollHighlightIntoView(
+  highlightedIndex: number,
+  listRef: RefObject<HTMLDivElement | null>
+) {
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const rows = listRef.current.querySelectorAll('[data-option]');
+    const row = rows[highlightedIndex] as HTMLElement | undefined;
+    row?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex, listRef]);
+}
+
+export type {
+  MultiSearchSelectOption,
+  MultiSearchSelectProps,
+  MultiSearchSelectSize,
+  MultiSearchSelectVariant,
+} from './types';
+
+export default MultiSearchSelect;

--- a/src/components/MultiSearchSelect/MultiSearchSelect.tsx
+++ b/src/components/MultiSearchSelect/MultiSearchSelect.tsx
@@ -362,6 +362,7 @@ export function MultiSearchSelect({
             loadingText={loadingText}
             disabled={disabled}
             maxVisibleChips={maxVisibleChips}
+            size={size}
             onRemove={removeValue}
           />
         </div>

--- a/src/components/MultiSearchSelect/OptionList.tsx
+++ b/src/components/MultiSearchSelect/OptionList.tsx
@@ -69,7 +69,11 @@ interface OptionRowProps {
 }
 
 /**
- * One selectable row.
+ * One selectable row of the ARIA combobox listbox.
+ *
+ * A native `option` is not usable here: it renders no checkbox and accepts no
+ * arbitrary markup, and it only lives inside `select`/`datalist`, which this
+ * pattern deliberately replaces.
  *
  * The checkbox is purely presentational: the row owns the interaction, so
  * letting the checkbox handle its own would toggle the value twice.
@@ -97,7 +101,7 @@ function OptionRow({
   };
 
   return (
-    <div
+    <div // NOSONAR — ARIA combobox pattern, no native tag fits (see JSDoc)
       id={optionId}
       data-option
       role="option"

--- a/src/components/MultiSearchSelect/OptionList.tsx
+++ b/src/components/MultiSearchSelect/OptionList.tsx
@@ -1,0 +1,132 @@
+import type { KeyboardEvent } from 'react';
+import Text from '../Text/Text';
+import CheckBox from '../CheckBox/CheckBox';
+import { cn } from '../../utils/utils';
+import { SpinnerGapIcon } from '@phosphor-icons/react/dist/csr/SpinnerGap';
+import type { MultiSearchSelectOption } from './types';
+
+interface OptionListProps {
+  options: MultiSearchSelectOption[];
+  selectedValues: string[];
+  highlightedIndex: number;
+  listboxId: string;
+  loading: boolean;
+  loadingText: string;
+  emptyText: string;
+  onToggle: (value: string) => void;
+}
+
+/**
+ * The dropdown body: a loading state, an empty state, or the option rows.
+ */
+export function OptionList({
+  options,
+  selectedValues,
+  highlightedIndex,
+  listboxId,
+  loading,
+  loadingText,
+  emptyText,
+  onToggle,
+}: Readonly<OptionListProps>) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 p-4 text-text-500">
+        <SpinnerGapIcon size={18} className="animate-spin" />
+        <Text size="sm" className="text-text-500">
+          {loadingText}
+        </Text>
+      </div>
+    );
+  }
+
+  if (options.length === 0) {
+    return (
+      <Text size="sm" className="p-4 text-center text-text-500">
+        {emptyText}
+      </Text>
+    );
+  }
+
+  return options.map((option, index) => (
+    <OptionRow
+      key={option.value}
+      option={option}
+      optionId={`${listboxId}-option-${index}`}
+      selected={selectedValues.includes(option.value)}
+      highlighted={index === highlightedIndex}
+      onToggle={onToggle}
+    />
+  ));
+}
+
+interface OptionRowProps {
+  option: MultiSearchSelectOption;
+  optionId: string;
+  selected: boolean;
+  highlighted: boolean;
+  onToggle: (value: string) => void;
+}
+
+/**
+ * One selectable row.
+ *
+ * The checkbox is purely presentational: the row owns the interaction, so
+ * letting the checkbox handle its own would toggle the value twice.
+ *
+ * A click moves focus onto the row, so it also answers Enter and Space to stay
+ * operable from the keyboard. Arrowing through the list is driven from the
+ * search field, which keeps focus while the dropdown is open.
+ */
+function OptionRow({
+  option,
+  optionId,
+  selected,
+  highlighted,
+  onToggle,
+}: Readonly<OptionRowProps>) {
+  const toggle = () => {
+    if (option.disabled) return;
+    onToggle(option.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    toggle();
+  };
+
+  return (
+    <div
+      id={optionId}
+      data-option
+      role="option"
+      aria-selected={selected}
+      aria-disabled={option.disabled}
+      tabIndex={-1}
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'relative flex items-center gap-2 px-3 py-2.5 cursor-pointer transition-colors text-sm',
+        selected && 'bg-primary-50',
+        highlighted && !selected && 'bg-background-50',
+        option.disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+        !option.disabled &&
+          !selected &&
+          !highlighted &&
+          'hover:bg-background-50'
+      )}
+    >
+      <CheckBox
+        checked={selected}
+        readOnly
+        tabIndex={-1}
+        size="small"
+        className="pointer-events-none"
+      />
+      <Text size="sm" className="flex-1 text-text-700">
+        {option.label}
+      </Text>
+    </div>
+  );
+}

--- a/src/components/MultiSearchSelect/TriggerContent.tsx
+++ b/src/components/MultiSearchSelect/TriggerContent.tsx
@@ -1,0 +1,100 @@
+import Text from '../Text/Text';
+import { SpinnerGapIcon } from '@phosphor-icons/react/dist/csr/SpinnerGap';
+import { XIcon } from '@phosphor-icons/react/dist/csr/X';
+import type { MultiSearchSelectOption } from './types';
+
+interface TriggerContentProps {
+  selectedOptions: MultiSearchSelectOption[];
+  placeholder: string;
+  loading: boolean;
+  loadingText: string;
+  disabled: boolean;
+  maxVisibleChips: number;
+  onRemove: (value: string) => void;
+}
+
+/**
+ * Renders what the closed trigger shows: a loading indicator, the placeholder,
+ * or one removable chip per selected value.
+ */
+export function TriggerContent({
+  selectedOptions,
+  placeholder,
+  loading,
+  loadingText,
+  disabled,
+  maxVisibleChips,
+  onRemove,
+}: Readonly<TriggerContentProps>) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2">
+        <SpinnerGapIcon size={14} className="animate-spin" />
+        <Text size="sm" className="text-text-500">
+          {loadingText}
+        </Text>
+      </div>
+    );
+  }
+
+  if (selectedOptions.length === 0) {
+    return <span className="truncate text-text-500">{placeholder}</span>;
+  }
+
+  const visible = selectedOptions.slice(0, maxVisibleChips);
+  const hiddenCount = selectedOptions.length - visible.length;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 py-0.5">
+      {visible.map((option) => (
+        <ValueChip
+          key={option.value}
+          option={option}
+          disabled={disabled}
+          onRemove={onRemove}
+        />
+      ))}
+      {hiddenCount > 0 && (
+        <span className="inline-flex items-center rounded-full border border-border-200 bg-background-50 px-2 py-0.5 text-xs font-medium text-text-700">
+          +{hiddenCount}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface ValueChipProps {
+  option: MultiSearchSelectOption;
+  disabled: boolean;
+  onRemove: (value: string) => void;
+}
+
+/**
+ * A single selected value.
+ *
+ * Both the click and the keydown are stopped from bubbling so that removing a
+ * value never reaches the trigger and toggles the dropdown open.
+ */
+function ValueChip({ option, disabled, onRemove }: Readonly<ValueChipProps>) {
+  return (
+    <span
+      data-chip={option.value}
+      className="inline-flex max-w-[160px] items-center gap-1 rounded-full border border-primary-300 bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-900"
+    >
+      <span className="truncate">{option.label}</span>
+      <button
+        type="button"
+        aria-label={`Remover ${option.label}`}
+        disabled={disabled}
+        className="shrink-0 cursor-pointer hover:text-indicator-error"
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove(option.value);
+        }}
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        <XIcon size={12} weight="bold" />
+      </button>
+    </span>
+  );
+}

--- a/src/components/MultiSearchSelect/TriggerContent.tsx
+++ b/src/components/MultiSearchSelect/TriggerContent.tsx
@@ -1,7 +1,9 @@
 import Text from '../Text/Text';
+import Button from '../Button/Button';
 import { SpinnerGapIcon } from '@phosphor-icons/react/dist/csr/SpinnerGap';
 import { XIcon } from '@phosphor-icons/react/dist/csr/X';
-import type { MultiSearchSelectOption } from './types';
+import { TRIGGER_TEXT_SIZES } from './constants';
+import type { MultiSearchSelectOption, MultiSearchSelectSize } from './types';
 
 interface TriggerContentProps {
   selectedOptions: MultiSearchSelectOption[];
@@ -10,6 +12,7 @@ interface TriggerContentProps {
   loadingText: string;
   disabled: boolean;
   maxVisibleChips: number;
+  size: MultiSearchSelectSize;
   onRemove: (value: string) => void;
 }
 
@@ -24,13 +27,16 @@ export function TriggerContent({
   loadingText,
   disabled,
   maxVisibleChips,
+  size,
   onRemove,
 }: Readonly<TriggerContentProps>) {
+  const textSize = TRIGGER_TEXT_SIZES[size];
+
   if (loading) {
     return (
       <div className="flex items-center gap-2">
         <SpinnerGapIcon size={14} className="animate-spin" />
-        <Text size="sm" className="text-text-500">
+        <Text as="span" size={textSize} className="text-text-500">
           {loadingText}
         </Text>
       </div>
@@ -38,7 +44,11 @@ export function TriggerContent({
   }
 
   if (selectedOptions.length === 0) {
-    return <span className="truncate text-text-500">{placeholder}</span>;
+    return (
+      <Text as="span" size={textSize} className="block truncate text-text-500">
+        {placeholder}
+      </Text>
+    );
   }
 
   const visible = selectedOptions.slice(0, maxVisibleChips);
@@ -55,9 +65,14 @@ export function TriggerContent({
         />
       ))}
       {hiddenCount > 0 && (
-        <span className="inline-flex items-center rounded-full border border-border-200 bg-background-50 px-2 py-0.5 text-xs font-medium text-text-700">
+        <Text
+          as="span"
+          size="xs"
+          weight="medium"
+          className="inline-flex items-center rounded-full border border-border-200 bg-background-50 px-2 py-0.5 text-text-700"
+        >
           +{hiddenCount}
-        </span>
+        </Text>
       )}
     </div>
   );
@@ -79,14 +94,22 @@ function ValueChip({ option, disabled, onRemove }: Readonly<ValueChipProps>) {
   return (
     <span
       data-chip={option.value}
-      className="inline-flex max-w-[160px] items-center gap-1 rounded-full border border-primary-300 bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-900"
+      className="inline-flex max-w-[160px] items-center gap-1 rounded-full border border-primary-300 bg-primary-100 px-2 py-0.5 text-primary-900"
     >
-      <span className="truncate">{option.label}</span>
-      <button
-        type="button"
+      <Text
+        as="span"
+        size="xs"
+        weight="medium"
+        color="text-primary-900"
+        className="truncate"
+      >
+        {option.label}
+      </Text>
+      <Button
+        variant="raw"
         aria-label={`Remover ${option.label}`}
         disabled={disabled}
-        className="shrink-0 cursor-pointer hover:text-indicator-error"
+        className="shrink-0 cursor-pointer hover:text-indicator-error disabled:cursor-not-allowed"
         onClick={(event) => {
           event.stopPropagation();
           onRemove(option.value);
@@ -94,7 +117,7 @@ function ValueChip({ option, disabled, onRemove }: Readonly<ValueChipProps>) {
         onKeyDown={(event) => event.stopPropagation()}
       >
         <XIcon size={12} weight="bold" />
-      </button>
+      </Button>
     </span>
   );
 }

--- a/src/components/MultiSearchSelect/constants.ts
+++ b/src/components/MultiSearchSelect/constants.ts
@@ -24,6 +24,16 @@ export const VARIANT_CLASSES: Record<MultiSearchSelectVariant, string> = {
   rounded: 'border-2 rounded-full focus:border-primary-950',
 };
 
+/** `Text` size that matches the trigger font for each select size. */
+export const TRIGGER_TEXT_SIZES: Record<
+  MultiSearchSelectSize,
+  'sm' | 'md' | 'lg'
+> = {
+  small: 'sm',
+  medium: 'md',
+  large: 'lg',
+};
+
 export const LABEL_SIZE_CLASSES: Record<MultiSearchSelectSize, string> = {
   small: 'text-sm',
   medium: 'text-md',

--- a/src/components/MultiSearchSelect/constants.ts
+++ b/src/components/MultiSearchSelect/constants.ts
@@ -36,5 +36,12 @@ export const OPEN_KEYS = ['Enter', ' ', 'ArrowDown'];
 /** Matches the dropdown's `max-h`, used to decide whether it flips above. */
 export const DROPDOWN_MAX_HEIGHT = 300;
 
+/**
+ * Floor for the dropdown height, enough for the search field plus a couple of
+ * rows. Guards against a trigger scrolled past a viewport edge, where the
+ * measured space turns negative.
+ */
+export const DROPDOWN_MIN_HEIGHT = 120;
+
 /** Distance between the trigger and the dropdown. */
 export const DROPDOWN_GAP = 4;

--- a/src/components/MultiSearchSelect/constants.ts
+++ b/src/components/MultiSearchSelect/constants.ts
@@ -1,0 +1,40 @@
+import type { MultiSearchSelectSize, MultiSearchSelectVariant } from './types';
+
+/**
+ * Trigger height per size.
+ *
+ * Uses `min-h-*` where `SearchSelect` uses a fixed `h-*`: chips wrap onto more
+ * than one line once several values are selected.
+ */
+export const SIZE_CLASSES: Record<MultiSearchSelectSize, string> = {
+  small: 'text-sm min-h-8',
+  medium: 'text-md min-h-9',
+  large: 'text-lg min-h-10',
+};
+
+export const PADDING_CLASSES: Record<MultiSearchSelectSize, string> = {
+  small: 'px-3 py-1',
+  medium: 'px-3 py-2',
+  large: 'px-4 py-3',
+};
+
+export const VARIANT_CLASSES: Record<MultiSearchSelectVariant, string> = {
+  outlined: 'border-2 rounded-lg focus:border-primary-950',
+  underlined: 'border-b-2 focus:border-primary-950',
+  rounded: 'border-2 rounded-full focus:border-primary-950',
+};
+
+export const LABEL_SIZE_CLASSES: Record<MultiSearchSelectSize, string> = {
+  small: 'text-sm',
+  medium: 'text-md',
+  large: 'text-lg',
+};
+
+/** Keys that open the dropdown while the trigger has focus. */
+export const OPEN_KEYS = ['Enter', ' ', 'ArrowDown'];
+
+/** Matches the dropdown's `max-h`, used to decide whether it flips above. */
+export const DROPDOWN_MAX_HEIGHT = 300;
+
+/** Distance between the trigger and the dropdown. */
+export const DROPDOWN_GAP = 4;

--- a/src/components/MultiSearchSelect/types.ts
+++ b/src/components/MultiSearchSelect/types.ts
@@ -1,0 +1,42 @@
+export interface MultiSearchSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export type MultiSearchSelectSize = 'small' | 'medium' | 'large';
+
+export type MultiSearchSelectVariant = 'outlined' | 'underlined' | 'rounded';
+
+export interface MultiSearchSelectProps {
+  /** Currently selected values. */
+  values: string[];
+  /** Receives the full next selection, never a delta. */
+  onValuesChange: (values: string[]) => void;
+  /** Options to pick from. Filtering happens locally. */
+  options: MultiSearchSelectOption[];
+  /** Caption rendered above the field. */
+  label?: string;
+  /** Shown inside the trigger while nothing is selected. */
+  placeholder?: string;
+  /** Placeholder of the search field inside the dropdown. */
+  searchPlaceholder?: string;
+  /** Shown when there is nothing left to pick. */
+  emptyText?: string;
+  /** Shown while `loading` is true. */
+  loadingText?: string;
+  /** Chip caption for a selected value that is missing from `options`. */
+  unknownValueLabel?: string;
+  /** Hint rendered below the field, hidden while `errorMessage` is set. */
+  helperText?: string;
+  /** Error rendered below the field; also marks the trigger as invalid. */
+  errorMessage?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  size?: MultiSearchSelectSize;
+  variant?: MultiSearchSelectVariant;
+  className?: string;
+  id?: string;
+  /** How many chips to render before collapsing the rest into a "+N" chip. */
+  maxVisibleChips?: number;
+}

--- a/src/components/MultiSearchSelect/useDropdownPosition.ts
+++ b/src/components/MultiSearchSelect/useDropdownPosition.ts
@@ -5,7 +5,11 @@ import {
   type CSSProperties,
   type RefObject,
 } from 'react';
-import { DROPDOWN_GAP, DROPDOWN_MAX_HEIGHT } from './constants';
+import {
+  DROPDOWN_GAP,
+  DROPDOWN_MAX_HEIGHT,
+  DROPDOWN_MIN_HEIGHT,
+} from './constants';
 
 interface UseDropdownPositionParams {
   open: boolean;
@@ -60,6 +64,10 @@ export function useDropdownPosition({
 /**
  * Turns a trigger rect into fixed-position styles, flipping the dropdown above
  * the trigger when the space below is too tight and the space above is larger.
+ *
+ * The available space is clamped to `DROPDOWN_MIN_HEIGHT`: a trigger scrolled
+ * past either viewport edge yields a negative measurement, which would produce
+ * an invalid `maxHeight` and collapse the dropdown.
  */
 function buildDropdownStyles(triggerRect: DOMRect | null): CSSProperties {
   if (!triggerRect) return {};
@@ -79,7 +87,13 @@ function buildDropdownStyles(triggerRect: DOMRect | null): CSSProperties {
     left: triggerRect.left,
     width: triggerRect.width,
     zIndex: 9999,
-    maxHeight: Math.min(availableSpace, DROPDOWN_MAX_HEIGHT),
+    maxHeight: clampDropdownHeight(availableSpace),
     ...placement,
   };
+}
+
+/** Keeps the dropdown between a usable floor and its documented ceiling. */
+function clampDropdownHeight(availableSpace: number): number {
+  const usableSpace = Math.max(availableSpace, DROPDOWN_MIN_HEIGHT);
+  return Math.min(usableSpace, DROPDOWN_MAX_HEIGHT);
 }

--- a/src/components/MultiSearchSelect/useDropdownPosition.ts
+++ b/src/components/MultiSearchSelect/useDropdownPosition.ts
@@ -1,0 +1,85 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type RefObject,
+} from 'react';
+import { DROPDOWN_GAP, DROPDOWN_MAX_HEIGHT } from './constants';
+
+interface UseDropdownPositionParams {
+  open: boolean;
+  triggerRef: RefObject<HTMLElement | null>;
+}
+
+interface UseDropdownPosition {
+  /** Null until the trigger has been measured; the dropdown waits for it. */
+  triggerRect: DOMRect | null;
+  /** Re-measures the trigger, called when the dropdown is about to open. */
+  measureTrigger: () => void;
+  /** Fixed-position styles that keep the dropdown glued to the trigger. */
+  dropdownStyles: CSSProperties;
+}
+
+/**
+ * Positions a portalled dropdown against its trigger.
+ *
+ * The dropdown renders into `document.body`, so it cannot rely on the trigger's
+ * layout. It is measured on open and re-measured on scroll and resize, and it
+ * flips above the trigger when there is not enough room below.
+ */
+export function useDropdownPosition({
+  open,
+  triggerRef,
+}: UseDropdownPositionParams): UseDropdownPosition {
+  const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null);
+
+  const measureTrigger = useCallback(() => {
+    if (!triggerRef.current) return;
+    setTriggerRect(triggerRef.current.getBoundingClientRect());
+  }, [triggerRef]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleUpdate = () => measureTrigger();
+    window.addEventListener('scroll', handleUpdate, true);
+    window.addEventListener('resize', handleUpdate);
+
+    return () => {
+      window.removeEventListener('scroll', handleUpdate, true);
+      window.removeEventListener('resize', handleUpdate);
+    };
+  }, [open, measureTrigger]);
+
+  const dropdownStyles = buildDropdownStyles(triggerRect);
+
+  return { triggerRect, measureTrigger, dropdownStyles };
+}
+
+/**
+ * Turns a trigger rect into fixed-position styles, flipping the dropdown above
+ * the trigger when the space below is too tight and the space above is larger.
+ */
+function buildDropdownStyles(triggerRect: DOMRect | null): CSSProperties {
+  if (!triggerRect) return {};
+
+  const viewportHeight = window.innerHeight;
+  const spaceBelow = viewportHeight - triggerRect.bottom - DROPDOWN_GAP;
+  const spaceAbove = triggerRect.top - DROPDOWN_GAP;
+  const openAbove = spaceBelow < DROPDOWN_MAX_HEIGHT && spaceAbove > spaceBelow;
+  const availableSpace = openAbove ? spaceAbove : spaceBelow;
+
+  const placement: CSSProperties = openAbove
+    ? { bottom: viewportHeight - triggerRect.top + DROPDOWN_GAP }
+    : { top: triggerRect.bottom + DROPDOWN_GAP };
+
+  return {
+    position: 'fixed',
+    left: triggerRect.left,
+    width: triggerRect.width,
+    zIndex: 9999,
+    maxHeight: Math.min(availableSpace, DROPDOWN_MAX_HEIGHT),
+    ...placement,
+  };
+}

--- a/src/components/MultiSearchSelect/useDropdownPosition.ts
+++ b/src/components/MultiSearchSelect/useDropdownPosition.ts
@@ -43,14 +43,29 @@ export function useDropdownPosition({
     setTriggerRect(triggerRef.current.getBoundingClientRect());
   }, [triggerRef]);
 
+  /**
+   * Scroll is listened to in the capture phase, so every nested scroll
+   * container feeds this handler. Measuring once per frame is enough to keep
+   * the panel glued to the trigger and avoids a layout read per event.
+   */
   useEffect(() => {
     if (!open) return;
 
-    const handleUpdate = () => measureTrigger();
+    let frame = 0;
+
+    const handleUpdate = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        measureTrigger();
+      });
+    };
+
     window.addEventListener('scroll', handleUpdate, true);
     window.addEventListener('resize', handleUpdate);
 
     return () => {
+      if (frame) cancelAnimationFrame(frame);
       window.removeEventListener('scroll', handleUpdate, true);
       window.removeEventListener('resize', handleUpdate);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -636,6 +636,15 @@ export type {
   SearchSelectPagination,
 } from './components/SearchSelect/SearchSelect';
 
+// MultiSearchSelect Component (SearchSelect for picking several values)
+export { default as MultiSearchSelect } from './components/MultiSearchSelect/MultiSearchSelect';
+export type {
+  MultiSearchSelectProps,
+  MultiSearchSelectOption,
+  MultiSearchSelectSize,
+  MultiSearchSelectVariant,
+} from './components/MultiSearchSelect/MultiSearchSelect';
+
 // TypeSelector Component (Activity/Exam type switcher)
 export {
   TypeSelector,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -303,6 +303,8 @@ export default defineConfig({
       'src/components/RecommendedLessonDetails/types.ts', // StudentPerformanceData
     'RestrictedAccess/index':
       'src/components/RestrictedAccess/RestrictedAccess.tsx', // RestrictedAccess
+    'MultiSearchSelect/index':
+      'src/components/MultiSearchSelect/MultiSearchSelect.tsx', // MultiSearchSelect, MultiSearchSelectOption, MultiSearchSelectProps
     'SearchSelect/index': 'src/components/SearchSelect/SearchSelect.tsx', // SearchSelect, SearchSelectOption, SearchSelectPagination
     'SendLessonModal/index':
       'src/components/SendLessonModal/SendLessonModal.tsx', // SendLessonModal


### PR DESCRIPTION
Irmao do SearchSelect para escolher varios valores: mesmo tamanho, bordas, dropdown portalado e modelo de teclado, com chips removiveis no trigger e um checkbox por opcao.

Um valor selecionado que nao esteja em options e mantido e rotulado em vez de descartado, para que uma lista ainda carregando nao apague um vinculo real. O Escape fecha apenas o dropdown, sem vazar para o listener de documento que fecha os modais.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a searchable multi-select control with checkbox options, removable selection chips, filtering, loading and empty states, validation messaging, and disabled options.
  - Added keyboard navigation, accessibility support, outside-click dismissal, and responsive dropdown positioning.
  - Added configurable sizes, visual variants, chip limits, labels, helper text, and error states.
  - Made the component available through the package’s public exports.

- **Tests**
  - Added comprehensive coverage for selection, filtering, keyboard interactions, states, styling, positioning, and accessibility behavior.

- **Documentation**
  - Added interactive examples covering common configurations and component states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->