### PR TITLE
AE-2984: fix filter by class - unwrap the /auth/me envelope in the user store

### DIFF
--- a/src/store/userStore.test.ts
+++ b/src/store/userStore.test.ts
@@ -24,35 +24,33 @@ Object.defineProperty(window, 'localStorage', {
 
 describe('createUserStore', () => {
   const mockUserData: MyDataResponse = {
-    message: 'Success',
     user: {
       id: 'user-1',
       email: 'test@example.com',
       name: 'Test User',
-      active: true,
-      createdAt: '2023-01-01T00:00:00Z',
-      updatedAt: '2023-01-01T00:00:00Z',
-    },
-    userInfos: {
-      id: '1',
-      userId: 'user-1',
       urlProfilePicture: null,
-      genre: null,
-      facebook: null,
-      instagram: null,
-      studentNumber: null,
-      street: null,
-      streetNumber: null,
-      neighborhood: null,
-      complement: null,
-      city: null,
-      state: null,
-      zipCode: null,
-      timeSpent: 0,
-      lastInteraction: '2023-01-01T00:00:00Z',
-      createdAt: '2023-01-01T00:00:00Z',
-      updatedAt: '2023-01-01T00:00:00Z',
     },
+    institutions: [{ id: '1', name: 'Test Institution' }],
+    schools: [{ id: '1', name: 'Test School', institutionId: '1' }],
+    schoolYears: [
+      {
+        id: '1',
+        name: '2023',
+        schoolId: '1',
+        school: { id: '1', name: 'Test School' },
+      },
+    ],
+    classes: [
+      {
+        id: '1',
+        name: '3A',
+        shift: 'MANHA',
+        schoolId: '1',
+        schoolYearId: '1',
+        school: { id: '1', name: 'Test School' },
+        schoolYear: { id: '1', name: '2023' },
+      },
+    ],
     userInstitutions: [
       {
         profile: {
@@ -63,6 +61,7 @@ describe('createUserStore', () => {
         },
         institution: { id: '1', name: 'Test School', type: 'school' },
         school: { id: '1', name: 'Test School' },
+        schoolGroup: null,
         schoolYear: { id: '1', name: '2023' },
         class: { id: '1', name: '3A' },
       },
@@ -72,7 +71,6 @@ describe('createUserStore', () => {
 
   const mockUserData2: MyDataResponse = {
     ...mockUserData,
-    message: 'Success User 2',
     user: {
       ...mockUserData.user,
       id: 'user-2',
@@ -80,6 +78,14 @@ describe('createUserStore', () => {
       name: 'User Two',
     },
   };
+
+  /**
+   * Wrap a payload the way GET /auth/me does: `{ message, data }` inside the
+   * axios response body. The store is responsible for unwrapping it.
+   */
+  const authMeResponse = (payload: MyDataResponse) => ({
+    data: { message: 'Dados de acesso obtidos com sucesso', data: payload },
+  });
 
   let mockApiClient: UserStoreApiClient;
 
@@ -136,9 +142,9 @@ describe('createUserStore', () => {
 
   describe('fetchUserData', () => {
     it('should fetch user data successfully', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -152,11 +158,32 @@ describe('createUserStore', () => {
       expect(useUserStore.getState().lastFetched).toBeGreaterThan(0);
     });
 
+    it('should unwrap the response envelope instead of storing it', async () => {
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
+
+      const useUserStore = createUserStore({ apiClient: mockApiClient });
+
+      await useUserStore.getState().fetchUserData();
+
+      const stored = useUserStore.getState().data as unknown as Record<
+        string,
+        unknown
+      >;
+      // Storing `{ message, data }` would push every field one level deeper and
+      // make the whole payload read as undefined for consumers.
+      expect(stored.data).toBeUndefined();
+      expect(stored.message).toBeUndefined();
+      expect(useUserStore.getState().data?.classes).toHaveLength(1);
+      expect(useUserStore.getState().data?.userInstitutions).toHaveLength(1);
+    });
+
     it('should set loading state during fetch', async () => {
       (mockApiClient.get as jest.Mock).mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: mockUserData }), 100)
+            setTimeout(() => resolve(authMeResponse(mockUserData)), 100)
           )
       );
 
@@ -204,9 +231,9 @@ describe('createUserStore', () => {
     });
 
     it('should use cache when valid', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -220,9 +247,9 @@ describe('createUserStore', () => {
     });
 
     it('should ignore cache when force = true', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValue({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValue(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -236,9 +263,9 @@ describe('createUserStore', () => {
     });
 
     it('should ignore cache when expired (default TTL)', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValue({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValue(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -255,9 +282,9 @@ describe('createUserStore', () => {
     });
 
     it('should respect custom cacheTTL', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValue({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValue(
+        authMeResponse(mockUserData)
+      );
 
       // Custom TTL of 1 minute
       const useUserStore = createUserStore({
@@ -288,7 +315,7 @@ describe('createUserStore', () => {
       (mockApiClient.get as jest.Mock).mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: mockUserData }), 100)
+            setTimeout(() => resolve(authMeResponse(mockUserData)), 100)
           )
       );
 
@@ -314,8 +341,8 @@ describe('createUserStore', () => {
       });
 
       (mockApiClient.get as jest.Mock)
-        .mockResolvedValueOnce({ data: mockUserData })
-        .mockResolvedValueOnce({ data: mockUserData2 });
+        .mockResolvedValueOnce(authMeResponse(mockUserData))
+        .mockResolvedValueOnce(authMeResponse(mockUserData2));
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -341,9 +368,9 @@ describe('createUserStore', () => {
         user: { id: 'user-1' },
       });
 
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -361,9 +388,9 @@ describe('createUserStore', () => {
         user: { id: 'user-1' },
       });
 
-      (mockApiClient.get as jest.Mock).mockResolvedValue({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValue(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -385,8 +412,8 @@ describe('createUserStore', () => {
       });
 
       (mockApiClient.get as jest.Mock)
-        .mockResolvedValueOnce({ data: mockUserData })
-        .mockResolvedValueOnce({ data: mockUserData2 });
+        .mockResolvedValueOnce(authMeResponse(mockUserData))
+        .mockResolvedValueOnce(authMeResponse(mockUserData2));
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -407,9 +434,9 @@ describe('createUserStore', () => {
 
   describe('clearUserData', () => {
     it('should clear all user data including cachedUserId', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -457,9 +484,9 @@ describe('createUserStore', () => {
 
   describe('Cache validation', () => {
     it('should consider cache invalid when lastFetched is null', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -473,9 +500,9 @@ describe('createUserStore', () => {
     });
 
     it('should consider cache valid within TTL', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 
@@ -495,13 +522,11 @@ describe('createUserStore', () => {
   describe('Factory isolation', () => {
     it('should create independent store instances', async () => {
       const mockApiClient1: UserStoreApiClient = {
-        get: jest.fn().mockResolvedValue({ data: mockUserData }),
+        get: jest.fn().mockResolvedValue(authMeResponse(mockUserData)),
       };
 
       const mockApiClient2: UserStoreApiClient = {
-        get: jest.fn().mockResolvedValue({
-          data: { ...mockUserData, message: 'Different' },
-        }),
+        get: jest.fn().mockResolvedValue(authMeResponse(mockUserData2)),
       };
 
       const useUserStore1 = createUserStore({
@@ -517,22 +542,22 @@ describe('createUserStore', () => {
       await useUserStore1.getState().fetchUserData();
       await useUserStore2.getState().fetchUserData();
 
-      expect(useUserStore1.getState().data?.message).toBe('Success');
-      expect(useUserStore2.getState().data?.message).toBe('Different');
+      expect(useUserStore1.getState().data?.user.id).toBe('user-1');
+      expect(useUserStore2.getState().data?.user.id).toBe('user-2');
 
       // Clear one store should not affect the other
       useUserStore1.getState().clearUserData();
 
       expect(useUserStore1.getState().data).toBeNull();
-      expect(useUserStore2.getState().data?.message).toBe('Different');
+      expect(useUserStore2.getState().data?.user.id).toBe('user-2');
     });
   });
 
   describe('Integration', () => {
     it('should execute complete flow: fetch -> clear', async () => {
-      (mockApiClient.get as jest.Mock).mockResolvedValueOnce({
-        data: mockUserData,
-      });
+      (mockApiClient.get as jest.Mock).mockResolvedValueOnce(
+        authMeResponse(mockUserData)
+      );
 
       const useUserStore = createUserStore({ apiClient: mockApiClient });
 

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -70,8 +70,15 @@ export function createUserStore(config: CreateUserStoreConfig) {
    * Get current user data from the backend
    */
   const getMyData = async (): Promise<MyDataResponse> => {
-    const response = await apiClient.get<MyDataResponse>('/auth/me');
-    return response.data;
+    // The endpoint answers `{ message, data }`; keeping the envelope would put
+    // every field one level deeper than the type promises, so consumers would
+    // silently read `undefined` — including `user.id`, which namespaces the
+    // cache and would leave it permanently invalid.
+    const response = await apiClient.get<{
+      message: string;
+      data: MyDataResponse;
+    }>('/auth/me');
+    return response.data.data;
   };
 
   /**

--- a/src/types/user.test.ts
+++ b/src/types/user.test.ts
@@ -181,13 +181,33 @@ describe('User Types', () => {
         },
         institution: { id: '1', name: 'School', type: 'school' },
         school: { id: '1', name: 'School' },
+        schoolGroup: null,
         schoolYear: { id: '1', name: '2023' },
         class: { id: '1', name: '3A' },
       };
 
       expect(userInstitution.profile.name).toBe('Student');
-      expect(userInstitution.school.name).toBe('School');
-      expect(userInstitution.class.name).toBe('3A');
+      expect(userInstitution.school?.name).toBe('School');
+      expect(userInstitution.class?.name).toBe('3A');
+    });
+
+    it('should accept an enrollment with no school, group, grade or class', () => {
+      const userInstitution: UserInstitution = {
+        profile: {
+          id: '1',
+          name: 'General Manager',
+          description: 'General Manager',
+          position: 1,
+        },
+        institution: { id: '1', name: 'School', type: 'school' },
+        school: null,
+        schoolGroup: null,
+        schoolYear: null,
+        class: null,
+      };
+
+      expect(userInstitution.school).toBeNull();
+      expect(userInstitution.class).toBeNull();
     });
   });
 
@@ -204,43 +224,41 @@ describe('User Types', () => {
   });
 
   describe('MyDataResponse', () => {
-    it('should accept valid my data response object', () => {
+    it('should accept the unwrapped GET /auth/me payload', () => {
       const response: MyDataResponse = {
-        message: 'Success',
         user: {
           id: '1',
           email: 'test@example.com',
           name: 'Test User',
-          active: true,
-          createdAt: '2023-01-01T00:00:00Z',
-          updatedAt: '2023-01-01T00:00:00Z',
-        },
-        userInfos: {
-          id: '1',
-          userId: '1',
           urlProfilePicture: null,
-          genre: null,
-          facebook: null,
-          instagram: null,
-          studentNumber: null,
-          street: null,
-          streetNumber: null,
-          neighborhood: null,
-          complement: null,
-          city: null,
-          state: null,
-          zipCode: null,
-          timeSpent: 0,
-          lastInteraction: '2023-01-01T00:00:00Z',
-          createdAt: '2023-01-01T00:00:00Z',
-          updatedAt: '2023-01-01T00:00:00Z',
         },
+        institutions: [{ id: 'inst-1', name: 'Institution' }],
+        schools: [{ id: 'school-1', name: 'School', institutionId: 'inst-1' }],
+        schoolYears: [
+          {
+            id: 'year-1',
+            name: '2023',
+            schoolId: 'school-1',
+            school: { id: 'school-1', name: 'School' },
+          },
+        ],
+        classes: [
+          {
+            id: 'class-1',
+            name: '3A',
+            shift: 'MANHA',
+            schoolId: 'school-1',
+            schoolYearId: 'year-1',
+            school: { id: 'school-1', name: 'School' },
+            schoolYear: { id: 'year-1', name: '2023' },
+          },
+        ],
         userInstitutions: [],
         subTeacherTopicClasses: [],
       };
 
-      expect(response.message).toBe('Success');
       expect(response.user.name).toBe('Test User');
+      expect(response.classes[0].name).toBe('3A');
       expect(response.userInstitutions).toEqual([]);
     });
   });

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -78,14 +78,27 @@ export interface Class {
 }
 
 /**
- * User institution relationship
+ * School group (NRE) information
+ */
+export interface SchoolGroup {
+  id: string;
+  name: string;
+  code: string | null;
+}
+
+/**
+ * User institution relationship (one enrollment row).
+ *
+ * Every nested entity is nullable: a GENERAL_MANAGER has no school, a teacher
+ * bound to a school but not to a class has no class, and so on.
  */
 export interface UserInstitution {
   profile: Profile;
-  institution: Institution;
-  school: School;
-  schoolYear: SchoolYear;
-  class: Class;
+  institution: Institution | null;
+  school: School | null;
+  schoolGroup: SchoolGroup | null;
+  schoolYear: SchoolYear | null;
+  class: Class | null;
 }
 
 /**
@@ -105,12 +118,71 @@ export interface SubTeacherTopicClass {
 }
 
 /**
- * Complete user data response from GET /auth/me endpoint
+ * Identity carried by GET /auth/me. Narrower than {@link User}: the endpoint
+ * only returns what is needed to render the logged-in user.
+ */
+export interface AccessUser {
+  id: string;
+  name: string;
+  email: string;
+  urlProfilePicture: string | null;
+}
+
+/**
+ * Institution the user may read
+ */
+export interface AccessInstitution {
+  id: string;
+  name: string;
+}
+
+/**
+ * School the user may read
+ */
+export interface AccessSchool {
+  id: string;
+  name: string;
+  institutionId: string;
+}
+
+/**
+ * School year the user may read
+ */
+export interface AccessSchoolYear {
+  id: string;
+  name: string;
+  schoolId: string;
+  school: School;
+}
+
+/**
+ * Class the user may read
+ */
+export interface AccessClass {
+  id: string;
+  name: string;
+  shift: string;
+  schoolId: string;
+  schoolYearId: string;
+  school: School;
+  schoolYear: SchoolYear;
+}
+
+/**
+ * Payload of GET /auth/me, already unwrapped from the `{ message, data }`
+ * envelope by the user store.
+ *
+ * The flat lists (`institutions` / `schools` / `schoolYears` / `classes`)
+ * answer "what may I read" and are the right source for access filters. The
+ * `userInstitutions` rows answer "how am I enrolled" and keep the
+ * school -> grade -> class relation of each enrollment.
  */
 export interface MyDataResponse {
-  message: string;
-  user: User;
-  userInfos: UserInfos;
+  user: AccessUser;
+  institutions: AccessInstitution[];
+  schools: AccessSchool[];
+  schoolYears: AccessSchoolYear[];
+  classes: AccessClass[];
   userInstitutions: UserInstitution[];
   subTeacherTopicClasses: SubTeacherTopicClass[];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account data loading by correctly processing the authentication response and storing the contained profile information.
  * Updated access and enrollment data handling to support users without an associated school, group, year, or class.
  * Added support for school groups and expanded access details for institutions, schools, school years, and classes.
* **Tests**
  * Expanded coverage for response handling, caching, sessions, isolation, and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->