### PR TITLE
AE-2981: fix(VideoPlayer): reset completion flag when storageKey changes

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.test.tsx
@@ -1183,6 +1183,53 @@ describe('VideoPlayer', () => {
 
       expect(mockOnVideoComplete).toHaveBeenCalledTimes(1);
     });
+
+    it('should rearm completion when storageKey changes while src stays the same', () => {
+      const mockOnVideoComplete = jest.fn();
+      const { container, rerender } = render(
+        <VideoPlayer
+          {...defaultProps}
+          storageKey="lesson-1"
+          onVideoComplete={mockOnVideoComplete}
+        />
+      );
+
+      const completeVideo = () => {
+        const video = container.querySelector('video')!;
+
+        Object.defineProperty(video, 'duration', {
+          configurable: true,
+          value: 100,
+        });
+
+        fireEvent.loadedMetadata(video);
+
+        // Writable: changing storageKey re-runs the resume effect, which
+        // assigns currentTime
+        Object.defineProperty(video, 'currentTime', {
+          configurable: true,
+          writable: true,
+          value: 96,
+        });
+
+        fireEvent.timeUpdate(video);
+      };
+
+      completeVideo();
+      expect(mockOnVideoComplete).toHaveBeenCalledTimes(1);
+
+      // Two lessons can share the same recording; only storageKey tells them apart
+      rerender(
+        <VideoPlayer
+          {...defaultProps}
+          storageKey="lesson-2"
+          onVideoComplete={mockOnVideoComplete}
+        />
+      );
+
+      completeVideo();
+      expect(mockOnVideoComplete).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('Metadata handling', () => {

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -350,11 +350,17 @@ const VideoPlayer = ({
     'idle' | 'validating' | 'valid' | 'invalid'
   >('idle');
 
-  // Reset completion flag when changing videos
+  // Reset completion flag when changing videos.
+  //
+  // `storageKey` is part of the identity here because two different items can
+  // legitimately share the same `src` (for example, two lessons built from the
+  // same recording). Keying the reset on `src` alone left `hasCompleted` set
+  // when the consumer swapped to such an item, and `onVideoComplete` never
+  // fired again for it.
   useEffect(() => {
     setHasCompleted(false);
     setHasStarted(false);
-  }, [src]);
+  }, [src, storageKey]);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [showSpeedMenu, setShowSpeedMenu] = useState(false);
   const lastSaveTimeRef = useRef(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video lessons now correctly reset their completion state when switching between lessons that use the same video source.
  * Completion callbacks can fire again for a newly selected lesson, even when its video URL hasn’t changed.

* **Tests**
  * Added regression coverage for switching lesson progress identities while keeping the same video.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->