### PR TITLE
Read modules from /me/modules when there is a session, so commercial plans reach the UI

### DIFF
--- a/src/components/ModuleProtectedRoute.test.tsx
+++ b/src/components/ModuleProtectedRoute.test.tsx
@@ -55,6 +55,7 @@ const createMockModulesReturn = (
   hasPerformance: true,
   hasDashboard: true,
   hasLessons: true,
+  hasPrintedKits: false,
   hasTutorial: false,
   tutorialUrl: '',
   hasReadingFluency: false,

--- a/src/hooks/useModules.ts
+++ b/src/hooks/useModules.ts
@@ -29,6 +29,9 @@ export interface UseModulesReturn {
   hasDashboard: boolean;
   hasLessons: boolean;
 
+  /** Printed kits: granted by a commercial plan, so it defaults to false. */
+  hasPrintedKits: boolean;
+
   // Tutorial menu link (true only when enabled AND tutorialUrl is non-empty)
   hasTutorial: boolean;
   tutorialUrl: string;
@@ -122,6 +125,9 @@ export const useModules = (): UseModulesReturn => {
     hasPerformance: modules.performance ?? true,
     hasDashboard: modules.dashboard ?? true,
     hasLessons: modules.lessons ?? true,
+
+    // Not `?? true`: this one is only ever granted, never inherited.
+    hasPrintedKits: modules.printedKits ?? false,
 
     // Tutorial: only show the menu link when enabled AND a url is configured
     hasTutorial: (modules.tutorial ?? false) && tutorialUrl.length > 0,

--- a/src/store/modulesStore.test.ts
+++ b/src/store/modulesStore.test.ts
@@ -1,5 +1,6 @@
 import type { AxiosInstance } from 'axios';
 import { useModulesStore } from './modulesStore';
+import { useAuthStore } from './authStore';
 import { KEYS } from '../utils/keys';
 import {
   DEFAULT_MODULES,
@@ -1330,6 +1331,201 @@ describe('ModulesStore', () => {
       }
 
       expect(callback).not.toBeNull();
+    });
+  });
+
+  describe('fetchModules with an authenticated session', () => {
+    const mockApi: MockApi = { get: jest.fn() };
+    const institutionId = 'test-institution';
+
+    /** Make useAuthStore report a session whose token the api instance can send. */
+    const withSession = (): void => {
+      (useAuthStore.getState as jest.Mock).mockReturnValue({
+        sessionInfo: {
+          institutionId: 'test-institution-id',
+          profileName: 'STUDENT',
+        },
+        selectedProfile: { name: 'STUDENT' },
+        tokens: { token: 'a-token' },
+      });
+    };
+
+    /** Cache a previous answer in localStorage, as a warm boot would have. */
+    const withCachedModules = (): void => {
+      localStorageMock.setItem(
+        KEYS.MODULES_STORAGE,
+        JSON.stringify({
+          state: {
+            modules: { ...DEFAULT_MODULES, essay: true },
+            ownerInstitutionId: institutionId,
+            ownerProfileType: 'STUDENT',
+          },
+        })
+      );
+    };
+
+    beforeEach(() => {
+      mockApi.get.mockReset();
+      withSession();
+    });
+
+    it('should ask /me/modules instead of the public institution flag', async () => {
+      mockApi.get.mockResolvedValue({
+        data: { data: { modules: { essay: false }, plan: null } },
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(mockApi.get).toHaveBeenCalledWith('/me/modules');
+      expect(useModulesStore.getState().modules.essay).toBe(false);
+    });
+
+    it('should store the plan the modules came from', async () => {
+      mockApi.get.mockResolvedValue({
+        data: {
+          data: {
+            modules: { essay: true, simulator: true },
+            plan: { code: 'B', name: 'Plano B' },
+          },
+        },
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(useModulesStore.getState().plan).toEqual({
+        code: 'B',
+        name: 'Plano B',
+      });
+    });
+
+    it('should leave plan null outside B2C', async () => {
+      mockApi.get.mockResolvedValue({
+        data: { data: { modules: { essay: true }, plan: null } },
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(useModulesStore.getState().plan).toBeNull();
+    });
+
+    it('should fall back to the public flag when /me/modules cannot be reached', async () => {
+      mockApi.get.mockImplementation((url: string) => {
+        if (url === '/me/modules') return Promise.reject(new Error('401'));
+        return Promise.resolve({
+          data: { data: { featureFlags: { version: { essay: false } } } },
+        });
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(mockApi.get).toHaveBeenCalledWith(
+        `/featureFlags/institution/${institutionId}/page/MODULES/profile/STUDENT`
+      );
+      expect(useModulesStore.getState().modules.essay).toBe(false);
+    }, 20000);
+
+    it('should revalidate cached modules instead of skipping the request', async () => {
+      withCachedModules();
+      mockApi.get.mockResolvedValue({
+        data: { data: { modules: { essay: false }, plan: null } },
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      // A plan change happens server-side, so a cached value must still be checked.
+      expect(mockApi.get).toHaveBeenCalledWith('/me/modules');
+      expect(useModulesStore.getState().modules.essay).toBe(false);
+    });
+
+    it('should not raise loading while revalidating a cached value', async () => {
+      withCachedModules();
+      const loadingSeen: boolean[] = [];
+      const unsubscribe = useModulesStore.subscribe((state) =>
+        loadingSeen.push(state.loading)
+      );
+      mockApi.get.mockResolvedValue({
+        data: { data: { modules: { essay: false }, plan: null } },
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+      unsubscribe();
+
+      // ModuleProtectedRoute renders nothing while loading; a warm boot must not
+      // blank every gated route for the length of a request.
+      expect(loadingSeen).not.toContain(true);
+    });
+
+    it('should keep the cached modules when every attempt fails', async () => {
+      withCachedModules();
+      useModulesStore.setState({
+        modules: { ...DEFAULT_MODULES, essay: false },
+      });
+      mockApi.get.mockRejectedValue(new Error('network down'));
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(useModulesStore.getState().modules.essay).toBe(false);
+      expect(useModulesStore.getState().loading).toBe(false);
+    }, 30000);
+
+    it('should not request anything when cached and unauthenticated', async () => {
+      withCachedModules();
+      (useAuthStore.getState as jest.Mock).mockReturnValue({
+        sessionInfo: { institutionId: 'test-institution-id' },
+        tokens: null,
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(mockApi.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/modulesStore.ts
+++ b/src/store/modulesStore.ts
@@ -17,11 +17,21 @@ const defaultModules = DEFAULT_MODULES;
 /**
  * Interface defining the modules state
  */
+export interface ActivePlan {
+  code: string;
+  name: string;
+}
+
 export interface ModulesState {
   modules: ModulesConfig;
   loading: boolean;
   ownerInstitutionId: string | null;
   ownerProfileType: string | null;
+  /**
+   * Commercial plan the modules came from, or `null` when they came from the
+   * institution (every non-B2C tenant) or when nothing has been fetched yet.
+   */
+  plan: ActivePlan | null;
 
   /**
    * Fetch modules configuration from the API
@@ -51,6 +61,24 @@ interface ModulesFeatureFlagResponse {
       isProfileSpecific?: boolean;
     };
   } | null;
+}
+
+/**
+ * API response of `GET /me/modules` — the authenticated, per-user answer.
+ */
+interface MyModulesResponse {
+  data: {
+    modules: Partial<ModulesConfig>;
+    plan: ActivePlan | null;
+  } | null;
+}
+
+/**
+ * What a fetch attempt produced. `plan` is only ever non-null for a B2C tenant.
+ */
+interface FetchedModules {
+  version: Partial<ModulesConfig>;
+  plan: ActivePlan | null;
 }
 
 // Guard against stale async responses
@@ -105,15 +133,13 @@ const isStaleRequest = (requestId: number): boolean =>
   requestId !== latestRequestId;
 
 /**
- * Attempt to fetch modules from API with retry logic
- * Returns the modules config on success, null on failure
+ * Run `attempt` with exponential backoff, aborting as soon as a newer request
+ * supersedes this one. Returns null when every attempt failed.
  */
-const fetchWithRetry = async (
-  institutionId: string,
-  api: AxiosInstance,
+const withRetry = async <T>(
   requestId: number,
-  profileType?: string
-): Promise<Partial<ModulesConfig> | null> => {
+  attemptFn: () => Promise<T>
+): Promise<T | null> => {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     if (attempt > 0) {
       await delay(INITIAL_RETRY_DELAY * Math.pow(2, attempt - 1));
@@ -122,24 +148,74 @@ const fetchWithRetry = async (
     if (isStaleRequest(requestId)) return null;
 
     try {
-      // Use the new profile-specific endpoint if profileType is provided
-      const endpoint = profileType
-        ? `/featureFlags/institution/${institutionId}/page/MODULES/profile/${profileType}`
-        : `/featureFlags/institution/${institutionId}/page/MODULES`;
-
-      const response = await api.get<ModulesFeatureFlagResponse>(endpoint);
+      const result = await attemptFn();
 
       if (isStaleRequest(requestId)) return null;
 
-      return response.data?.data?.featureFlags?.version ?? {};
+      return result;
     } catch {
       // Continue to next retry attempt
     }
   }
 
-  console.warn('[modulesStore] Failed to fetch modules after retries');
   return null;
 };
+
+/**
+ * Whether there is a session whose token the API instance can send.
+ *
+ * `/me/modules` is authenticated; without a token it would only ever answer 401,
+ * so the public per-institution endpoint stays the pre-login path.
+ */
+const hasSession = (): boolean =>
+  Boolean(useAuthStore.getState().tokens?.token);
+
+/**
+ * Fetch the effective modules of the authenticated user.
+ *
+ * This is the only call that knows about commercial plans: in a B2C institution
+ * it answers with the active plan's modules, and outside B2C it answers with the
+ * institution's modules unchanged — which is why it replaces the public endpoint
+ * for every product, not just the B2C one.
+ */
+const fetchMyModules = async (
+  api: AxiosInstance,
+  requestId: number
+): Promise<FetchedModules | null> =>
+  withRetry(requestId, async () => {
+    const response = await api.get<MyModulesResponse>('/me/modules');
+
+    return {
+      version: response.data?.data?.modules ?? {},
+      plan: response.data?.data?.plan ?? null,
+    };
+  });
+
+/**
+ * Fetch the institution's MODULES feature flag — the anonymous answer.
+ *
+ * Used before login, and as the fallback when `/me/modules` cannot be reached,
+ * so a failure there degrades to the previous behaviour instead of an empty app.
+ */
+const fetchInstitutionModules = async (
+  institutionId: string,
+  api: AxiosInstance,
+  requestId: number,
+  profileType?: string
+): Promise<FetchedModules | null> =>
+  withRetry(requestId, async () => {
+    // Use the new profile-specific endpoint if profileType is provided
+    const endpoint = profileType
+      ? `/featureFlags/institution/${institutionId}/page/MODULES/profile/${profileType}`
+      : `/featureFlags/institution/${institutionId}/page/MODULES`;
+
+    const response = await api.get<ModulesFeatureFlagResponse>(endpoint);
+
+    return {
+      version: response.data?.data?.featureFlags?.version ?? {},
+      plan: null,
+    };
+  });
 
 /**
  * Zustand store for managing modules visibility with persistence
@@ -153,13 +229,25 @@ export const useModulesStore = create<ModulesState>()(
       loading: false,
       ownerInstitutionId: null,
       ownerProfileType: null,
+      plan: null,
 
       /**
-       * Fetch modules configuration from the API
-       * Only fetches if:
-       * 1. No modules data exists in localStorage for this profile
-       * 2. User made a new login (data cleared by auth subscriber)
-       * Implements retry with exponential backoff on failure
+       * Fetch the modules configuration from the API.
+       *
+       * Picks the endpoint by session, not by tenant: with a session it asks
+       * `/me/modules`, which resolves the commercial plan when the institution is
+       * B2C and returns the institution's own modules otherwise. Without a session
+       * — the login screen — it falls back to the public per-institution flag.
+       * Branching on "is this tenant B2C?" instead would leave the authenticated
+       * path unexercised everywhere else, so it would rot.
+       *
+       * Caching is stale-while-revalidate. A cached value is served immediately and
+       * still revalidated in the background whenever there is a session, because
+       * modules can now change server-side (a plan upgrade) with nothing on the
+       * client to signal it — no cache key the client builds can detect that. The
+       * background pass deliberately leaves `loading` alone: `ModuleProtectedRoute`
+       * renders nothing while loading, so raising it on a warm boot would blank
+       * every gated route for the length of a request.
        *
        * @param institutionId - The institution UUID
        * @param api - Axios instance for API calls
@@ -170,30 +258,57 @@ export const useModulesStore = create<ModulesState>()(
         api: AxiosInstance,
         profileType?: string
       ): Promise<void> => {
-        if (hasCachedModules(profileType)) return;
+        const authenticated = hasSession();
+        const cached = hasCachedModules(profileType);
+
+        // Nothing to revalidate before login: the public flag is the only answer
+        // available, and it is what the cache already holds.
+        if (cached && !authenticated) return;
 
         const requestId = ++latestRequestId;
-        set({ loading: true });
 
-        const version = await fetchWithRetry(
-          institutionId,
-          api,
-          requestId,
-          profileType
-        );
+        if (!cached) {
+          set({ loading: true });
+        }
+
+        const result = authenticated
+          ? ((await fetchMyModules(api, requestId)) ??
+            // Degrade to the previous behaviour rather than to an empty app when
+            // the authenticated call cannot be reached.
+            (await fetchInstitutionModules(
+              institutionId,
+              api,
+              requestId,
+              profileType
+            )))
+          : await fetchInstitutionModules(
+              institutionId,
+              api,
+              requestId,
+              profileType
+            );
 
         if (isStaleRequest(requestId)) return;
 
-        if (version === null) {
-          set({ modules: defaultModules, loading: false });
-        } else {
-          set({
-            modules: mergeModulesConfig(version),
-            ownerInstitutionId: institutionId,
-            ownerProfileType: profileType ?? null,
-            loading: false,
-          });
+        if (result === null) {
+          console.warn('[modulesStore] Failed to fetch modules after retries');
+          // Keep whatever is already cached; only a cold start falls back to the
+          // permissive defaults, which is the pre-existing behaviour.
+          set(
+            cached
+              ? { loading: false }
+              : { modules: defaultModules, loading: false }
+          );
+          return;
         }
+
+        set({
+          modules: mergeModulesConfig(result.version),
+          plan: result.plan,
+          ownerInstitutionId: institutionId,
+          ownerProfileType: profileType ?? null,
+          loading: false,
+        });
       },
 
       /**
@@ -207,6 +322,7 @@ export const useModulesStore = create<ModulesState>()(
           loading: false,
           ownerInstitutionId: null,
           ownerProfileType: null,
+          plan: null,
         });
       },
     }),
@@ -217,6 +333,7 @@ export const useModulesStore = create<ModulesState>()(
         modules: state.modules,
         ownerInstitutionId: state.ownerInstitutionId,
         ownerProfileType: state.ownerProfileType,
+        plan: state.plan,
       }),
       onRehydrateStorage: () => (rehydrated) => {
         if (!rehydrated) return;

--- a/src/types/modulesConfig.ts
+++ b/src/types/modulesConfig.ts
@@ -126,6 +126,13 @@ export interface ModulesConfig {
   dashboard: boolean;
   lessons: boolean;
 
+  /**
+   * Printed kits — an entitlement of the top commercial plan, with no screen of
+   * its own yet. Unlike every other key it defaults to `false`: it is granted by
+   * a plan, never inherited from a permissive institution default.
+   */
+  printedKits: boolean;
+
   // Tutorial menu link (off by default; also needs a non-empty tutorialUrl)
   tutorial: boolean;
   tutorialUrl: string;
@@ -173,6 +180,9 @@ export const DEFAULT_MODULES: ModulesConfig = {
   performance: true,
   dashboard: true,
   lessons: true,
+
+  // Granted by a commercial plan only — see the interface
+  printedKits: false,
 
   // Tutorial off by default (opt-in per institution, requires a url)
   tutorial: false,


### PR DESCRIPTION
Consumes the B2C work merged in the monolith. Without this, plans exist in the database and
change nothing on screen.

## Why

`fetchModules` always asked `/featureFlags/institution/{id}/page/MODULES`, which is anonymous
— the backend cannot know which student is calling, so a per-student plan has nowhere to enter.
`GET /me/modules` is the authenticated answer and resolves it.

The failure today is not cosmetic and it **fails open**: a B2C institution gets a `MODULES` flag
auto-created with the permissive default, so every B2C student currently sees every module —
Redação and the SISU calculator included — regardless of the plan they paid for. Since module
gating is client-side only, nothing else stops them.

## What changes

**The endpoint is chosen by session, not by tenant.** With a session it asks `/me/modules`;
before login it keeps the public per-institution flag. It is deliberately *not* conditional on
B2C: outside B2C the route returns the institution's modules unchanged, so it replaces the old
call everywhere. Branching on tenant type would leave the authenticated path unexercised in
B2B and it would rot.

**Caching became stale-while-revalidate.** A cached value is still served immediately, but it
is also revalidated in the background whenever there is a session. Modules can now change
server-side — a plan upgrade — with nothing on the client to signal it, and **no cache key the
client builds can detect that**; only a request can. The background pass deliberately leaves
`loading` alone: `ModuleProtectedRoute` renders nothing while loading, so raising it on a warm
boot would blank every gated route for the length of a request. There is a test for exactly
that.

**`plan` is now in the store** (`{ code, name } | null`, persisted) — what an upsell screen
will read.

**`printedKits` / `hasPrintedKits`.** Comparing both vocabularies, this was the only key
missing: 28 in common, `printedKits` only on the backend. It is the one key defaulting to
`false` — granted by a plan, never inherited from a permissive institution default.

## Safety

A failed `/me/modules` falls back to the public endpoint rather than to an empty app, so this
degrades to today's behaviour if the route is unreachable — including against an older API.
That also means the release order between backend and lib does not matter.

The 44 pre-existing store tests pass **unchanged**: the anonymous path is byte-for-byte the
same, which was the condition for not regressing the professor and gestor apps, which share
this store.

## Verification

`tsc` clean, `eslint` clean, **10,712 tests / 401 suites passing**, global coverage 95.15%
(threshold 80%).

8 new tests: calls `/me/modules`; stores the plan; leaves `plan` null outside B2C; falls back
when the authenticated call fails; revalidates instead of skipping; does not raise `loading`
on a warm boot; keeps cached modules when every attempt fails; issues no request when cached
and unauthenticated.

## After merging

`frontend-aluno-web`, `frontend-professor-web` and `frontend-gestor-web` need the version bump
to pick this up. The mobile app is independent — it has its own store, handled separately.