### PR TITLE
AE-2984: fix filter by class

### DIFF
--- a/src/components/Filter/useTableFilter.test.ts
+++ b/src/components/Filter/useTableFilter.test.ts
@@ -637,6 +637,41 @@ describe('useTableFilter', () => {
         []
       );
     });
+
+    it('should keep a selection restored from the URL while the options are still loading', () => {
+      globalThis.location.href = 'http://localhost/?filter_escola=2';
+      globalThis.location.search = '?filter_escola=2';
+
+      // First render happens before the async options arrive, so every category
+      // starts with an empty item list.
+      const emptyConfigs: FilterConfig[] = [
+        {
+          ...mockInitialConfigs[0],
+          categories: [
+            { ...mockInitialConfigs[0].categories[0], itens: [] },
+            { ...mockInitialConfigs[0].categories[1], itens: [] },
+          ],
+        },
+        mockInitialConfigs[1],
+      ];
+
+      const { result, rerender } = renderHook(
+        ({ configs }) => useTableFilter(configs, { syncWithUrl: true }),
+        { initialProps: { configs: emptyConfigs } }
+      );
+
+      expect(result.current.filterConfigs[0].categories[0].selectedIds).toEqual(
+        ['2']
+      );
+
+      // Options arrive on a later render and the selection must survive.
+      rerender({ configs: mockInitialConfigs });
+
+      expect(result.current.filterConfigs[0].categories[0].selectedIds).toEqual(
+        ['2']
+      );
+      expect(result.current.activeFilters.escola).toEqual(['2']);
+    });
   });
 
   describe('popstate event', () => {

--- a/src/components/Filter/useTableFilter.ts
+++ b/src/components/Filter/useTableFilter.ts
@@ -29,6 +29,14 @@ const mergeConfigsWithSelections = (
       }
 
       if (prevCat?.key === newCat.key && prevCat?.selectedIds?.length) {
+        // An empty item list means the options have not been fetched yet, not
+        // that every selected id became invalid. Dropping the selection here
+        // would permanently discard filters restored from the URL, since the
+        // options only arrive on a later render.
+        if (newItems.length === 0) {
+          return { ...newCat, selectedIds: prevCat.selectedIds };
+        }
+
         const availableIds = new Set(newItems.map((item) => item.id));
         const selectedIds = prevCat.selectedIds.filter((id) =>
           availableIds.has(id)

--- a/src/components/SimulatedFilters/SimulatedFiltersModal.test.tsx
+++ b/src/components/SimulatedFilters/SimulatedFiltersModal.test.tsx
@@ -207,8 +207,10 @@ describe('SimulatedFiltersModal', () => {
       />
     );
 
+    // Anchored: a string argument would match a substring, so reintroducing a
+    // dependency on any category would still pass.
     expect(screen.getByTestId('categories-depends')).toHaveTextContent(
-      'school:|schoolYear:|class:'
+      /^school:\|schoolYear:\|class:$/
     );
   });
 

--- a/src/components/SimulatedFilters/SimulatedFiltersModal.test.tsx
+++ b/src/components/SimulatedFilters/SimulatedFiltersModal.test.tsx
@@ -53,7 +53,11 @@ jest.mock('../CheckBoxGroup/CheckBoxGroup', () => ({
     categories,
     onCategoriesChange,
   }: {
-    categories: Array<{ key: string; selectedIds?: string[] }>;
+    categories: Array<{
+      key: string;
+      selectedIds?: string[];
+      dependsOn?: string[];
+    }>;
     onCategoriesChange: (
       categories: Array<{ key: string; selectedIds?: string[] }>
     ) => void;
@@ -62,6 +66,11 @@ jest.mock('../CheckBoxGroup/CheckBoxGroup', () => ({
       <span data-testid="categories-selected">
         {categories
           .map((cat) => `${cat.key}:${(cat.selectedIds ?? []).join(',')}`)
+          .join('|')}
+      </span>
+      <span data-testid="categories-depends">
+        {categories
+          .map((cat) => `${cat.key}:${(cat.dependsOn ?? []).join(',')}`)
           .join('|')}
       </span>
       <button
@@ -178,6 +187,29 @@ describe('SimulatedFiltersModal', () => {
     expect(screen.getByTestId('modal-title')).toHaveTextContent('Filtros');
     expect(screen.getByText('Limpar filtros')).toBeInTheDocument();
     expect(screen.getByText('Aplicar')).toBeInTheDocument();
+  });
+
+  it('leaves grade and class selectable without a parent selection', () => {
+    // Two schools means nothing is auto-selected, so a cascade requirement on
+    // "Série"/"Turma" would leave them disabled and the teacher would apply the
+    // filter with no class at all - which the backend reads as "every class".
+    mockUserAccessState.schools = [
+      { id: 'school-1', name: 'Escola FGB' },
+      { id: 'school-2', name: 'Escola IF' },
+    ];
+
+    render(
+      <SimulatedFiltersModal
+        isOpen
+        onClose={onClose}
+        onApply={onApply}
+        api={api}
+      />
+    );
+
+    expect(screen.getByTestId('categories-depends')).toHaveTextContent(
+      'school:|schoolYear:|class:'
+    );
   });
 
   it('renders loading state when academic filters are loading', () => {

--- a/src/components/SimulatedFilters/SimulatedFiltersModal.tsx
+++ b/src/components/SimulatedFilters/SimulatedFiltersModal.tsx
@@ -137,10 +137,15 @@ export function SimulatedFiltersModal({
           itens: schools,
           selectedIds: autoSelectedSchoolIds,
         },
+        // Neither category declares `dependsOn`: requiring the parent selection
+        // would leave "Série" and "Turma" disabled for a teacher with more than
+        // one school (nothing is auto-selected then), and applying without
+        // reaching the class means "no class filter", which the backend reads
+        // as "every class I teach". `filteredBy` still narrows the lists once a
+        // parent is picked.
         {
           key: 'schoolYear',
           label: 'Série',
-          dependsOn: ['school'],
           filteredBy: [{ key: 'school', internalField: 'schoolId' }],
           itens: schoolYears,
           selectedIds: initialFilters?.schoolYearIds || [],
@@ -148,7 +153,6 @@ export function SimulatedFiltersModal({
         {
           key: 'class',
           label: 'Turma',
-          dependsOn: ['school', 'schoolYear'],
           filteredBy: [
             { key: 'school', internalField: 'schoolId' },
             { key: 'schoolYear', internalField: 'schoolYearId' },

--- a/src/components/SimulationsPage/SimulationsPage.test.tsx
+++ b/src/components/SimulationsPage/SimulationsPage.test.tsx
@@ -117,7 +117,9 @@ describe('SimulationsPage', () => {
         ([url]: [string]) => url.endsWith('/students')
       );
       const lastCall = studentsCalls.at(-1);
-      expect(lastCall?.[1]?.params?.classIds).toEqual(['c1']);
+      // CSV, not an array: axios turns arrays into `classIds[]=…`, a key the
+      // backend schema ignores, which silently disables the filter.
+      expect(lastCall?.[1]?.params?.classIds).toBe('c1');
     });
   });
 });

--- a/src/hooks/useActivitiesHistory.ts
+++ b/src/hooks/useActivitiesHistory.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import dayjs from 'dayjs';
 import type { BaseApiClient } from '../types/api';
 import { mapApiStatusToDisplay } from '../types/common';
+import { toCsv } from '../utils/queryParams';
 import type {
   ActivityHistoryResponse,
   ActivityTableItem,
@@ -107,18 +108,6 @@ export const transformActivityToTableItem = (
 export const extractActivityFilterOptions = (
   activities: ActivityHistoryResponse[]
 ): ActivityApiFilterOptions => extractBreakdownFilterOptions(activities);
-
-/**
- * Join an array of selected ids into the backend's comma-separated convention
- * (e.g. `schoolIds=a,b,c`). Returns undefined for empty / non-array input so the
- * query param is omitted entirely.
- */
-const toCsv = (value: unknown): string | undefined => {
-  if (Array.isArray(value) && value.length > 0) {
-    return value.map(String).join(',');
-  }
-  return undefined;
-};
 
 /**
  * Collapse a single-select filter (emitted as an array by TableProvider) to its

--- a/src/hooks/useSimulations.test.ts
+++ b/src/hooks/useSimulations.test.ts
@@ -41,6 +41,50 @@ describe('createUseSimulations', () => {
     expect(page.total).toBe(1);
   });
 
+  it('fetchStudents sends classIds as CSV, never as an array', async () => {
+    const api = makeApi();
+    api.get.mockResolvedValue({
+      data: {
+        message: 'ok',
+        data: {
+          students: { data: [], page: 1, limit: 20, total: 0 },
+        },
+      },
+    });
+    const { result } = renderHook(() => createUseSimulations(api)());
+
+    await result.current.fetchStudents({ classIds: ['c1', 'c2'] });
+
+    const params = api.get.mock.calls[0][1]?.params as {
+      classIds?: unknown;
+    };
+    // An array here would be serialized by axios as `classIds[]=c1&classIds[]=c2`,
+    // a key the backend query schema does not declare, so the class filter would
+    // be dropped and every class of the teacher returned instead.
+    expect(Array.isArray(params.classIds)).toBe(false);
+    expect(params.classIds).toBe('c1,c2');
+  });
+
+  it('fetchStudents omits classIds when nothing is selected', async () => {
+    const api = makeApi();
+    api.get.mockResolvedValue({
+      data: {
+        message: 'ok',
+        data: {
+          students: { data: [], page: 1, limit: 20, total: 0 },
+        },
+      },
+    });
+    const { result } = renderHook(() => createUseSimulations(api)());
+
+    await result.current.fetchStudents({ classIds: [] });
+
+    const params = api.get.mock.calls[0][1]?.params as {
+      classIds?: unknown;
+    };
+    expect(params.classIds).toBeUndefined();
+  });
+
   it('fetchStudentSimulations calls the per-student endpoint', async () => {
     const api = makeApi();
     api.get.mockResolvedValue({

--- a/src/hooks/useSimulations.ts
+++ b/src/hooks/useSimulations.ts
@@ -12,6 +12,7 @@ import type {
   NoteResponse,
   NoteData,
 } from '../types/simulations';
+import { toCsv } from '../utils/queryParams';
 
 const BASE_URL = '/performance/simulations';
 
@@ -66,7 +67,10 @@ export const createUseSimulations =
         const { page = 1, limit = 20, search, classIds } = filters;
         const response = await apiClient.get<SimulationsStudentsResponse>(
           `${BASE_URL}/students`,
-          { params: { page, limit, search, classIds } }
+          // classIds goes as CSV, never as a raw array: axios would serialize
+          // it as `classIds[]=…`, a key the backend schema does not know, so
+          // the class filter would be silently dropped.
+          { params: { page, limit, search, classIds: toCsv(classIds) } }
         );
         return response.data.data.students;
       },

--- a/src/utils/queryParams.test.ts
+++ b/src/utils/queryParams.test.ts
@@ -1,0 +1,25 @@
+import { toCsv } from './queryParams';
+
+describe('toCsv', () => {
+  it('joins the ids with commas', () => {
+    expect(toCsv(['a', 'b', 'c'])).toBe('a,b,c');
+  });
+
+  it('returns the single id as-is', () => {
+    expect(toCsv(['only'])).toBe('only');
+  });
+
+  it('returns undefined for an empty array so the param is omitted', () => {
+    expect(toCsv([])).toBeUndefined();
+  });
+
+  it('returns undefined for non-array input', () => {
+    expect(toCsv(undefined)).toBeUndefined();
+    expect(toCsv(null)).toBeUndefined();
+    expect(toCsv('a,b')).toBeUndefined();
+  });
+
+  it('stringifies non-string entries', () => {
+    expect(toCsv([1, 2])).toBe('1,2');
+  });
+});

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -1,0 +1,25 @@
+/**
+ * Join an array of selected ids into the backend's comma-separated convention
+ * (e.g. `schoolIds=a,b,c`). Returns undefined for empty / non-array input so the
+ * query param is omitted entirely.
+ *
+ * Arrays must never be handed to axios directly: it serializes them as
+ * `classIds[]=a&classIds[]=b`, and the backend's query parser keeps the
+ * brackets in the key, so the filter is dropped and the endpoint silently
+ * answers as if no filter had been sent.
+ *
+ * @param value - The selected ids, usually straight from a filter state
+ * @returns The comma-separated ids, or undefined when there is nothing to send
+ *
+ * @example
+ * ```ts
+ * toCsv(['a', 'b']); // → 'a,b'
+ * toCsv([]);         // → undefined
+ * ```
+ */
+export const toCsv = (value: unknown): string | undefined => {
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map(String).join(',');
+  }
+  return undefined;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved URL-restored filter selections while options are temporarily unavailable during loading.
  * Kept grade and class filters enabled when parent selections are not yet made.
  * Corrected class filter requests to use comma-separated values.

* **Improvements**
  * Standardized query parameter formatting for selected classes and other list values.
  * Omitted empty selections from generated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->