### PR TITLE
Stop the modules fallback from doubling how long gated routes stay blank

### DIFF
--- a/src/store/modulesStore.test.ts
+++ b/src/store/modulesStore.test.ts
@@ -1448,6 +1448,28 @@ describe('ModulesStore', () => {
       expect(useModulesStore.getState().modules.essay).toBe(false);
     }, 20000);
 
+    it('should not spend a second retry cycle on the fallback', async () => {
+      // `ModuleProtectedRoute` renders nothing while `loading`, so the time both calls take
+      // is the time every gated route stays blank on a cold start. The retries belong to
+      // `/me/modules`; the fallback gets one shot.
+      const calls: string[] = [];
+      mockApi.get.mockImplementation((url: string) => {
+        calls.push(url);
+        return Promise.reject(new Error('network down'));
+      });
+
+      await useModulesStore
+        .getState()
+        .fetchModules(
+          institutionId,
+          mockApi as unknown as AxiosInstance,
+          'STUDENT'
+        );
+
+      expect(calls.filter((url) => url === '/me/modules')).toHaveLength(4);
+      expect(calls.filter((url) => url !== '/me/modules')).toHaveLength(1);
+    }, 30000);
+
     it('should revalidate cached modules instead of skipping the request', async () => {
       withCachedModules();
       mockApi.get.mockResolvedValue({

--- a/src/store/modulesStore.ts
+++ b/src/store/modulesStore.ts
@@ -138,9 +138,10 @@ const isStaleRequest = (requestId: number): boolean =>
  */
 const withRetry = async <T>(
   requestId: number,
-  attemptFn: () => Promise<T>
+  attemptFn: () => Promise<T>,
+  maxRetries: number = MAX_RETRIES
 ): Promise<T | null> => {
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (attempt > 0) {
       await delay(INITIAL_RETRY_DELAY * Math.pow(2, attempt - 1));
     }
@@ -201,21 +202,26 @@ const fetchInstitutionModules = async (
   institutionId: string,
   api: AxiosInstance,
   requestId: number,
-  profileType?: string
+  profileType?: string,
+  maxRetries: number = MAX_RETRIES
 ): Promise<FetchedModules | null> =>
-  withRetry(requestId, async () => {
-    // Use the new profile-specific endpoint if profileType is provided
-    const endpoint = profileType
-      ? `/featureFlags/institution/${institutionId}/page/MODULES/profile/${profileType}`
-      : `/featureFlags/institution/${institutionId}/page/MODULES`;
+  withRetry(
+    requestId,
+    async () => {
+      // Use the new profile-specific endpoint if profileType is provided
+      const endpoint = profileType
+        ? `/featureFlags/institution/${institutionId}/page/MODULES/profile/${profileType}`
+        : `/featureFlags/institution/${institutionId}/page/MODULES`;
 
-    const response = await api.get<ModulesFeatureFlagResponse>(endpoint);
+      const response = await api.get<ModulesFeatureFlagResponse>(endpoint);
 
-    return {
-      version: response.data?.data?.featureFlags?.version ?? {},
-      plan: null,
-    };
-  });
+      return {
+        version: response.data?.data?.featureFlags?.version ?? {},
+        plan: null,
+      };
+    },
+    maxRetries
+  );
 
 /**
  * Zustand store for managing modules visibility with persistence
@@ -274,12 +280,18 @@ export const useModulesStore = create<ModulesState>()(
         const result = authenticated
           ? ((await fetchMyModules(api, requestId)) ??
             // Degrade to the previous behaviour rather than to an empty app when
-            // the authenticated call cannot be reached.
+            // the authenticated call cannot be reached — but with a single attempt.
+            // The retries belong to `/me/modules`, which is the call that gives the
+            // right answer; spending a second full backoff cycle here would double
+            // the time gated routes stay blank, and `ModuleProtectedRoute` renders
+            // nothing while `loading`. If the authenticated call is simply absent,
+            // one request settles it; if the network is down, repeating it is waste.
             (await fetchInstitutionModules(
               institutionId,
               api,
               requestId,
-              profileType
+              profileType,
+              0
             )))
           : await fetchInstitutionModules(
               institutionId,


### PR DESCRIPTION
Regression introduced by the `/me/modules` change. Caught by the E2E suites of
`frontend-aluno-web` (https://github.com/analytica-ensino/frontend-aluno-web/pull/293) and `frontend-professor-web` ([#182](https://github.com/analytica-ensino/frontend-professor-web/pull/182)), which started failing on the
lib bump.

## What went wrong

`fetchModules` asks `/me/modules` and, when that fails, falls back to the public
per-institution flag. Both calls ran a **full retry cycle**: with `MAX_RETRIES = 3` and
exponential backoff, each costs `0 + 1s + 2s + 4s ≈ 7s`.

`ModuleProtectedRoute` renders nothing while `loading`, so that time is exactly how long every
gated route stays blank on a cold start with a slow or unreachable API:

| | Cycles | Blank screen |
|---|---|---|
| Before | public endpoint only | ~7s |
| After the `/me/modules` change | `/me/modules` **then** the fallback | ~14s |

That is a product regression, not just a test artifact — the E2E suites only made it visible,
by asserting with a 10s budget that used to have 3s of slack.

## The fix

The fallback now gets **a single attempt**. Retries stay on `/me/modules`, which is the call
that produces the correct answer and the one where insisting is worth it. If that endpoint is
simply unavailable, one request to the public flag settles it; if the network is down,
repeating it is waste. Worst case is back to ~7s.

A test pins the budget: with everything failing, `/me/modules` is called 4 times and the public
endpoint once. Reintroducing the double cycle fails it.

## Verification

`tsc` and `eslint` clean, **10,722 tests / 402 suites** passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading reliability by applying appropriate retry behavior to authenticated and unauthenticated requests.
  * Prevented unnecessary repeated attempts when falling back to public feature-flag module data after authenticated requests fail.

* **Tests**
  * Added coverage confirming the expected request and fallback attempt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->