### PR TITLE
AE-2987 - feat: presencial activities components

### DIFF
--- a/src/components/ActivityCreate/ActivityCreate.test.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.test.tsx
@@ -189,6 +189,11 @@ jest.mock('../ActivityFilters/ActivityFilters', () => ({
 }));
 
 jest.mock('../Menu/Menu', () => {
+  // The real Menu owns selection: items carry a value and the Menu emits
+  // onValueChange. The mock keeps the last handler so a MenuItem click can
+  // drive it, which is what the tab tests exercise.
+  let latestOnValueChange: ((value: string) => void) | undefined;
+
   return {
     __esModule: true,
     default: ({
@@ -196,22 +201,26 @@ jest.mock('../Menu/Menu', () => {
       defaultValue,
       value,
       variant,
+      onValueChange,
     }: {
       children: React.ReactNode;
       defaultValue: string;
       value?: string;
       onValueChange?: (value: string) => void;
       variant?: string;
-    }) => (
-      <div
-        data-testid="menu"
-        data-variant={variant}
-        data-value={value || defaultValue}
-        data-default-value={defaultValue}
-      >
-        {children}
-      </div>
-    ),
+    }) => {
+      latestOnValueChange = onValueChange;
+      return (
+        <div
+          data-testid="menu"
+          data-variant={variant}
+          data-value={value || defaultValue}
+          data-default-value={defaultValue}
+        >
+          {children}
+        </div>
+      );
+    },
     MenuContent: ({
       children,
       variant,
@@ -238,13 +247,41 @@ jest.mock('../Menu/Menu', () => {
         type="button"
         data-testid={`menu-item-${value}`}
         data-variant={variant}
-        onClick={onClick}
+        onClick={() => {
+          onClick?.();
+          latestOnValueChange?.(value);
+        }}
       >
         {children}
       </button>
     ),
   };
 });
+
+jest.mock('../EssayThemePicker/EssayThemePicker', () => ({
+  EssayThemePicker: ({
+    selectedTheme,
+    onSelectTheme,
+    onRemoveTheme,
+  }: {
+    selectedTheme: { id: string; title: string } | null;
+    onSelectTheme: (theme: { id: string; title: string }) => void;
+    onRemoveTheme: () => void;
+  }) => (
+    <div data-testid="essay-theme-picker">
+      <span data-testid="selected-theme">{selectedTheme?.id ?? 'none'}</span>
+      <button
+        type="button"
+        onClick={() => onSelectTheme({ id: 'theme-1', title: 'Tema 1' })}
+      >
+        pick-theme
+      </button>
+      <button type="button" onClick={onRemoveTheme}>
+        clear-theme
+      </button>
+    </div>
+  ),
+}));
 
 jest.mock('../ActivityPreview/ActivityPreview', () => ({
   ActivityPreview: ({
@@ -5252,6 +5289,75 @@ describe('CreateActivity', () => {
       await waitFor(() => {
         expect(screen.getByTestId('students-count')).toHaveTextContent('2');
       });
+    });
+  });
+
+  describe('Essay tab', () => {
+    it('does not show the tabs on a regular activity', () => {
+      render(<CreateActivity {...defaultProps} enableEssayTab />);
+
+      expect(screen.queryByTestId('menu-item-essay')).not.toBeInTheDocument();
+    });
+
+    it('does not show the tabs on an in-person exam while the flag is off', () => {
+      render(<CreateActivity {...defaultProps} isInPersonExam />);
+
+      expect(screen.queryByTestId('menu-item-essay')).not.toBeInTheDocument();
+    });
+
+    it('shows both tabs on an in-person exam with the flag on', () => {
+      render(
+        <CreateActivity {...defaultProps} isInPersonExam enableEssayTab />
+      );
+
+      expect(screen.getByTestId('menu-item-questions')).toBeInTheDocument();
+      expect(screen.getByTestId('menu-item-essay')).toBeInTheDocument();
+      expect(screen.getByText('Redação')).toBeInTheDocument();
+    });
+
+    it('opens the theme picker on the essay tab and goes back to the questions', () => {
+      render(
+        <CreateActivity {...defaultProps} isInPersonExam enableEssayTab />
+      );
+
+      expect(
+        screen.queryByTestId('essay-theme-picker')
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('menu-item-essay'));
+      expect(screen.getByTestId('essay-theme-picker')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('menu-item-questions'));
+      expect(
+        screen.queryByTestId('essay-theme-picker')
+      ).not.toBeInTheDocument();
+    });
+
+    it('keeps the picked theme while switching tabs', () => {
+      render(
+        <CreateActivity {...defaultProps} isInPersonExam enableEssayTab />
+      );
+
+      fireEvent.click(screen.getByTestId('menu-item-essay'));
+      fireEvent.click(screen.getByText('pick-theme'));
+      expect(screen.getByTestId('selected-theme')).toHaveTextContent('theme-1');
+
+      fireEvent.click(screen.getByTestId('menu-item-questions'));
+      fireEvent.click(screen.getByTestId('menu-item-essay'));
+
+      expect(screen.getByTestId('selected-theme')).toHaveTextContent('theme-1');
+    });
+
+    it('detaches the theme', () => {
+      render(
+        <CreateActivity {...defaultProps} isInPersonExam enableEssayTab />
+      );
+
+      fireEvent.click(screen.getByTestId('menu-item-essay'));
+      fireEvent.click(screen.getByText('pick-theme'));
+      fireEvent.click(screen.getByText('clear-theme'));
+
+      expect(screen.getByTestId('selected-theme')).toHaveTextContent('none');
     });
   });
 });

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -206,6 +206,9 @@ const CreateActivity = ({
   );
   const [essayTheme, setEssayTheme] = useState<EssayTheme | null>(null);
 
+  /** The questions builder is hidden only while the essay tab is open. */
+  const showQuestionsTab = !showEssayTab || activeTab === 'questions';
+
   // Estados internos
   const [activity, setActivity] = useState<ActivityData | null>(null);
   const [preFilters, setPreFilters] = useState<ActivityPreFiltersInput | null>(
@@ -1206,57 +1209,60 @@ const CreateActivity = ({
       )}
 
       {/* Main Content */}
-      {showEssayTab && activeTab === 'essay' ? (
+      {showEssayTab && activeTab === 'essay' && (
         <EssayThemePicker
           apiClient={apiClient}
           selectedTheme={essayTheme}
           onSelectTheme={setEssayTheme}
           onRemoveTheme={() => setEssayTheme(null)}
         />
-      ) : isSmallScreen ? (
-        <SmallScreenLayout
-          apiClient={apiClient}
-          institutionId={institutionId}
-          isDark={isDark}
-          selectedView={selectedView}
-          onViewChange={setSelectedView}
-          initialFiltersData={initialFiltersData}
-          onFiltersChange={handleFiltersChange}
-          onApplyFilters={handleApplyFilters}
-          onClearFilters={handleClearFilters}
-          onAddQuestion={handleAddQuestion}
-          addedQuestionIds={addedQuestionIds}
-          enableExamMode={enableExamMode || isInPersonExam}
-          isInPersonExam={isInPersonExam}
-          loadingInitialQuestions={loadingInitialQuestions}
-          questions={questions}
-          onRemoveAll={handleRemoveAll}
-          onRemoveQuestion={handleRemoveQuestion}
-          onReorder={handleReorder}
-          filtersKey={filtersKey}
-        />
-      ) : (
-        <DesktopLayout
-          apiClient={apiClient}
-          institutionId={institutionId}
-          isDark={isDark}
-          initialFiltersData={initialFiltersData}
-          draftFilters={draftFilters}
-          onFiltersChange={handleFiltersChange}
-          onApplyFilters={handleApplyFilters}
-          onClearFilters={handleClearFilters}
-          onAddQuestion={handleAddQuestion}
-          addedQuestionIds={addedQuestionIds}
-          enableExamMode={enableExamMode || isInPersonExam}
-          isInPersonExam={isInPersonExam}
-          loadingInitialQuestions={loadingInitialQuestions}
-          questions={questions}
-          onRemoveAll={handleRemoveAll}
-          onRemoveQuestion={handleRemoveQuestion}
-          onReorder={handleReorder}
-          filtersKey={filtersKey}
-        />
       )}
+
+      {showQuestionsTab &&
+        (isSmallScreen ? (
+          <SmallScreenLayout
+            apiClient={apiClient}
+            institutionId={institutionId}
+            isDark={isDark}
+            selectedView={selectedView}
+            onViewChange={setSelectedView}
+            initialFiltersData={initialFiltersData}
+            onFiltersChange={handleFiltersChange}
+            onApplyFilters={handleApplyFilters}
+            onClearFilters={handleClearFilters}
+            onAddQuestion={handleAddQuestion}
+            addedQuestionIds={addedQuestionIds}
+            enableExamMode={enableExamMode || isInPersonExam}
+            isInPersonExam={isInPersonExam}
+            loadingInitialQuestions={loadingInitialQuestions}
+            questions={questions}
+            onRemoveAll={handleRemoveAll}
+            onRemoveQuestion={handleRemoveQuestion}
+            onReorder={handleReorder}
+            filtersKey={filtersKey}
+          />
+        ) : (
+          <DesktopLayout
+            apiClient={apiClient}
+            institutionId={institutionId}
+            isDark={isDark}
+            initialFiltersData={initialFiltersData}
+            draftFilters={draftFilters}
+            onFiltersChange={handleFiltersChange}
+            onApplyFilters={handleApplyFilters}
+            onClearFilters={handleClearFilters}
+            onAddQuestion={handleAddQuestion}
+            addedQuestionIds={addedQuestionIds}
+            enableExamMode={enableExamMode || isInPersonExam}
+            isInPersonExam={isInPersonExam}
+            loadingInitialQuestions={loadingInitialQuestions}
+            questions={questions}
+            onRemoveAll={handleRemoveAll}
+            onRemoveQuestion={handleRemoveQuestion}
+            onReorder={handleReorder}
+            filtersKey={filtersKey}
+          />
+        ))}
 
       {/* Save Activity Model Modal */}
       <SaveActivityModelModal

--- a/src/components/ActivityCreate/ActivityCreate.tsx
+++ b/src/components/ActivityCreate/ActivityCreate.tsx
@@ -35,6 +35,11 @@ import type {
 } from './ActivityCreate.types';
 import { ActivityType } from './ActivityCreate.types';
 import type { CreateActivityPayload } from '../../types/sendActivity';
+import type { EssayTheme } from '../../types/essayThemes';
+import { EssayThemePicker } from '../EssayThemePicker/EssayThemePicker';
+import Menu, { MenuContent, MenuItem } from '../Menu/Menu';
+import { ArticleIcon } from '@phosphor-icons/react/dist/csr/Article';
+import { TextAlignLeftIcon } from '@phosphor-icons/react/dist/csr/TextAlignLeft';
 import {
   convertFiltersToBackendFormat,
   generateTitle,
@@ -95,6 +100,7 @@ const CreateActivity = ({
   isInPersonExam = false,
   basePath = '/criar-atividade',
   activityCategory = 'ATIVIDADE',
+  enableEssayTab = false,
 }: {
   apiClient: BaseApiClient;
   institutionId: string;
@@ -113,6 +119,15 @@ const CreateActivity = ({
   basePath?: string;
   /** Activity category: 'ATIVIDADE' or 'PROVA' - sent in draft payloads */
   activityCategory?: 'ATIVIDADE' | 'PROVA';
+  /**
+   * Show the "Redação" tab, where the teacher attaches an essay theme to an
+   * in-person booklet. Only meaningful together with `isInPersonExam`.
+   *
+   * Off by default on purpose: `activity_drafts` cannot store the chosen theme
+   * yet, so with autosave on the teacher would lose the pick on reload. Flip it
+   * once the draft carries `essayThemeId`.
+   */
+  enableEssayTab?: boolean;
 }) => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -180,6 +195,16 @@ const CreateActivity = ({
   const [selectedView, setSelectedView] = useState<'questions' | 'preview'>(
     'questions'
   );
+
+  /**
+   * Builder tab. The essay tab only exists for the in-person booklet, which is
+   * the only activity the backend accepts a theme on.
+   */
+  const showEssayTab = isInPersonExam && enableEssayTab;
+  const [activeTab, setActiveTab] = useState<'questions' | 'essay'>(
+    'questions'
+  );
+  const [essayTheme, setEssayTheme] = useState<EssayTheme | null>(null);
 
   // Estados internos
   const [activity, setActivity] = useState<ActivityData | null>(null);
@@ -1040,7 +1065,8 @@ const CreateActivity = ({
           questions.map((q) => q.id),
           startDateTime,
           finalDateTime,
-          activityCategory
+          activityCategory,
+          essayTheme?.id ?? null
         );
 
         // Create activity/exam
@@ -1100,7 +1126,16 @@ const CreateActivity = ({
         setIsSendingActivity(false);
       }
     },
-    [activity, appliedFilters, questions, apiClient, addToast, activityEndpoint]
+    [
+      activity,
+      appliedFilters,
+      questions,
+      apiClient,
+      addToast,
+      activityEndpoint,
+      activityCategory,
+      essayTheme?.id,
+    ]
   );
 
   const addedQuestionIds = useMemo(
@@ -1134,8 +1169,51 @@ const CreateActivity = ({
         enableExamMode={enableExamMode || isInPersonExam}
       />
 
+      {/* Builder tabs — in-person booklets also carry an essay theme */}
+      {showEssayTab && (
+        <div className="flex-shrink-0 border-b border-border-100 mb-4">
+          {/* The menu2 variant makes both the list and its items `w-full`, so
+              the underline would span half the page. Shrink-wrapping from the
+              outside keeps each tab as wide as its label, while the divider
+              above still runs the full width. */}
+          <div className="w-fit">
+            <Menu
+              defaultValue="questions"
+              value={activeTab}
+              onValueChange={(value) =>
+                setActiveTab(value as 'questions' | 'essay')
+              }
+              variant="menu2"
+              className="bg-transparent shadow-none px-0"
+            >
+              <MenuContent variant="menu2">
+                <MenuItem
+                  value="questions"
+                  variant="menu2"
+                  data-testid="tab-questions"
+                >
+                  <ArticleIcon size={18} aria-hidden />
+                  Questões
+                </MenuItem>
+                <MenuItem value="essay" variant="menu2" data-testid="tab-essay">
+                  <TextAlignLeftIcon size={18} aria-hidden />
+                  Redação
+                </MenuItem>
+              </MenuContent>
+            </Menu>
+          </div>
+        </div>
+      )}
+
       {/* Main Content */}
-      {isSmallScreen ? (
+      {showEssayTab && activeTab === 'essay' ? (
+        <EssayThemePicker
+          apiClient={apiClient}
+          selectedTheme={essayTheme}
+          onSelectTheme={setEssayTheme}
+          onRemoveTheme={() => setEssayTheme(null)}
+        />
+      ) : isSmallScreen ? (
         <SmallScreenLayout
           apiClient={apiClient}
           institutionId={institutionId}

--- a/src/components/ActivityCreate/ActivityCreate.utils.test.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.test.ts
@@ -876,5 +876,50 @@ describe('ActivityCreate.utils', () => {
         expect(payload.isDigital).toBe(expectedIsDigital);
       }
     );
+
+    const buildWithTheme = (
+      subtype: ActivitySubtype,
+      mode: ActivityMode | undefined,
+      essayThemeId: string | null
+    ) =>
+      buildSendActivityPayload(
+        { ...baseFormData, subtype, mode },
+        'subject-1',
+        ['q-1'],
+        '2026-01-01T08:00:00.000Z',
+        '2026-01-02T18:00:00.000Z',
+        'PROVA',
+        essayThemeId
+      );
+
+    it('should send the essay theme on an in-person exam', () => {
+      const payload = buildWithTheme(
+        ActivitySubtype.PROVA,
+        ActivityMode.PRESENCIAL,
+        'theme-1'
+      );
+
+      expect(payload.essayThemeId).toBe('theme-1');
+    });
+
+    it('should omit the essay theme on a digital activity, which the backend rejects', () => {
+      const payload = buildWithTheme(
+        ActivitySubtype.PROVA,
+        ActivityMode.ONLINE,
+        'theme-1'
+      );
+
+      expect(payload).not.toHaveProperty('essayThemeId');
+    });
+
+    it('should omit the essay theme when none was picked', () => {
+      const payload = buildWithTheme(
+        ActivitySubtype.PROVA,
+        ActivityMode.PRESENCIAL,
+        null
+      );
+
+      expect(payload).not.toHaveProperty('essayThemeId');
+    });
   });
 });

--- a/src/components/ActivityCreate/ActivityCreate.utils.ts
+++ b/src/components/ActivityCreate/ActivityCreate.utils.ts
@@ -413,8 +413,14 @@ export function buildSendActivityPayload(
   questionIds: string[],
   startDateTime: string,
   finalDateTime: string | null,
-  activityType?: 'ATIVIDADE' | 'PROVA'
+  activityType?: 'ATIVIDADE' | 'PROVA',
+  essayThemeId?: string | null
 ): CreateActivityPayload {
+  const isDigital =
+    formData.subtype === ActivitySubtype.PROVA
+      ? formData.mode !== ActivityMode.PRESENCIAL
+      : true;
+
   return {
     title: formData.title,
     subjectId,
@@ -425,10 +431,10 @@ export function buildSendActivityPayload(
     startDate: startDateTime,
     finalDate: finalDateTime,
     canRetry: formData.canRetry,
-    isDigital:
-      formData.subtype === ActivitySubtype.PROVA
-        ? formData.mode !== ActivityMode.PRESENCIAL
-        : true,
+    isDigital,
+    // The backend rejects a theme on a digital activity, so it only rides along
+    // on the in-person booklet that actually carries the essay sheet.
+    ...(!isDigital && essayThemeId ? { essayThemeId } : {}),
   };
 }
 

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -2525,35 +2525,18 @@ describe('ActivityDetails', () => {
       mockFetchActivityDetails.mockResolvedValue(mockActivityDataPresencial);
     });
 
-    it('should show "Gabarito recebido em" column instead of "Respondido em"', async () => {
-      render(<ActivityDetails {...defaultProps} />);
+    it.each(['Respondido em', 'Duração', 'Baixar gabarito'])(
+      'should not show "%s" in presencial mode',
+      async (label) => {
+        render(<ActivityDetails {...defaultProps} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Gabarito recebido em')).toBeInTheDocument();
-      });
+        await waitFor(() => {
+          expect(screen.getByText('Gabarito recebido em')).toBeInTheDocument();
+        });
 
-      expect(screen.queryByText('Respondido em')).not.toBeInTheDocument();
-    });
-
-    it('should not show "Duração" column in presencial mode', async () => {
-      render(<ActivityDetails {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText('Gabarito recebido em')).toBeInTheDocument();
-      });
-
-      expect(screen.queryByText('Duração')).not.toBeInTheDocument();
-    });
-
-    it('should drop the per-student "Baixar gabarito" column', async () => {
-      render(<ActivityDetails {...defaultProps} />);
-
-      await waitFor(() => {
-        expect(screen.getByText('Gabarito recebido em')).toBeInTheDocument();
-      });
-
-      expect(screen.queryByText('Baixar gabarito')).not.toBeInTheDocument();
-    });
+        expect(screen.queryByText(label)).not.toBeInTheDocument();
+      }
+    );
 
     it('should show the creation date instead of the academic breakdown', async () => {
       render(<ActivityDetails {...defaultProps} />);

--- a/src/components/ActivityDetails/ActivityDetails.test.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.test.tsx
@@ -1,7 +1,10 @@
 import type { HTMLAttributes, ReactNode, Ref } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { STUDENT_ACTIVITY_STATUS } from '../../types/activityDetails';
+import {
+  PRESENCIAL_DELIVERY_STATUS,
+  STUDENT_ACTIVITY_STATUS,
+} from '../../types/activityDetails';
 import {
   getStatusBadgeConfig,
   formatTimeSpent,
@@ -91,15 +94,6 @@ jest.mock('../TableProvider/TableProvider', () => ({
       return <div data-testid="table-provider">{emptyState.component}</div>;
     }
 
-    // Find column renderers
-    const actionsColumn = headers?.find((h) => h.key === 'actions');
-    const studentNameColumn = headers?.find((h) => h.key === 'studentName');
-    const statusColumn = headers?.find((h) => h.key === 'status');
-    const answeredAtColumn = headers?.find((h) => h.key === 'answeredAt');
-    const timeSpentColumn = headers?.find((h) => h.key === 'timeSpent');
-    const scoreColumn = headers?.find((h) => h.key === 'score');
-    const answerSheetColumn = headers?.find((h) => h.key === 'answerSheet');
-
     return (
       <div data-testid="table-provider">
         {children({
@@ -115,52 +109,17 @@ jest.mock('../TableProvider/TableProvider', () => ({
                 </tr>
               </thead>
               <tbody>
-                {(
-                  data as {
-                    studentName: string;
-                    status: string;
-                    studentId: string;
-                    answeredAt: string | null;
-                    timeSpent: number;
-                    score: number | null;
-                  }[]
-                ).map((item) => (
-                  <tr key={item.studentId}>
-                    <td>
-                      {studentNameColumn?.render
-                        ? studentNameColumn.render(item.studentName, item)
-                        : item.studentName}
-                    </td>
-                    <td>
-                      {statusColumn?.render
-                        ? statusColumn.render(item.status, item)
-                        : item.status}
-                    </td>
-                    <td>
-                      {answeredAtColumn?.render
-                        ? answeredAtColumn.render(item.answeredAt, item)
-                        : null}
-                    </td>
-                    <td>
-                      {timeSpentColumn?.render
-                        ? timeSpentColumn.render(item.timeSpent, item)
-                        : null}
-                    </td>
-                    <td>
-                      {scoreColumn?.render
-                        ? scoreColumn.render(item.score, item)
-                        : null}
-                    </td>
-                    <td>
-                      {answerSheetColumn?.render
-                        ? answerSheetColumn.render(null, item)
-                        : null}
-                    </td>
-                    <td>
-                      {actionsColumn?.render
-                        ? actionsColumn.render(null, item)
-                        : null}
-                    </td>
+                {/* Render every configured column through its own renderer, so
+                    the mock stays faithful as columns come and go. */}
+                {(data as Record<string, unknown>[]).map((item) => (
+                  <tr key={String(item.studentId)}>
+                    {headers?.map((h) => (
+                      <td key={h.key}>
+                        {h.render
+                          ? h.render(item[h.key], item)
+                          : String(item[h.key] ?? '')}
+                      </td>
+                    ))}
                   </tr>
                 ))}
               </tbody>
@@ -396,7 +355,7 @@ jest.mock('../Toast/utils/ToastStore', () => ({
 }));
 
 // Import after mocks
-import { ActivityDetails } from './ActivityDetails';
+import { ActivityDetails, getStatsGridColsClass } from './ActivityDetails';
 import type { ActivityDetailsProps } from './ActivityDetails';
 import { useActivityDetails } from '../../hooks/useActivityDetails';
 import type { BaseApiClient } from '../../types/api';
@@ -2523,6 +2482,7 @@ describe('ActivityDetails', () => {
         title: 'Prova Presencial',
         startDate: '2024-03-01',
         finalDate: '2024-03-10',
+        createdAt: '2024-02-20T10:00:00Z',
         schoolName: 'Escola Teste',
         year: '2024',
         subjectName: 'Matemática',
@@ -2538,6 +2498,8 @@ describe('ActivityDetails', () => {
           timeSpent: 0,
           score: null,
           status: STUDENT_ACTIVITY_STATUS.ANSWER_SHEET_RECEIVED,
+          essayStatus: PRESENCIAL_DELIVERY_STATUS.RECEIVED,
+          essayReceivedAt: '2024-03-05T09:00:00Z',
         },
         {
           studentId: 'student-p2',
@@ -2546,11 +2508,17 @@ describe('ActivityDetails', () => {
           timeSpent: 0,
           score: null,
           status: STUDENT_ACTIVITY_STATUS.AWAITING_ANSWER_SHEET,
+          essayStatus: PRESENCIAL_DELIVERY_STATUS.AWAITING,
+          essayReceivedAt: null,
         },
       ],
       pagination: { total: 2, page: 1, limit: 10, totalPages: 1 },
       generalStats: { averageScore: 0, completionPercentage: 50 },
-      questionStats: { mostCorrect: [], mostIncorrect: [], notAnswered: [] },
+      questionStats: {
+        mostCorrect: [1, 2],
+        mostIncorrect: [3],
+        notAnswered: [],
+      },
     };
 
     beforeEach(() => {
@@ -2577,54 +2545,151 @@ describe('ActivityDetails', () => {
       expect(screen.queryByText('Duração')).not.toBeInTheDocument();
     });
 
-    it('should show "Baixar gabarito" button in presencial mode', async () => {
-      const mockOnDownloadAnswerSheet = jest.fn();
-      render(
-        <ActivityDetails
-          {...defaultProps}
-          onDownloadAnswerSheet={mockOnDownloadAnswerSheet}
-        />
-      );
-
-      await waitFor(() => {
-        const baixarButtons = screen.getAllByText('Baixar gabarito');
-        expect(baixarButtons.length).toBeGreaterThan(0);
-      });
-    });
-
-    it('should call onDownloadAnswerSheet with studentId when "Baixar gabarito" is clicked', async () => {
-      const mockOnDownloadAnswerSheet = jest.fn();
-      render(
-        <ActivityDetails
-          {...defaultProps}
-          onDownloadAnswerSheet={mockOnDownloadAnswerSheet}
-        />
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByText('Baixar gabarito').length).toBeGreaterThan(
-          0
-        );
-      });
-
-      fireEvent.click(screen.getAllByText('Baixar gabarito')[0]);
-
-      expect(mockOnDownloadAnswerSheet).toHaveBeenCalledWith('student-p1');
-    });
-
-    it('should render disabled "Baixar gabarito" button when onDownloadAnswerSheet is not provided', async () => {
+    it('should drop the per-student "Baixar gabarito" column', async () => {
       render(<ActivityDetails {...defaultProps} />);
 
       await waitFor(() => {
-        expect(screen.getAllByText('Baixar gabarito').length).toBeGreaterThan(
-          0
-        );
+        expect(screen.getByText('Gabarito recebido em')).toBeInTheDocument();
       });
 
-      const baixarButtons = screen.getAllByText('Baixar gabarito');
-      baixarButtons.forEach((btn) => {
-        expect(btn.closest('button')).toBeDisabled();
+      expect(screen.queryByText('Baixar gabarito')).not.toBeInTheDocument();
+    });
+
+    it('should show the creation date instead of the academic breakdown', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Criada em/)).toBeInTheDocument();
       });
+
+      expect(screen.queryByText('Escola Teste')).not.toBeInTheDocument();
+      expect(screen.queryByText('9º Ano B')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Prazo final/)).not.toBeInTheDocument();
+    });
+
+    it('should show a single "Baixar prova" action', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Baixar prova')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Ver Atividade')).not.toBeInTheDocument();
+      expect(screen.queryByText('Baixar Atividade')).not.toBeInTheDocument();
+    });
+
+    it('should append the app-provided pages to the printed exam', async () => {
+      const getExamExtraPagesHtml = jest
+        .fn()
+        .mockResolvedValue('<div>folha de redação</div>');
+      render(
+        <ActivityDetails
+          {...defaultProps}
+          getExamExtraPagesHtml={getExamExtraPagesHtml}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Baixar prova')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Baixar prova'));
+
+      // The lib prints the questions; these pages ride along in the same
+      // document, which is what makes the download the full printable package.
+      expect(useQuestionsPdfPrint).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        undefined,
+        getExamExtraPagesHtml
+      );
+    });
+
+    it('should not append extra pages outside presencial mode', async () => {
+      const getExamExtraPagesHtml = jest.fn().mockResolvedValue('<div/>');
+      mockFetchActivityDetails.mockResolvedValue(mockActivityData);
+
+      render(
+        <ActivityDetails
+          {...defaultProps}
+          getExamExtraPagesHtml={getExamExtraPagesHtml}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Baixar Atividade')).toBeInTheDocument();
+      });
+
+      expect(useQuestionsPdfPrint).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        undefined,
+        undefined
+      );
+    });
+
+    it('should show the essay delivery columns', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Status redação')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Redação recebida em')).toBeInTheDocument();
+      expect(screen.getByText('Status gabarito')).toBeInTheDocument();
+      expect(screen.getByText('Estudante')).toBeInTheDocument();
+    });
+
+    it('should label delivery badges as Aguardando / Recebido', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Status redação')).toBeInTheDocument();
+      });
+
+      // One student delivered both sheets, the other delivered neither.
+      expect(screen.getAllByText('RECEBIDO')).toHaveLength(2);
+      expect(screen.getAllByText('AGUARDANDO')).toHaveLength(2);
+    });
+
+    it('should show only the three question cards', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Resultados da atividade')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Questões com mais acertos')).toBeInTheDocument();
+      expect(screen.getByText('Questões com mais erros')).toBeInTheDocument();
+      expect(screen.getByText('Questões não respondidas')).toBeInTheDocument();
+      expect(screen.queryByText('Concluído')).not.toBeInTheDocument();
+      expect(screen.queryByText('Média da Turma')).not.toBeInTheDocument();
+    });
+
+    it('should title the students table as "Resultados"', async () => {
+      render(<ActivityDetails {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Resultados')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('getStatsGridColsClass', () => {
+    it('uses five columns on desktop outside presencial mode', () => {
+      expect(getStatsGridColsClass(false, false)).toBe('grid-cols-5');
+    });
+
+    it('uses three columns on desktop in presencial mode', () => {
+      expect(getStatsGridColsClass(false, true)).toBe('grid-cols-3');
+    });
+
+    it('collapses to two columns on mobile outside presencial mode', () => {
+      expect(getStatsGridColsClass(true, false)).toBe('grid-cols-2');
+    });
+
+    it('collapses to a single column on mobile in presencial mode', () => {
+      expect(getStatsGridColsClass(true, true)).toBe('grid-cols-1');
     });
   });
 });

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -191,10 +191,17 @@ const createTableColumns = (
       render: (value: unknown) => {
         const status = value as StudentActivityStatus;
         if (isPresencial) {
+          // Only the states that imply a sheet in hand count as received —
+          // NAO_ENTREGUE must not be dressed up as delivered.
+          const received =
+            status === STUDENT_ACTIVITY_STATUS.ANSWER_SHEET_RECEIVED ||
+            status === STUDENT_ACTIVITY_STATUS.AGUARDANDO_CORRECAO ||
+            status === STUDENT_ACTIVITY_STATUS.CONCLUIDO;
+
           return renderDeliveryBadge(
-            status === STUDENT_ACTIVITY_STATUS.AWAITING_ANSWER_SHEET
-              ? PRESENCIAL_DELIVERY_STATUS.AWAITING
-              : PRESENCIAL_DELIVERY_STATUS.RECEIVED
+            received
+              ? PRESENCIAL_DELIVERY_STATUS.RECEIVED
+              : PRESENCIAL_DELIVERY_STATUS.AWAITING
           );
         }
         const config = getStatusBadgeConfig(status);

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -160,7 +160,38 @@ const createTableColumns = (
   onCorrectActivity: (studentId: string) => void,
   isPresencial: boolean
 ): ColumnConfig<ActivityStudentTableItem>[] => {
-  const columns: ColumnConfig<ActivityStudentTableItem>[] = [
+  /** Delivery of the essay sheet, which only the printed booklet carries. */
+  const essayColumns: ColumnConfig<ActivityStudentTableItem>[] = [
+    {
+      key: 'essayStatus',
+      label: 'Status redação',
+      sortable: false,
+      render: renderDeliveryBadge,
+    },
+    {
+      key: 'essayReceivedAt',
+      label: 'Redação recebida em',
+      sortable: true,
+      render: renderDateCell,
+    },
+  ];
+
+  /** Time spent answering, meaningless for a booklet done on paper. */
+  const timeSpentColumn: ColumnConfig<ActivityStudentTableItem> = {
+    key: 'timeSpent',
+    label: 'Duração',
+    sortable: false,
+    render: (value: unknown) =>
+      Number(value) > 0 ? (
+        <Text className="text-sm text-text-700">
+          {formatTimeSpent(Number(value))}
+        </Text>
+      ) : (
+        <Text className="text-sm text-text-400">-</Text>
+      ),
+  };
+
+  return [
     {
       key: 'studentName',
       label: isPresencial ? 'Estudante' : 'Aluno',
@@ -220,119 +251,80 @@ const createTableColumns = (
       sortable: true,
       render: renderDateCell,
     },
-  ];
-
-  // The printed exam carries an essay sheet, delivered independently of the
-  // answer sheet — hence its own status and date.
-  if (isPresencial) {
-    columns.push(
-      {
-        key: 'essayStatus',
-        label: 'Status redação',
-        sortable: false,
-        render: renderDeliveryBadge,
-      },
-      {
-        key: 'essayReceivedAt',
-        label: 'Redação recebida em',
-        sortable: true,
-        render: renderDateCell,
-      }
-    );
-  }
-
-  // "Duração" column is hidden in presencial mode
-  if (!isPresencial) {
-    columns.push({
-      key: 'timeSpent',
-      label: 'Duração',
-      sortable: false,
+    ...(isPresencial ? essayColumns : [timeSpentColumn]),
+    {
+      key: 'score',
+      label: 'Nota',
+      sortable: true,
       render: (value: unknown) =>
-        Number(value) > 0 ? (
-          <Text className="text-sm text-text-700">
-            {formatTimeSpent(Number(value))}
-          </Text>
-        ) : (
+        value === null ? (
           <Text className="text-sm text-text-400">-</Text>
+        ) : (
+          <Text className="text-sm font-semibold text-text-950">
+            {Number(value).toFixed(1)}
+          </Text>
         ),
-    });
-  }
-
-  columns.push({
-    key: 'score',
-    label: 'Nota',
-    sortable: true,
-    render: (value: unknown) =>
-      value === null ? (
-        <Text className="text-sm text-text-400">-</Text>
-      ) : (
-        <Text className="text-sm font-semibold text-text-950">
-          {Number(value).toFixed(1)}
-        </Text>
-      ),
-  });
-
-  columns.push({
-    key: 'actions',
-    label: 'Resultado',
-    sortable: false,
-    render: (_value: unknown, row: ActivityStudentTableItem) => {
-      // Presencial mode: show "Ver respostas" — disabled until answer sheet is received
-      if (isPresencial) {
-        const hasResponse =
-          row.status === STUDENT_ACTIVITY_STATUS.ANSWER_SHEET_RECEIVED ||
-          row.status === STUDENT_ACTIVITY_STATUS.AGUARDANDO_CORRECAO ||
-          row.status === STUDENT_ACTIVITY_STATUS.CONCLUIDO;
-        return (
-          <Button
-            variant="link"
-            size="small"
-            onClick={
-              hasResponse ? () => onCorrectActivity(row.studentId) : undefined
-            }
-            disabled={!hasResponse}
-            className="text-xs"
-          >
-            Ver respostas
-          </Button>
-        );
-      }
-
-      // Normal mode
-      if (row.status === STUDENT_ACTIVITY_STATUS.AGUARDANDO_CORRECAO) {
-        return (
-          <Button
-            variant="outline"
-            size="small"
-            onClick={() => onCorrectActivity(row.studentId)}
-            className="text-xs"
-          >
-            Corrigir atividade
-          </Button>
-        );
-      }
-
-      if (
-        row.status === STUDENT_ACTIVITY_STATUS.CONCLUIDO ||
-        row.status === STUDENT_ACTIVITY_STATUS.NAO_ENTREGUE
-      ) {
-        return (
-          <Button
-            variant="link"
-            size="small"
-            onClick={() => onCorrectActivity(row.studentId)}
-            className="text-xs"
-          >
-            Ver detalhes
-          </Button>
-        );
-      }
-
-      return null;
     },
-  });
+    {
+      key: 'actions',
+      label: 'Resultado',
+      sortable: false,
+      render: (_value: unknown, row: ActivityStudentTableItem) => {
+        // Presencial mode: show "Ver respostas" — disabled until answer sheet is received
+        if (isPresencial) {
+          const hasResponse =
+            row.status === STUDENT_ACTIVITY_STATUS.ANSWER_SHEET_RECEIVED ||
+            row.status === STUDENT_ACTIVITY_STATUS.AGUARDANDO_CORRECAO ||
+            row.status === STUDENT_ACTIVITY_STATUS.CONCLUIDO;
+          return (
+            <Button
+              variant="link"
+              size="small"
+              onClick={
+                hasResponse ? () => onCorrectActivity(row.studentId) : undefined
+              }
+              disabled={!hasResponse}
+              className="text-xs"
+            >
+              Ver respostas
+            </Button>
+          );
+        }
 
-  return columns;
+        // Normal mode
+        if (row.status === STUDENT_ACTIVITY_STATUS.AGUARDANDO_CORRECAO) {
+          return (
+            <Button
+              variant="outline"
+              size="small"
+              onClick={() => onCorrectActivity(row.studentId)}
+              className="text-xs"
+            >
+              Corrigir atividade
+            </Button>
+          );
+        }
+
+        if (
+          row.status === STUDENT_ACTIVITY_STATUS.CONCLUIDO ||
+          row.status === STUDENT_ACTIVITY_STATUS.NAO_ENTREGUE
+        ) {
+          return (
+            <Button
+              variant="link"
+              size="small"
+              onClick={() => onCorrectActivity(row.studentId)}
+              className="text-xs"
+            >
+              Ver detalhes
+            </Button>
+          );
+        }
+
+        return null;
+      },
+    },
+  ];
 };
 
 /**

--- a/src/components/ActivityDetails/ActivityDetails.tsx
+++ b/src/components/ActivityDetails/ActivityDetails.tsx
@@ -30,6 +30,7 @@ import type {
 } from '../../utils/studentActivityCorrection';
 import { convertApiResponseToCorrectionData } from '../../utils/studentActivityCorrection';
 import {
+  PRESENCIAL_DELIVERY_STATUS,
   STUDENT_ACTIVITY_STATUS,
   type ActivityDetailsData,
   type ActivityStudentTableItem,
@@ -70,32 +71,99 @@ export interface ActivityDetailsProps {
   /** Function to map subject name to SubjectEnum */
   mapSubjectNameToEnum?: (subjectName: string) => SubjectEnum | null;
   /**
-   * Callback for downloading the answer sheet for a student.
-   * Presencial mode is determined by `activity.isDigital === false && activity.subtype === ActivitySubtype.PROVA`,
-   * not by the presence of this callback. When the activity is presencial:
-   * - Hides the "Duração" column
-   * - Renames "Respondido em" → "Gabarito recebido em"
-   * - Shows a "Gabarito" column (before "Resultado"); button is disabled when callback is absent
+   * Extra pages appended to the printed exam, resolved when "Baixar prova" is
+   * clicked. The lib renders the questions; the app supplies whatever else goes
+   * in the same document — for an in-person exam, the essay sheet and every
+   * student's answer sheet, which need app-side data (QR codes, institution
+   * domain) the lib does not have.
+   *
+   * Only used in presencial mode, which is determined by
+   * `activity.isDigital === false && activity.subtype === ActivitySubtype.PROVA`.
+   * In that mode the screen also:
+   * - drops the "Duração" column and the activity's academic metadata;
+   * - renames "Respondido em" → "Gabarito recebido em";
+   * - adds "Status redação" / "Redação recebida em";
+   * - shows only the three question-statistics cards.
    */
-  onDownloadAnswerSheet?: (studentId: string) => void;
+  getExamExtraPagesHtml?: () => Promise<string>;
 }
+
+/**
+ * Render a delivery-state badge for a physical sheet (answers or essay).
+ *
+ * @param status - Delivery state, or null/undefined when unknown
+ * @returns Badge element, or a dash when there is nothing to show
+ */
+const renderDeliveryBadge = (status: unknown) => {
+  if (
+    status !== PRESENCIAL_DELIVERY_STATUS.AWAITING &&
+    status !== PRESENCIAL_DELIVERY_STATUS.RECEIVED
+  ) {
+    return <Text className="text-sm text-text-400">-</Text>;
+  }
+
+  const received = status === PRESENCIAL_DELIVERY_STATUS.RECEIVED;
+  return (
+    <Badge
+      className={
+        received
+          ? 'bg-emerald-50 text-emerald-800 text-xs px-2 py-1'
+          : 'bg-sky-50 text-sky-700 text-xs px-2 py-1'
+      }
+    >
+      {status}
+    </Badge>
+  );
+};
+
+/**
+ * Render a date cell, falling back to a dash when the date is absent.
+ *
+ * @param value - ISO date string, or anything else when absent
+ * @returns Text element with the Brazilian-formatted date
+ */
+const renderDateCell = (value: unknown) => {
+  if (!value || typeof value !== 'string') {
+    return <Text className="text-sm text-text-400">-</Text>;
+  }
+  return (
+    <Text className="text-sm text-text-700">
+      {formatDateToBrazilian(value)}
+    </Text>
+  );
+};
+
+/**
+ * Tailwind column count for the statistics grid.
+ *
+ * @param isMobile - Whether the viewport is mobile
+ * @param isPresencial - Whether the activity is an in-person exam (3 cards)
+ * @returns Tailwind grid-cols class
+ */
+export const getStatsGridColsClass = (
+  isMobile: boolean,
+  isPresencial: boolean
+): string => {
+  if (isMobile) {
+    return isPresencial ? 'grid-cols-1' : 'grid-cols-2';
+  }
+  return isPresencial ? 'grid-cols-3' : 'grid-cols-5';
+};
 
 /**
  * Create table columns configuration
  * @param onCorrectActivity - Callback for correction action
  * @param isPresencial - Whether the activity is in presencial mode (drives column visibility)
- * @param onDownloadAnswerSheet - Optional callback for answer sheet download button in presencial mode
  * @returns Column configuration array
  */
 const createTableColumns = (
   onCorrectActivity: (studentId: string) => void,
-  isPresencial: boolean,
-  onDownloadAnswerSheet?: (studentId: string) => void
+  isPresencial: boolean
 ): ColumnConfig<ActivityStudentTableItem>[] => {
   const columns: ColumnConfig<ActivityStudentTableItem>[] = [
     {
       key: 'studentName',
-      label: 'Aluno',
+      label: isPresencial ? 'Estudante' : 'Aluno',
       sortable: true,
       className: 'max-w-[220px]',
       render: (value: unknown) => {
@@ -116,10 +184,19 @@ const createTableColumns = (
     },
     {
       key: 'status',
-      label: 'Status',
+      // The column header already says "gabarito", so the badge only carries
+      // the delivery state — matching the essay column right next to it.
+      label: isPresencial ? 'Status gabarito' : 'Status',
       sortable: false,
       render: (value: unknown) => {
         const status = value as StudentActivityStatus;
+        if (isPresencial) {
+          return renderDeliveryBadge(
+            status === STUDENT_ACTIVITY_STATUS.AWAITING_ANSWER_SHEET
+              ? PRESENCIAL_DELIVERY_STATUS.AWAITING
+              : PRESENCIAL_DELIVERY_STATUS.RECEIVED
+          );
+        }
         const config = getStatusBadgeConfig(status);
         return (
           <Badge
@@ -134,18 +211,28 @@ const createTableColumns = (
       key: 'answeredAt',
       label: isPresencial ? 'Gabarito recebido em' : 'Respondido em',
       sortable: true,
-      render: (value: unknown) => {
-        if (!value || typeof value !== 'string') {
-          return <Text className="text-sm text-text-400">-</Text>;
-        }
-        return (
-          <Text className="text-sm text-text-700">
-            {formatDateToBrazilian(value)}
-          </Text>
-        );
-      },
+      render: renderDateCell,
     },
   ];
+
+  // The printed exam carries an essay sheet, delivered independently of the
+  // answer sheet — hence its own status and date.
+  if (isPresencial) {
+    columns.push(
+      {
+        key: 'essayStatus',
+        label: 'Status redação',
+        sortable: false,
+        render: renderDeliveryBadge,
+      },
+      {
+        key: 'essayReceivedAt',
+        label: 'Redação recebida em',
+        sortable: true,
+        render: renderDateCell,
+      }
+    );
+  }
 
   // "Duração" column is hidden in presencial mode
   if (!isPresencial) {
@@ -177,26 +264,6 @@ const createTableColumns = (
         </Text>
       ),
   });
-
-  // "Gabarito" column is always shown in presencial mode; button disabled when callback is absent
-  if (isPresencial) {
-    columns.push({
-      key: 'answerSheet',
-      label: 'Gabarito',
-      sortable: false,
-      render: (_value: unknown, row: ActivityStudentTableItem) => (
-        <Button
-          variant="outline"
-          size="small"
-          onClick={() => onDownloadAnswerSheet?.(row.studentId)}
-          disabled={!onDownloadAnswerSheet}
-          className="text-xs"
-        >
-          Baixar gabarito
-        </Button>
-      ),
-    });
-  }
 
   columns.push({
     key: 'actions',
@@ -400,10 +467,9 @@ export const ActivityDetails = ({
   onBack,
   emptyStateImage,
   mapSubjectNameToEnum,
-  onDownloadAnswerSheet,
+  getExamExtraPagesHtml,
 }: ActivityDetailsProps) => {
   const { isMobile } = useMobile();
-  const statsGridColsClass = isMobile ? 'grid-cols-2' : 'grid-cols-5';
 
   // Pagination and sorting state
   const [page, setPage] = useState(1);
@@ -637,6 +703,12 @@ export const ActivityDetails = ({
     data?.activity?.subtype === ActivitySubtype.PROVA;
 
   /**
+   * Statistics grid: five cards normally, only the three question cards in
+   * presencial mode.
+   */
+  const statsGridColsClass = getStatsGridColsClass(isMobile, isPresencial);
+
+  /**
    * Convert student data to table format.
    * Presencial status remapping happens here so all consumers (modal logic,
    * view-only check, column render) see a consistent value.
@@ -661,6 +733,8 @@ export const ActivityDetails = ({
         answeredAt: student.answeredAt,
         timeSpent: student.timeSpent,
         score: student.score,
+        essayStatus: student.essayStatus,
+        essayReceivedAt: student.essayReceivedAt,
       };
     });
   }, [data?.students, isPresencial]);
@@ -669,13 +743,8 @@ export const ActivityDetails = ({
    * Table columns configuration
    */
   const columns = useMemo(
-    () =>
-      createTableColumns(
-        handleCorrectActivity,
-        isPresencial,
-        onDownloadAnswerSheet
-      ),
-    [handleCorrectActivity, isPresencial, onDownloadAnswerSheet]
+    () => createTableColumns(handleCorrectActivity, isPresencial),
+    [handleCorrectActivity, isPresencial]
   );
 
   /**
@@ -706,7 +775,12 @@ export const ActivityDetails = ({
   /**
    * Use PDF print hook
    */
-  const { contentRef, handlePrint } = useQuestionsPdfPrint(orderedQuestions);
+  const { contentRef, handlePrint } = useQuestionsPdfPrint(
+    orderedQuestions,
+    undefined,
+    undefined,
+    isPresencial ? getExamExtraPagesHtml : undefined
+  );
 
   /**
    * Extract questions from API response
@@ -1051,8 +1125,15 @@ export const ActivityDetails = ({
 
   return (
     <div className="flex flex-col w-full h-auto relative justify-center items-center mb-5 overflow-hidden">
-      {/* Main container */}
-      <div className="flex flex-col w-full h-full max-w-[1150px] mx-auto z-10 lg:px-0 px-4 pt-4 gap-4">
+      {/* Main container. Presencial gets the wider canvas the listing pages
+          already use: its results table carries two extra columns and the
+          "Ver respostas" action would otherwise start off-screen. */}
+      <div
+        className={cn(
+          'flex flex-col w-full h-full mx-auto z-10 lg:px-0 px-4 pt-4 gap-4',
+          isPresencial ? 'max-w-[1350px]' : 'max-w-[1150px]'
+        )}
+      >
         {/* Breadcrumb */}
         <div className="flex items-center gap-2 py-4">
           <button
@@ -1067,8 +1148,36 @@ export const ActivityDetails = ({
           </Text>
         </div>
 
+        {/* Activity header card — presencial: title, creation date and the
+            printable package download. There is no school/class/subject line
+            because an in-person exam is not tied to that breakdown. */}
+        {data.activity && isPresencial && (
+          <div className="bg-background rounded-xl p-4 flex justify-between items-center gap-4">
+            <div className="flex flex-col gap-1">
+              <Text className="text-2xl font-bold text-text-950">
+                {data.activity.title}
+              </Text>
+              <Text className="text-sm text-text-500">
+                Criada em{' '}
+                {data.activity.createdAt
+                  ? formatActivityDateToBrazilian(data.activity.createdAt)
+                  : '00/00/0000'}
+              </Text>
+            </div>
+            <Button
+              size="small"
+              onClick={handleDownloadPdf}
+              disabled={isLoadingQuestions}
+              iconLeft={<DownloadSimpleIcon size={16} />}
+              className="bg-primary-950 text-text gap-2 shrink-0"
+            >
+              Baixar prova
+            </Button>
+          </div>
+        )}
+
         {/* Activity header card */}
-        {data.activity && (
+        {data.activity && !isPresencial && (
           <div className="bg-background rounded-xl p-4 flex flex-col gap-2">
             <div className="flex justify-between items-start">
               <div className="flex flex-col gap-2">
@@ -1163,54 +1272,69 @@ export const ActivityDetails = ({
           </div>
         )}
 
+        {/* Section title, presencial only: the cards below are about the exam
+            as a whole, not about any single student. */}
+        {isPresencial && (
+          <Text className="text-lg font-bold text-text-950">
+            Resultados da atividade
+          </Text>
+        )}
+
         {/* Statistics cards */}
         <div className={cn('grid gap-5', statsGridColsClass)}>
-          {/* Completion percentage */}
-          <div className="border border-border-50 rounded-xl py-4 px-0 flex flex-col items-center justify-center gap-2 bg-primary-50">
-            <div className="relative w-[90px] h-[90px]">
-              <svg className="w-full h-full transform -rotate-90">
-                <circle
-                  cx="45"
-                  cy="45"
-                  r="40"
-                  stroke="var(--color-primary-100)"
-                  strokeWidth="8"
-                  fill="none"
-                />
-                <circle
-                  cx="45"
-                  cy="45"
-                  r="40"
-                  stroke="var(--color-primary-700)"
-                  strokeWidth="8"
-                  fill="none"
-                  strokeDasharray={`${(data.generalStats.completionPercentage / 100) * 251.2} 251.2`}
-                  strokeLinecap="round"
-                />
-              </svg>
-              <div className="absolute inset-0 flex flex-col items-center justify-center">
-                <Text className="text-xl font-medium text-primary-600">
-                  {Math.round(data.generalStats.completionPercentage)}%
+          {/* Completion percentage and average score are dropped in presencial
+              mode: the exam is graded off the scanned sheets, so what the
+              teacher acts on is the per-question breakdown below. */}
+          {!isPresencial && (
+            <>
+              {/* Completion percentage */}
+              <div className="border border-border-50 rounded-xl py-4 px-0 flex flex-col items-center justify-center gap-2 bg-primary-50">
+                <div className="relative w-[90px] h-[90px]">
+                  <svg className="w-full h-full transform -rotate-90">
+                    <circle
+                      cx="45"
+                      cy="45"
+                      r="40"
+                      stroke="var(--color-primary-100)"
+                      strokeWidth="8"
+                      fill="none"
+                    />
+                    <circle
+                      cx="45"
+                      cy="45"
+                      r="40"
+                      stroke="var(--color-primary-700)"
+                      strokeWidth="8"
+                      fill="none"
+                      strokeDasharray={`${(data.generalStats.completionPercentage / 100) * 251.2} 251.2`}
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  <div className="absolute inset-0 flex flex-col items-center justify-center">
+                    <Text className="text-xl font-medium text-primary-600">
+                      {Math.round(data.generalStats.completionPercentage)}%
+                    </Text>
+                    <Text className="text-2xs font-bold text-text-600 uppercase">
+                      Concluído
+                    </Text>
+                  </div>
+                </div>
+              </div>
+
+              {/* Average score */}
+              <div className="border border-border-50 rounded-xl py-4 px-3 flex flex-col items-center justify-center gap-1 bg-warning-background">
+                <div className="w-[30px] h-[30px] rounded-2xl flex items-center justify-center bg-warning-300">
+                  <StarIcon size={16} className="text-white" weight="regular" />
+                </div>
+                <Text className="text-2xs font-bold uppercase text-center text-warning-600">
+                  {getAverageScoreLabel(data.pagination.total)}
                 </Text>
-                <Text className="text-2xs font-bold text-text-600 uppercase">
-                  Concluído
+                <Text className="text-xl font-bold text-warning-600">
+                  {data.generalStats.averageScore.toFixed(1)}
                 </Text>
               </div>
-            </div>
-          </div>
-
-          {/* Average score */}
-          <div className="border border-border-50 rounded-xl py-4 px-3 flex flex-col items-center justify-center gap-1 bg-warning-background">
-            <div className="w-[30px] h-[30px] rounded-2xl flex items-center justify-center bg-warning-300">
-              <StarIcon size={16} className="text-white" weight="regular" />
-            </div>
-            <Text className="text-2xs font-bold uppercase text-center text-warning-600">
-              {getAverageScoreLabel(data.pagination.total)}
-            </Text>
-            <Text className="text-xl font-bold text-warning-600">
-              {data.generalStats.averageScore.toFixed(1)}
-            </Text>
-          </div>
+            </>
+          )}
 
           {/* Most correct questions */}
           <div className="border border-border-50 rounded-xl py-2 px-3 flex flex-col items-center justify-center gap-1 bg-success-200">
@@ -1270,6 +1394,12 @@ export const ActivityDetails = ({
             />
             <Text className="text-error-700 text-sm">{correctionError}</Text>
           </div>
+        )}
+
+        {/* Section title, presencial only: separates the per-student results
+            from the exam-wide cards above. */}
+        {isPresencial && (
+          <Text className="text-lg font-bold text-text-950">Resultados</Text>
         )}
 
         {/* Students table */}

--- a/src/components/ActivityPageLayout/activitiesTableConfig.tsx
+++ b/src/components/ActivityPageLayout/activitiesTableConfig.tsx
@@ -29,6 +29,37 @@ export const getActivityStatusBadgeAction = (
 };
 
 /**
+ * Render the activity status as a badge.
+ *
+ * An unrecognised status keeps its own text and falls back to the neutral
+ * action, so an API value this build does not know about is never dressed up as
+ * an active activity.
+ *
+ * @param value - Raw status coming from the API
+ * @returns Badge element
+ */
+export const renderActivityStatusBadge = (value: unknown) => {
+  const status = typeof value === 'string' ? value : '';
+  const isKnown = Object.values(ActivityDisplayStatus).includes(
+    value as ActivityDisplayStatus
+  );
+
+  return (
+    <Badge
+      variant="solid"
+      action={
+        isKnown
+          ? getActivityStatusBadgeAction(value as ActivityDisplayStatus)
+          : ActivityBadgeActionType.INFO
+      }
+      size="small"
+    >
+      {status}
+    </Badge>
+  );
+};
+
+/**
  * Column configuration for activities table
  *
  * Columns:
@@ -94,26 +125,7 @@ export const activitiesTableColumns: ColumnConfig<ActivityTableItem>[] = [
     key: 'status',
     label: 'Status',
     sortable: true,
-    render: (value: unknown) => {
-      const status = typeof value === 'string' ? value : '';
-      // Validate status is a valid ActivityDisplayStatus enum value
-      const validStatuses = Object.values(ActivityDisplayStatus);
-      const validatedStatus = validStatuses.includes(
-        value as ActivityDisplayStatus
-      )
-        ? (value as ActivityDisplayStatus)
-        : ActivityDisplayStatus.ATIVA; // Default fallback
-
-      return (
-        <Badge
-          variant="solid"
-          action={getActivityStatusBadgeAction(validatedStatus)}
-          size="small"
-        >
-          {status}
-        </Badge>
-      );
-    },
+    render: renderActivityStatusBadge,
   },
   {
     key: 'completionPercentage',

--- a/src/components/ActivityPageLayout/presencialActivitiesTableConfig.test.tsx
+++ b/src/components/ActivityPageLayout/presencialActivitiesTableConfig.test.tsx
@@ -42,15 +42,18 @@ describe('presencialActivitiesTableConfig', () => {
       ).toBeInTheDocument();
     });
 
-    it('should fall back to ATIVA when the status is not a known value', () => {
+    it('should keep an unknown status neutral instead of styling it as active', () => {
       const statusColumn = presencialActivitiesTableColumns[1];
 
       const { container } = render(
         <>{statusColumn.render?.('SOMETHING_ELSE', row, 0)}</>
       );
 
-      // Unknown values still render, but are styled as ATIVA.
       expect(container).toHaveTextContent('SOMETHING_ELSE');
+      // Neutral (info) styling, not the warning used by ATIVA.
+      expect(container.querySelector('div')?.className).not.toContain(
+        'warning'
+      );
     });
 
     it('should render an empty string when the status is not a string', () => {

--- a/src/components/ActivityPageLayout/presencialActivitiesTableConfig.test.tsx
+++ b/src/components/ActivityPageLayout/presencialActivitiesTableConfig.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { presencialActivitiesTableColumns } from './presencialActivitiesTableConfig';
+import { ActivityDisplayStatus } from '../../types/activitiesHistory';
+import type { ActivityTableItem } from '../../types/activitiesHistory';
+
+describe('presencialActivitiesTableConfig', () => {
+  const row = {} as ActivityTableItem;
+
+  describe('presencialActivitiesTableColumns', () => {
+    it('should expose only title, status and createdAt', () => {
+      expect(
+        presencialActivitiesTableColumns.map((column) => column.key)
+      ).toEqual(['title', 'status', 'createdAt']);
+    });
+
+    it('should not carry the academic breakdown columns', () => {
+      const keys = presencialActivitiesTableColumns.map((column) => column.key);
+
+      expect(keys).not.toContain('school');
+      expect(keys).not.toContain('year');
+      expect(keys).not.toContain('subject');
+      expect(keys).not.toContain('class');
+      expect(keys).not.toContain('completionPercentage');
+    });
+
+    it('should label the createdAt column as "Criada em"', () => {
+      const createdAtColumn = presencialActivitiesTableColumns[2];
+
+      expect(createdAtColumn.label).toBe('Criada em');
+      expect(createdAtColumn.sortable).toBe(true);
+    });
+
+    it('should render the status as a badge', () => {
+      const statusColumn = presencialActivitiesTableColumns[1];
+
+      render(
+        <>{statusColumn.render?.(ActivityDisplayStatus.VENCIDA, row, 0)}</>
+      );
+
+      expect(
+        screen.getByText(ActivityDisplayStatus.VENCIDA)
+      ).toBeInTheDocument();
+    });
+
+    it('should fall back to ATIVA when the status is not a known value', () => {
+      const statusColumn = presencialActivitiesTableColumns[1];
+
+      const { container } = render(
+        <>{statusColumn.render?.('SOMETHING_ELSE', row, 0)}</>
+      );
+
+      // Unknown values still render, but are styled as ATIVA.
+      expect(container).toHaveTextContent('SOMETHING_ELSE');
+    });
+
+    it('should render an empty string when the status is not a string', () => {
+      const statusColumn = presencialActivitiesTableColumns[1];
+
+      const { container } = render(<>{statusColumn.render?.(null, row, 0)}</>);
+
+      expect(container).toHaveTextContent('');
+    });
+
+    it('should render the title through the text cell renderer', () => {
+      const titleColumn = presencialActivitiesTableColumns[0];
+
+      render(<>{titleColumn.render?.('Prova de História', row, 0)}</>);
+
+      expect(screen.getByText('Prova de História')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ActivityPageLayout/presencialActivitiesTableConfig.tsx
+++ b/src/components/ActivityPageLayout/presencialActivitiesTableConfig.tsx
@@ -1,9 +1,7 @@
-import Badge from '../Badge/Badge';
 import { renderTextCell } from '../../utils/renderTextCell';
 import type { ColumnConfig } from '../TableProvider/TableProvider';
 import type { ActivityTableItem } from '../../types/activitiesHistory';
-import { ActivityDisplayStatus } from '../../types/activitiesHistory';
-import { getActivityStatusBadgeAction } from './activitiesTableConfig';
+import { renderActivityStatusBadge } from './activitiesTableConfig';
 
 /**
  * Column configuration for the in-person (presencial) activities table.
@@ -32,25 +30,7 @@ export const presencialActivitiesTableColumns: ColumnConfig<ActivityTableItem>[]
       key: 'status',
       label: 'Status',
       sortable: true,
-      render: (value: unknown) => {
-        const status = typeof value === 'string' ? value : '';
-        const validStatuses = Object.values(ActivityDisplayStatus);
-        const validatedStatus = validStatuses.includes(
-          value as ActivityDisplayStatus
-        )
-          ? (value as ActivityDisplayStatus)
-          : ActivityDisplayStatus.ATIVA; // Default fallback
-
-        return (
-          <Badge
-            variant="solid"
-            action={getActivityStatusBadgeAction(validatedStatus)}
-            size="small"
-          >
-            {status}
-          </Badge>
-        );
-      },
+      render: renderActivityStatusBadge,
     },
     {
       key: 'createdAt',

--- a/src/components/ActivityPageLayout/presencialActivitiesTableConfig.tsx
+++ b/src/components/ActivityPageLayout/presencialActivitiesTableConfig.tsx
@@ -1,0 +1,60 @@
+import Badge from '../Badge/Badge';
+import { renderTextCell } from '../../utils/renderTextCell';
+import type { ColumnConfig } from '../TableProvider/TableProvider';
+import type { ActivityTableItem } from '../../types/activitiesHistory';
+import { ActivityDisplayStatus } from '../../types/activitiesHistory';
+import { getActivityStatusBadgeAction } from './activitiesTableConfig';
+
+/**
+ * Column configuration for the in-person (presencial) activities table.
+ *
+ * Deliberately leaner than `activitiesTableColumns`: a presencial activity is
+ * not tied to the school/class/subject breakdown the regular listing filters
+ * by, so only identity, state and creation date are shown.
+ *
+ * Columns:
+ * - title: Título
+ * - status: Status (Ativa, Vencida, Concluída)
+ * - createdAt: Criada em
+ *
+ * The owner-only edit/delete actions are appended by UnifiedHistoryPage.
+ */
+export const presencialActivitiesTableColumns: ColumnConfig<ActivityTableItem>[] =
+  [
+    {
+      key: 'title',
+      label: 'Título',
+      sortable: true,
+      className: 'max-w-[420px]',
+      render: renderTextCell,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (value: unknown) => {
+        const status = typeof value === 'string' ? value : '';
+        const validStatuses = Object.values(ActivityDisplayStatus);
+        const validatedStatus = validStatuses.includes(
+          value as ActivityDisplayStatus
+        )
+          ? (value as ActivityDisplayStatus)
+          : ActivityDisplayStatus.ATIVA; // Default fallback
+
+        return (
+          <Badge
+            variant="solid"
+            action={getActivityStatusBadgeAction(validatedStatus)}
+            size="small"
+          >
+            {status}
+          </Badge>
+        );
+      },
+    },
+    {
+      key: 'createdAt',
+      label: 'Criada em',
+      sortable: true,
+    },
+  ];

--- a/src/components/EssayThemePicker/EssayThemePicker.test.tsx
+++ b/src/components/EssayThemePicker/EssayThemePicker.test.tsx
@@ -1,0 +1,240 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EssayThemePicker } from './EssayThemePicker';
+import type { BaseApiClient } from '../../types/api';
+import type { EssayTheme } from '../../types/essayThemes';
+
+const theme = (overrides: Partial<EssayTheme> = {}): EssayTheme => ({
+  id: 'theme-1',
+  title: 'Cidadania digital na era da informação',
+  description: null,
+  supportingTexts: [],
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const themesResponse = (themes: EssayTheme[], total = themes.length) => ({
+  data: {
+    message: 'ok',
+    data: { themes, pagination: { page: 1, limit: 20, total, totalPages: 1 } },
+  },
+});
+
+const makeApi = (get: jest.Mock): BaseApiClient =>
+  ({ get }) as unknown as BaseApiClient;
+
+const defaultProps = {
+  selectedTheme: null,
+  onSelectTheme: jest.fn(),
+  onRemoveTheme: jest.fn(),
+};
+
+/** The picker debounces the search, so tests must let the timer run. */
+const flushDebounce = async () => {
+  await act(async () => {
+    jest.advanceTimersByTime(500);
+  });
+};
+
+describe('EssayThemePicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reads the theme bank on mount', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([theme()]));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+
+    expect(get).toHaveBeenCalledWith('/essays/themes', {
+      params: { page: 1, limit: 20 },
+    });
+    expect(
+      screen.getByText('Cidadania digital na era da informação')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the total returned by the API', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([theme()], 4));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+
+    expect(screen.getByText('4 temas total')).toBeInTheDocument();
+  });
+
+  it('renders the origin badge only when the backend carries it', async () => {
+    const get = jest
+      .fn()
+      .mockResolvedValue(
+        themesResponse([
+          theme({ id: 'a' }),
+          theme({ id: 'b', origin: 'Enem 2024' }),
+        ])
+      );
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+
+    // Two themes rendered, but only the one carrying `origin` shows a badge.
+    expect(screen.getByText('Enem 2024')).toBeInTheDocument();
+  });
+
+  it('attaches a theme when "Adicionar à atividade" is clicked', async () => {
+    const onSelectTheme = jest.fn();
+    const picked = theme();
+    const get = jest.fn().mockResolvedValue(themesResponse([picked]));
+    render(
+      <EssayThemePicker
+        {...defaultProps}
+        apiClient={makeApi(get)}
+        onSelectTheme={onSelectTheme}
+      />
+    );
+
+    await flushDebounce();
+    fireEvent.click(screen.getByText('Adicionar à atividade'));
+
+    expect(onSelectTheme).toHaveBeenCalledWith(picked);
+  });
+
+  it('does not offer the attached theme again in the bank', async () => {
+    const attached = theme({ id: 'attached', title: 'Tema escolhido' });
+    const other = theme({ id: 'other', title: 'Outro tema' });
+    const get = jest.fn().mockResolvedValue(themesResponse([attached, other]));
+
+    render(
+      <EssayThemePicker
+        {...defaultProps}
+        apiClient={makeApi(get)}
+        selectedTheme={attached}
+      />
+    );
+
+    await flushDebounce();
+
+    // Present once, in the preview panel — not repeated in the bank list.
+    expect(screen.getAllByText('Tema escolhido')).toHaveLength(1);
+    expect(screen.getByText('Outro tema')).toBeInTheDocument();
+    expect(screen.getAllByText('Adicionar à atividade')).toHaveLength(1);
+  });
+
+  it('detaches the theme through the trash action', async () => {
+    const onRemoveTheme = jest.fn();
+    const get = jest.fn().mockResolvedValue(themesResponse([]));
+
+    render(
+      <EssayThemePicker
+        {...defaultProps}
+        apiClient={makeApi(get)}
+        selectedTheme={theme()}
+        onRemoveTheme={onRemoveTheme}
+      />
+    );
+
+    await flushDebounce();
+    fireEvent.click(screen.getByLabelText('Remover tema'));
+
+    expect(onRemoveTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers no trash action when nothing is attached', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([]));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+
+    expect(screen.queryByLabelText('Remover tema')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Nenhum tema adicionado. Escolha um tema no banco ao lado.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('searches the bank, debounced', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([theme()]));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+    expect(get).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByPlaceholderText('Buscar'), {
+      target: { value: 'cidadania' },
+    });
+    // Still one call: the request waits for the debounce.
+    expect(get).toHaveBeenCalledTimes(1);
+
+    await flushDebounce();
+
+    expect(get).toHaveBeenLastCalledWith('/essays/themes', {
+      params: { page: 1, limit: 20, search: 'cidadania' },
+    });
+  });
+
+  it('reports an empty bank', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([]));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+
+    expect(screen.getByText('Nenhum tema encontrado.')).toBeInTheDocument();
+  });
+
+  it('surfaces a load failure', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const get = jest.fn().mockRejectedValue(new Error('403'));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Erro ao carregar temas de redação')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('keeps "Baixar pdf" disabled until a theme is attached', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([]));
+    const onDownloadPdf = jest.fn();
+
+    const { rerender } = render(
+      <EssayThemePicker
+        {...defaultProps}
+        apiClient={makeApi(get)}
+        onDownloadPdf={onDownloadPdf}
+      />
+    );
+    await flushDebounce();
+
+    expect(screen.getByText('Baixar pdf').closest('button')).toBeDisabled();
+
+    rerender(
+      <EssayThemePicker
+        {...defaultProps}
+        apiClient={makeApi(get)}
+        selectedTheme={theme()}
+        onDownloadPdf={onDownloadPdf}
+      />
+    );
+
+    const button = screen.getByText('Baixar pdf').closest('button');
+    expect(button).toBeEnabled();
+    fireEvent.click(button!);
+    expect(onDownloadPdf).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/EssayThemePicker/EssayThemePicker.test.tsx
+++ b/src/components/EssayThemePicker/EssayThemePicker.test.tsx
@@ -67,6 +67,17 @@ describe('EssayThemePicker', () => {
     ).toBeInTheDocument();
   });
 
+  it('reads the bank immediately on mount, without waiting for the debounce', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse([theme()]));
+    render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);
+
+    // No timer advanced: the empty state must never flash before the request.
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Nenhum tema encontrado.')).toBeNull();
+
+    await flushDebounce();
+  });
+
   it('shows the total returned by the API', async () => {
     const get = jest.fn().mockResolvedValue(themesResponse([theme()], 4));
     render(<EssayThemePicker {...defaultProps} apiClient={makeApi(get)} />);

--- a/src/components/EssayThemePicker/EssayThemePicker.tsx
+++ b/src/components/EssayThemePicker/EssayThemePicker.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -106,8 +107,18 @@ export const EssayThemePicker = ({
   const { themes, loading, error, pagination, fetchThemes } = useEssayThemes();
 
   const [search, setSearch] = useState('');
+  const hasLoadedRef = useRef(false);
 
   useEffect(() => {
+    // The debounce protects the search box, not the first paint: waiting for it
+    // on mount would show "Nenhum tema encontrado" before the request even
+    // starts.
+    if (!hasLoadedRef.current) {
+      hasLoadedRef.current = true;
+      fetchThemes({ page: 1, limit: THEMES_PAGE_SIZE, search });
+      return;
+    }
+
     const timer = setTimeout(() => {
       fetchThemes({ page: 1, limit: THEMES_PAGE_SIZE, search });
     }, SEARCH_DEBOUNCE_MS);

--- a/src/components/EssayThemePicker/EssayThemePicker.tsx
+++ b/src/components/EssayThemePicker/EssayThemePicker.tsx
@@ -1,0 +1,250 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { TextAlignLeftIcon } from '@phosphor-icons/react/dist/csr/TextAlignLeft';
+import { ClipboardTextIcon } from '@phosphor-icons/react/dist/csr/ClipboardText';
+import { MagnifyingGlassIcon } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
+import { DownloadSimpleIcon } from '@phosphor-icons/react/dist/csr/DownloadSimple';
+import { FileIcon } from '@phosphor-icons/react/dist/csr/File';
+import { PlusIcon } from '@phosphor-icons/react/dist/csr/Plus';
+import { TrashIcon } from '@phosphor-icons/react/dist/csr/Trash';
+import Text from '../Text/Text';
+import Badge from '../Badge/Badge';
+import Button from '../Button/Button';
+import IconButton from '../IconButton/IconButton';
+import Input from '../Input/Input';
+import { SkeletonRounded } from '../Skeleton/Skeleton';
+import { cn } from '../../utils/utils';
+import type { BaseApiClient } from '../../types/api';
+import type { EssayTheme } from '../../types/essayThemes';
+import { createUseEssayThemes } from '../../hooks/useEssayThemes';
+
+/**
+ * Props for the EssayThemePicker component
+ */
+export interface EssayThemePickerProps {
+  /** API client used to read the theme bank */
+  apiClient: BaseApiClient;
+  /** Theme currently attached to the activity, if any */
+  selectedTheme: EssayTheme | null;
+  /** Called when the teacher attaches a theme */
+  onSelectTheme: (theme: EssayTheme) => void;
+  /** Called when the teacher detaches the current theme */
+  onRemoveTheme: () => void;
+  /** Called by the "Baixar pdf" action of the preview panel */
+  onDownloadPdf?: () => void;
+}
+
+/** How many themes are read per page. */
+const THEMES_PAGE_SIZE = 20;
+
+/** Debounce applied to the search box, to avoid a request per keystroke. */
+const SEARCH_DEBOUNCE_MS = 400;
+
+/**
+ * Card of a single theme, used both in the bank and in the preview panel.
+ *
+ * @param theme - Theme to render
+ * @param action - Optional footer action (e.g. the "add" button)
+ * @returns Theme card element
+ */
+const ThemeCard = ({
+  theme,
+  action,
+}: {
+  theme: EssayTheme;
+  action?: ReactNode;
+}) => (
+  <div className="border border-border-100 rounded-xl p-4 flex flex-col gap-3">
+    <div className="flex items-start justify-between gap-3">
+      {/* The badge only shows once the backend carries the theme origin. */}
+      {theme.origin ? (
+        <Badge variant="solid" action="muted" size="small">
+          {theme.origin}
+        </Badge>
+      ) : (
+        <span />
+      )}
+      {/* Decorative: marks the card as an essay theme. */}
+      <ClipboardTextIcon
+        size={20}
+        className="text-primary-700 shrink-0"
+        aria-hidden
+      />
+    </div>
+
+    <Text className="text-sm font-bold text-text-950">{theme.title}</Text>
+
+    {action}
+  </div>
+);
+
+/**
+ * "Redação" tab of the activity builder: the teacher browses the essay theme
+ * bank on the left and sees the theme attached to the activity on the right.
+ *
+ * An in-person exam carries at most one theme (`activities.essay_theme_id`), so
+ * picking a new one replaces the previous.
+ *
+ * @returns The essay tab content
+ */
+export const EssayThemePicker = ({
+  apiClient,
+  selectedTheme,
+  onSelectTheme,
+  onRemoveTheme,
+  onDownloadPdf,
+}: EssayThemePickerProps) => {
+  const useEssayThemes = useMemo(
+    () => createUseEssayThemes(apiClient),
+    [apiClient]
+  );
+  const { themes, loading, error, pagination, fetchThemes } = useEssayThemes();
+
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchThemes({ page: 1, limit: THEMES_PAGE_SIZE, search });
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [fetchThemes, search]);
+
+  const handleSelect = useCallback(
+    (theme: EssayTheme) => () => onSelectTheme(theme),
+    [onSelectTheme]
+  );
+
+  /** The attached theme is shown on the right, not offered again on the left. */
+  const availableThemes = useMemo(
+    () => themes.filter((theme) => theme.id !== selectedTheme?.id),
+    [themes, selectedTheme?.id]
+  );
+
+  return (
+    <div
+      data-testid="essay-theme-picker"
+      className="flex flex-col lg:flex-row w-full flex-1 overflow-hidden gap-5 min-h-0"
+    >
+      {/* Theme bank */}
+      <div className="flex-1 min-w-0 bg-background rounded-xl p-6 flex flex-col gap-4 min-h-0">
+        <div className="flex items-center gap-2">
+          <TextAlignLeftIcon size={20} className="text-text-950" aria-hidden />
+          <Text className="text-lg font-bold text-text-950">
+            Banco de temas
+          </Text>
+        </div>
+
+        <Badge
+          variant="solid"
+          action="muted"
+          size="small"
+          className="self-start"
+        >
+          {pagination.total} {pagination.total === 1 ? 'tema' : 'temas'} total
+        </Badge>
+
+        <Input
+          placeholder="Buscar"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          iconRight={<MagnifyingGlassIcon size={20} />}
+        />
+
+        <div className="flex flex-col gap-4 overflow-y-auto min-h-0 flex-1">
+          {loading && (
+            <>
+              <SkeletonRounded className="h-32 w-full" />
+              <SkeletonRounded className="h-32 w-full" />
+            </>
+          )}
+
+          {!loading && error && (
+            <Text className="text-sm text-error-700">{error}</Text>
+          )}
+
+          {!loading && !error && availableThemes.length === 0 && (
+            <Text className="text-sm text-text-600">
+              Nenhum tema encontrado.
+            </Text>
+          )}
+
+          {!loading &&
+            !error &&
+            availableThemes.map((theme) => (
+              <ThemeCard
+                key={theme.id}
+                theme={theme}
+                action={
+                  <Button
+                    variant="outline"
+                    size="small"
+                    className="w-full border-dashed"
+                    iconLeft={<PlusIcon size={16} />}
+                    onClick={handleSelect(theme)}
+                  >
+                    Adicionar à atividade
+                  </Button>
+                }
+              />
+            ))}
+        </div>
+      </div>
+
+      {/* Activity preview */}
+      <div
+        className={cn(
+          'bg-background rounded-xl p-6 flex flex-col gap-4 min-h-0',
+          'w-full lg:w-[420px] lg:flex-shrink-0'
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <FileIcon size={20} className="text-text-950" aria-hidden />
+          <Text className="text-lg font-bold text-text-950">
+            Prévia da atividade
+          </Text>
+        </div>
+
+        <Button
+          variant="outline"
+          size="small"
+          className="self-start"
+          iconLeft={<DownloadSimpleIcon size={16} />}
+          onClick={onDownloadPdf}
+          disabled={!onDownloadPdf || !selectedTheme}
+        >
+          Baixar pdf
+        </Button>
+
+        <div className="flex items-center justify-between gap-2">
+          <Text className="text-lg font-bold text-text-950">Tema</Text>
+          {selectedTheme && (
+            <IconButton
+              icon={<TrashIcon size={20} />}
+              size="sm"
+              title="Remover tema"
+              aria-label="Remover tema"
+              className="hover:text-error-500"
+              onClick={onRemoveTheme}
+            />
+          )}
+        </div>
+
+        {selectedTheme ? (
+          <ThemeCard theme={selectedTheme} />
+        ) : (
+          <Text className="text-sm text-text-600">
+            Nenhum tema adicionado. Escolha um tema no banco ao lado.
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EssayThemePicker;

--- a/src/components/QuestionsPdfGenerator/QuestionsPdfGenerator.tsx
+++ b/src/components/QuestionsPdfGenerator/QuestionsPdfGenerator.tsx
@@ -492,10 +492,9 @@ export const useQuestionsPdfPrint = (
         throw new Error('Elemento de PDF não encontrado no DOM');
       }
 
-      // Resolved before opening the window on purpose: an await after
-      // window.open() leaves a blank popup on screen while the data loads.
-      const extraPagesHtml = getExtraPagesHtml ? await getExtraPagesHtml() : '';
-
+      // Opened before any await: window.open() outside the user-activation
+      // window is what popup blockers reject. The extra pages are fetched after,
+      // and written into this already-open window.
       const printWindow = window.open('', '_blank');
       if (!printWindow) {
         throw new Error(
@@ -503,6 +502,17 @@ export const useQuestionsPdfPrint = (
         );
       }
       printWindow.opener = null;
+
+      let extraPagesHtml = '';
+      if (getExtraPagesHtml) {
+        try {
+          extraPagesHtml = await getExtraPagesHtml();
+        } catch (error) {
+          // Leaving a blank popup behind is worse than not printing at all.
+          printWindow.close();
+          throw error;
+        }
+      }
 
       const contentHTML = contentRef.current.innerHTML + extraPagesHtml;
       const styles = collectRelevantStyles();

--- a/src/components/QuestionsPdfGenerator/QuestionsPdfGenerator.tsx
+++ b/src/components/QuestionsPdfGenerator/QuestionsPdfGenerator.tsx
@@ -479,17 +479,22 @@ const setupPrintWindowHandler = (printWindow: Window): void => {
 export const useQuestionsPdfPrint = (
   questions: PreviewQuestion[],
   onPrint?: () => void,
-  onPrintError?: (error: Error) => void
+  onPrintError?: (error: Error) => void,
+  getExtraPagesHtml?: () => Promise<string>
 ) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
-  const handlePrint = useCallback(() => {
+  const handlePrint = useCallback(async () => {
     try {
       onPrint?.();
 
       if (!contentRef.current) {
         throw new Error('Elemento de PDF não encontrado no DOM');
       }
+
+      // Resolved before opening the window on purpose: an await after
+      // window.open() leaves a blank popup on screen while the data loads.
+      const extraPagesHtml = getExtraPagesHtml ? await getExtraPagesHtml() : '';
 
       const printWindow = window.open('', '_blank');
       if (!printWindow) {
@@ -499,7 +504,7 @@ export const useQuestionsPdfPrint = (
       }
       printWindow.opener = null;
 
-      const contentHTML = contentRef.current.innerHTML;
+      const contentHTML = contentRef.current.innerHTML + extraPagesHtml;
       const styles = collectRelevantStyles();
       const htmlContent = generatePrintHTML(contentHTML, styles);
 
@@ -515,7 +520,7 @@ export const useQuestionsPdfPrint = (
       onPrintError?.(errorObj);
       console.error('Erro ao gerar PDF:', errorObj);
     }
-  }, [onPrint, onPrintError]);
+  }, [onPrint, onPrintError, getExtraPagesHtml]);
 
   return {
     contentRef,

--- a/src/components/TypeSelector/TypeSelector.test.tsx
+++ b/src/components/TypeSelector/TypeSelector.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TypeSelector } from './TypeSelector';
-import type { ActivityCategory, TypeConfig } from './TypeSelector.types';
+import type { ActivityCategoryConfig } from './TypeSelector.types';
 import { ReactNode } from 'react';
 
 // Mock react-router-dom
@@ -35,6 +35,12 @@ jest.mock('../Select/Select', () => ({
       >
         Change to ATIVIDADE
       </button>
+      <button
+        data-testid="change-to-presencial"
+        onClick={() => onValueChange('PRESENCIAL')}
+      >
+        Change to PRESENCIAL
+      </button>
     </div>
   ),
   SelectTrigger: ({ children }: { children: ReactNode }) => (
@@ -54,7 +60,7 @@ jest.mock('../Select/Select', () => ({
 }));
 
 describe('TypeSelector', () => {
-  const mockConfig: Record<ActivityCategory, TypeConfig> = {
+  const mockConfig: ActivityCategoryConfig = {
     ATIVIDADE: {
       labels: {
         pageTitle: {
@@ -285,6 +291,111 @@ describe('TypeSelector', () => {
       );
 
       expect(screen.getByTestId('select-item-PROVA')).toBeInTheDocument();
+    });
+  });
+
+  describe('PRESENCIAL category', () => {
+    const presencialConfig: ActivityCategoryConfig = {
+      ...mockConfig,
+      PRESENCIAL: {
+        labels: {
+          ...mockConfig.ATIVIDADE.labels,
+          selectorLabel: 'Presenciais',
+        },
+        routes: {
+          base: '/atividades-presenciais',
+          create: '/criar-atividade-presencial',
+          details: (id: string) => `/atividades-presenciais/${id}`,
+          editDraft: (id: string) => `/criar-atividade-presencial?id=${id}`,
+          editModel: (id: string) => `/criar-atividade-presencial?id=${id}`,
+        },
+        statusOptions: [{ id: 'active', name: 'Ativa' }],
+      },
+    };
+
+    it('should not offer PRESENCIAL when the config omits it', () => {
+      render(
+        <TypeSelector
+          value="ATIVIDADE"
+          currentTab="history"
+          config={mockConfig}
+        />
+      );
+
+      expect(screen.queryByTestId('select-item-PRESENCIAL')).toBeNull();
+      expect(screen.queryByText('Presenciais')).toBeNull();
+    });
+
+    it('should offer PRESENCIAL when the config provides it', () => {
+      render(
+        <TypeSelector
+          value="ATIVIDADE"
+          currentTab="history"
+          config={presencialConfig}
+        />
+      );
+
+      expect(screen.getByTestId('select-item-PRESENCIAL')).toBeInTheDocument();
+      expect(screen.getByText('Presenciais')).toBeInTheDocument();
+    });
+
+    it('should navigate to the PRESENCIAL base route preserving the history tab', () => {
+      render(
+        <TypeSelector
+          value="ATIVIDADE"
+          currentTab="history"
+          config={presencialConfig}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('change-to-presencial'));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/atividades-presenciais');
+    });
+
+    it('should navigate to the PRESENCIAL models route preserving the models tab', () => {
+      render(
+        <TypeSelector
+          value="ATIVIDADE"
+          currentTab="models"
+          config={presencialConfig}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('change-to-presencial'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/atividades-presenciais/modelos'
+      );
+    });
+
+    it('should honour an explicit allowedCategories over the config-derived list', () => {
+      render(
+        <TypeSelector
+          value="ATIVIDADE"
+          currentTab="history"
+          config={presencialConfig}
+          allowedCategories={['ATIVIDADE']}
+        />
+      );
+
+      expect(screen.getByTestId('select-item-ATIVIDADE')).toBeInTheDocument();
+      expect(screen.queryByTestId('select-item-PROVA')).toBeNull();
+      expect(screen.queryByTestId('select-item-PRESENCIAL')).toBeNull();
+    });
+
+    it('should not navigate when the selected category is missing from the config', () => {
+      render(
+        <TypeSelector
+          value="ATIVIDADE"
+          currentTab="history"
+          config={mockConfig}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('change-to-presencial'));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/TypeSelector/TypeSelector.tsx
+++ b/src/components/TypeSelector/TypeSelector.tsx
@@ -7,9 +7,9 @@ import Select, {
   SelectItem,
 } from '../Select/Select';
 import {
-  type ActivityCategory,
+  type ExtendedActivityCategory,
+  type ActivityCategoryConfig,
   type ActiveTab,
-  type TypeConfig,
   getTabPath,
 } from './TypeSelector.types';
 import { useModules } from '../../hooks/useModules';
@@ -20,22 +20,23 @@ import { ExamActivityCategory } from '../../types/examDrafts';
  */
 export interface TypeSelectorProps {
   /** Current activity type selected */
-  value: ActivityCategory;
+  value: ExtendedActivityCategory;
   /** Current active tab (to preserve when switching types) */
   currentTab: ActiveTab;
   /** Configuration for activity types (routes and labels) */
-  config: Record<ActivityCategory, TypeConfig>;
+  config: ActivityCategoryConfig;
   /**
    * Optional filter to include only specific categories.
    * If not provided, automatically calculated based on hasExams flag from useModules.
    * Only use this prop for special cases where you need to override the default behavior.
    */
-  allowedCategories?: ActivityCategory[];
+  allowedCategories?: ExtendedActivityCategory[];
 }
 
 /**
- * Type selector dropdown for switching between Atividades and Provas
- * Navigates to the corresponding route while preserving the current tab
+ * Type selector dropdown for switching between Atividades, Provas and
+ * Presenciais. Navigates to the corresponding route while preserving the
+ * current tab.
  */
 export const TypeSelector = ({
   value,
@@ -54,29 +55,38 @@ export const TypeSelector = ({
     }
 
     // Otherwise, calculate based on hasExams flag
-    const categories: ActivityCategory[] = [ExamActivityCategory.ATIVIDADE];
+    const categories: ExtendedActivityCategory[] = [
+      ExamActivityCategory.ATIVIDADE,
+    ];
     if (hasExams) {
       categories.push(ExamActivityCategory.PROVA);
     }
+    // Optional categories are opt-in: the app enables them by passing routes.
+    if (config.PRESENCIAL) {
+      categories.push('PRESENCIAL');
+    }
     return categories;
-  }, [hasExams, allowedCategoriesProp]);
+  }, [hasExams, allowedCategoriesProp, config]);
 
   const handleTypeChange = useCallback(
     (newType: string) => {
       if (newType === value) return;
 
-      const typeConfig = config[newType as ActivityCategory];
+      const typeConfig = config[newType as ExtendedActivityCategory];
+      if (!typeConfig) return;
       const tabPath = getTabPath(currentTab);
       navigate(`${typeConfig.routes.base}${tabPath}`);
     },
     [value, currentTab, navigate, config]
   );
 
-  const selectItems = allowedCategories.map((category) => (
-    <SelectItem key={category} value={category}>
-      {config[category].labels.selectorLabel}
-    </SelectItem>
-  ));
+  const selectItems = allowedCategories
+    .filter((category) => !!config[category])
+    .map((category) => (
+      <SelectItem key={category} value={category}>
+        {config[category]!.labels.selectorLabel}
+      </SelectItem>
+    ));
 
   return (
     <Select value={value} onValueChange={handleTypeChange} size="small">

--- a/src/components/TypeSelector/TypeSelector.types.test.ts
+++ b/src/components/TypeSelector/TypeSelector.types.test.ts
@@ -4,9 +4,9 @@ import {
   createActivityCategoryConfig,
   ATIVIDADE_LABELS,
   PROVA_LABELS,
+  PRESENCIAL_LABELS,
   DEFAULT_STATUS_OPTIONS,
-  type TypeRoutes,
-  type ActivityCategory,
+  type ActivityRoutesInput,
 } from './TypeSelector.types';
 
 describe('TypeSelector.types', () => {
@@ -68,7 +68,7 @@ describe('TypeSelector.types', () => {
   });
 
   describe('createActivityCategoryConfig', () => {
-    const mockRoutes: Record<ActivityCategory, TypeRoutes> = {
+    const mockRoutes: ActivityRoutesInput = {
       ATIVIDADE: {
         base: '/atividades',
         create: '/criar-atividade',
@@ -140,6 +140,52 @@ describe('TypeSelector.types', () => {
         '/criar-atividade?id=789'
       );
       expect(config.PROVA.routes.editModel('abc')).toBe('/criar-prova?id=abc');
+    });
+
+    it('should omit PRESENCIAL when no routes are provided for it', () => {
+      const config = createActivityCategoryConfig(mockRoutes);
+
+      expect(config.PRESENCIAL).toBeUndefined();
+    });
+
+    it('should create config with PRESENCIAL labels and routes when provided', () => {
+      const presencialRoutes = {
+        base: '/atividades-presenciais',
+        create: '/criar-atividade-presencial',
+        details: (id: string) => `/atividades-presenciais/${id}`,
+        editDraft: (id: string) => `/criar-atividade-presencial?id=${id}`,
+        editModel: (id: string) => `/criar-atividade-presencial?id=${id}`,
+      };
+      const config = createActivityCategoryConfig({
+        ...mockRoutes,
+        PRESENCIAL: presencialRoutes,
+      });
+
+      expect(config.PRESENCIAL?.labels).toBe(PRESENCIAL_LABELS);
+      expect(config.PRESENCIAL?.routes).toBe(presencialRoutes);
+      expect(config.PRESENCIAL?.statusOptions).toBe(
+        DEFAULT_STATUS_OPTIONS.PRESENCIAL
+      );
+      expect(config.PRESENCIAL?.routes.details('123')).toBe(
+        '/atividades-presenciais/123'
+      );
+    });
+  });
+
+  describe('PRESENCIAL_LABELS', () => {
+    it('should label the selector as Presenciais', () => {
+      expect(PRESENCIAL_LABELS.selectorLabel).toBe('Presenciais');
+    });
+
+    it('should reuse the activity page titles, since the selector disambiguates', () => {
+      expect(PRESENCIAL_LABELS.pageTitle.history).toBe(
+        'Histórico de atividades'
+      );
+      expect(PRESENCIAL_LABELS.pageTitle.drafts).toBe(
+        'Rascunhos de atividades'
+      );
+      expect(PRESENCIAL_LABELS.pageTitle.models).toBe('Modelos de atividades');
+      expect(PRESENCIAL_LABELS.createButton).toBe('Criar atividade');
     });
   });
 

--- a/src/components/TypeSelector/TypeSelector.types.ts
+++ b/src/components/TypeSelector/TypeSelector.types.ts
@@ -2,9 +2,28 @@ import { ACTIVITY_FILTER_STATUS_OPTIONS } from '../../types/activitiesHistory';
 import { EXAM_STATUS_OPTIONS } from '../../utils/examFilterHelpers';
 
 /**
- * Activity type enum
+ * Activity type enum.
+ *
+ * Deliberately still the two original categories: consumer apps key their own
+ * records by this type (`Record<ActivityCategory, TypeRoutes>`), so widening it
+ * would break their type-check on the next release. Optional categories live in
+ * `OptionalActivityCategory` and the full set in `ExtendedActivityCategory`.
  */
 export type ActivityCategory = 'ATIVIDADE' | 'PROVA';
+
+/**
+ * Categories a consumer opts into by providing routes for them. Omitting one
+ * simply keeps it out of the selector.
+ */
+export type OptionalActivityCategory = 'PRESENCIAL';
+
+/**
+ * Every category the selector can display: the two required ones plus whatever
+ * the app opted into.
+ */
+export type ExtendedActivityCategory =
+  | ActivityCategory
+  | OptionalActivityCategory;
 
 /**
  * Active tab type for activity pages
@@ -47,6 +66,21 @@ export interface TypeConfig {
   routes: TypeRoutes;
   statusOptions: Array<{ id: string; name: string }>;
 }
+
+/**
+ * Routes an app provides for the activity categories it supports. The two core
+ * categories are required; optional ones (e.g. PRESENCIAL) are what enables
+ * them in the selector.
+ */
+export type ActivityRoutesInput = Record<ActivityCategory, TypeRoutes> &
+  Partial<Record<OptionalActivityCategory, TypeRoutes>>;
+
+/**
+ * Resolved configuration keyed by category. Mirrors ActivityRoutesInput: the
+ * optional categories are only present when routes were provided for them.
+ */
+export type ActivityCategoryConfig = Record<ActivityCategory, TypeConfig> &
+  Partial<Record<OptionalActivityCategory, TypeConfig>>;
 
 /**
  * Default labels for ATIVIDADE type
@@ -109,14 +143,48 @@ export const PROVA_LABELS: TypeLabels = {
 };
 
 /**
+ * Default labels for PRESENCIAL type (in-person activities).
+ *
+ * Page titles intentionally match ATIVIDADE_LABELS: the type selector sits next
+ * to the title and already tells the two apart.
+ */
+export const PRESENCIAL_LABELS: TypeLabels = {
+  pageTitle: {
+    history: 'Histórico de atividades',
+    drafts: 'Rascunhos de atividades',
+    models: 'Modelos de atividades',
+  },
+  createButton: 'Criar atividade',
+  selectorLabel: 'Presenciais',
+  itemLabel: {
+    history: 'atividades',
+    drafts: 'rascunhos',
+    models: 'modelos',
+  },
+  searchPlaceholder: {
+    history: 'Buscar atividade',
+    drafts: 'Buscar rascunho',
+    models: 'Buscar modelo',
+  },
+  emptyState: {
+    title: 'Nenhuma atividade presencial por aqui',
+    description:
+      'Crie uma nova atividade presencial e acompanhe o desempenho dos seus alunos!',
+    buttonText: 'Criar atividade',
+  },
+  statusLabel: 'Status da Atividade',
+};
+
+/**
  * Default status options by type
  */
 export const DEFAULT_STATUS_OPTIONS: Record<
-  ActivityCategory,
+  ExtendedActivityCategory,
   Array<{ id: string; name: string }>
 > = {
   ATIVIDADE: ACTIVITY_FILTER_STATUS_OPTIONS,
   PROVA: EXAM_STATUS_OPTIONS,
+  PRESENCIAL: ACTIVITY_FILTER_STATUS_OPTIONS,
 };
 
 /**
@@ -145,11 +213,14 @@ export const getTabFromPath = (pathname: string): ActiveTab => {
 };
 
 /**
- * Create activity type config with custom routes
+ * Create activity type config with custom routes.
+ *
+ * Optional categories (PRESENCIAL) are only included when the caller provided
+ * routes for them — that is how an app opts into showing them in the selector.
  */
 export const createActivityCategoryConfig = (
-  routes: Record<ActivityCategory, TypeRoutes>
-): Record<ActivityCategory, TypeConfig> => ({
+  routes: ActivityRoutesInput
+): ActivityCategoryConfig => ({
   ATIVIDADE: {
     labels: ATIVIDADE_LABELS,
     routes: routes.ATIVIDADE,
@@ -160,4 +231,13 @@ export const createActivityCategoryConfig = (
     routes: routes.PROVA,
     statusOptions: DEFAULT_STATUS_OPTIONS.PROVA,
   },
+  ...(routes.PRESENCIAL
+    ? {
+        PRESENCIAL: {
+          labels: PRESENCIAL_LABELS,
+          routes: routes.PRESENCIAL,
+          statusOptions: DEFAULT_STATUS_OPTIONS.PRESENCIAL,
+        },
+      }
+    : {}),
 });

--- a/src/components/UnifiedDraftModelPage/UnifiedDraftModelPage.tsx
+++ b/src/components/UnifiedDraftModelPage/UnifiedDraftModelPage.tsx
@@ -7,6 +7,7 @@ import EmptyState from '../EmptyState/EmptyState';
 import { AlertDialog } from '../AlertDialog/AlertDialog';
 import TypeSelector from '../TypeSelector/TypeSelector';
 import { createActivityCategoryConfig } from '../TypeSelector/TypeSelector.types';
+import type { TypeRoutes } from '../TypeSelector/TypeSelector.types';
 import type { ActivityModelTableItem } from '../../types/activitiesHistory';
 import { useActivityDraftModelPage } from '../../hooks/useActivityDraftModelPage';
 import { ActivityTab } from '../ActivityPageLayout/ActivityPageLayout';
@@ -35,13 +36,9 @@ export const UnifiedDraftModelPage = ({
   const config = PAGE_CONFIG[activityCategory][type];
   const PageLayout = getPageLayout(activityCategory);
 
-  /**
-   * Routes for the active category. Optional categories (PRESENCIAL) only exist
-   * in `routes` when the app configured them — and an app never renders this
-   * page for a category it did not configure, so the fallback is unreachable in
-   * practice and exists only to keep the type total.
-   */
-  const currentRoutes = routes[activityCategory] ?? routes.ATIVIDADE;
+  // Guaranteed by the props type: a PRESENCIAL page can only be rendered with
+  // PRESENCIAL routes, so there is no fallback to another category's URLs.
+  const currentRoutes = routes[activityCategory] as TypeRoutes;
 
   /**
    * TypeSelector config with proper labels, routes, and status options

--- a/src/components/UnifiedDraftModelPage/UnifiedDraftModelPage.tsx
+++ b/src/components/UnifiedDraftModelPage/UnifiedDraftModelPage.tsx
@@ -36,6 +36,14 @@ export const UnifiedDraftModelPage = ({
   const PageLayout = getPageLayout(activityCategory);
 
   /**
+   * Routes for the active category. Optional categories (PRESENCIAL) only exist
+   * in `routes` when the app configured them — and an app never renders this
+   * page for a category it did not configure, so the fallback is unreachable in
+   * practice and exists only to keep the type total.
+   */
+  const currentRoutes = routes[activityCategory] ?? routes.ATIVIDADE;
+
+  /**
    * TypeSelector config with proper labels, routes, and status options
    */
   const typeSelectorConfig = useMemo(
@@ -78,7 +86,7 @@ export const UnifiedDraftModelPage = ({
     openSendModal: onSend || (() => {}),
     editUrlType: config.editUrlType,
     errorLogLabel: config.errorLogLabel,
-    routes: routes[activityCategory],
+    routes: currentRoutes,
   });
 
   // Wrap hook's handleConfirmDelete to close dialog on success
@@ -96,7 +104,6 @@ export const UnifiedDraftModelPage = ({
    */
   const handleTabChange = useCallback(
     (tab: string) => {
-      const currentRoutes = routes[activityCategory];
       switch (tab) {
         case ActivityTab.HISTORY:
         case ExamTab.HISTORY:
@@ -116,7 +123,7 @@ export const UnifiedDraftModelPage = ({
           );
       }
     },
-    [navigate, routes, type, activityCategory]
+    [navigate, currentRoutes, type]
   );
 
   // Build layout props dynamically

--- a/src/components/UnifiedDraftModelPage/config.ts
+++ b/src/components/UnifiedDraftModelPage/config.ts
@@ -36,130 +36,110 @@ type CategoryConfig = {
 };
 
 /**
+ * Build the drafts/models pair for one category.
+ *
+ * The three categories differ only in wording, tab enum and test ids, so they
+ * are generated from those differences instead of being copied.
+ *
+ * @param options - The parts that actually vary between categories
+ * @returns Config for both the drafts and the models page
+ */
+const createCategoryConfig = ({
+  tabs,
+  pluralNoun,
+  createButton,
+  draftHint,
+  modelHint,
+  testIdPrefix,
+  onCreatePropName,
+}: {
+  tabs: { drafts: string; models: string };
+  /** Plural noun used in the page titles, e.g. "atividades" */
+  pluralNoun: string;
+  createButton: string;
+  /** Sentence shown on the empty drafts page */
+  draftHint: string;
+  /** Sentence shown on the empty models page */
+  modelHint: string;
+  testIdPrefix: string;
+  onCreatePropName: 'onCreateActivity' | 'onCreateExam';
+}): CategoryConfig => ({
+  drafts: {
+    activeTab: tabs.drafts,
+    pageTitle: `Rascunhos de ${pluralNoun}`,
+    emptyTitle: 'Você ainda não tem rascunhos',
+    emptyDescription: draftHint,
+    buttonText: createButton,
+    itemLabel: 'rascunhos',
+    searchPlaceholder: 'Buscar rascunho',
+    dialogTitle: 'Excluir rascunho',
+    editUrlType: 'rascunho',
+    errorLogLabel: 'rascunho',
+    currentTab: 'drafts',
+    dataKey: 'drafts',
+    fetchKey: 'fetchDrafts',
+    deleteKey: 'deleteDraft',
+    testId: `${testIdPrefix}-drafts-page`,
+    onCreatePropName,
+  },
+  models: {
+    activeTab: tabs.models,
+    pageTitle: `Modelos de ${pluralNoun}`,
+    emptyTitle: 'Você ainda não tem modelos salvos',
+    emptyDescription: modelHint,
+    buttonText: createButton,
+    itemLabel: 'modelos',
+    searchPlaceholder: 'Buscar modelo',
+    dialogTitle: 'Excluir modelo',
+    editUrlType: 'modelo',
+    errorLogLabel: 'modelo',
+    currentTab: 'models',
+    dataKey: 'models',
+    fetchKey: 'fetchModels',
+    deleteKey: 'deleteModel',
+    testId: `${testIdPrefix}-models-page`,
+    onCreatePropName,
+  },
+});
+
+/**
  * Configuration for drafts vs models by activity category
  */
 export const PAGE_CONFIG: Record<ExtendedActivityCategory, CategoryConfig> = {
-  ATIVIDADE: {
-    drafts: {
-      activeTab: ActivityTab.DRAFTS,
-      pageTitle: 'Rascunhos de atividades',
-      emptyTitle: 'Você ainda não tem rascunhos',
-      emptyDescription:
-        'Comece a criar uma atividade e salve como rascunho para continuar depois!',
-      buttonText: 'Criar atividade',
-      itemLabel: 'rascunhos',
-      searchPlaceholder: 'Buscar rascunho',
-      dialogTitle: 'Excluir rascunho',
-      editUrlType: 'rascunho' as const,
-      errorLogLabel: 'rascunho',
-      currentTab: 'drafts' as const,
-      dataKey: 'drafts' as const,
-      fetchKey: 'fetchDrafts' as const,
-      deleteKey: 'deleteDraft' as const,
-      testId: 'activity-drafts-page',
-      onCreatePropName: 'onCreateActivity' as const,
-    },
-    models: {
-      activeTab: ActivityTab.MODELS,
-      pageTitle: 'Modelos de atividades',
-      emptyTitle: 'Você ainda não tem modelos salvos',
-      emptyDescription:
-        'Salve uma atividade como modelo para reutilizá-la facilmente no futuro!',
-      buttonText: 'Criar atividade',
-      itemLabel: 'modelos',
-      searchPlaceholder: 'Buscar modelo',
-      dialogTitle: 'Excluir modelo',
-      editUrlType: 'modelo' as const,
-      errorLogLabel: 'modelo',
-      currentTab: 'models' as const,
-      dataKey: 'models' as const,
-      fetchKey: 'fetchModels' as const,
-      deleteKey: 'deleteModel' as const,
-      testId: 'activity-models-page',
-      onCreatePropName: 'onCreateActivity' as const,
-    },
-  },
-  PROVA: {
-    drafts: {
-      activeTab: ExamTab.DRAFTS,
-      pageTitle: 'Rascunhos de provas',
-      emptyTitle: 'Você ainda não tem rascunhos',
-      emptyDescription:
-        'Comece a criar uma prova e salve como rascunho para continuar depois!',
-      buttonText: 'Criar prova',
-      itemLabel: 'rascunhos',
-      searchPlaceholder: 'Buscar rascunho',
-      dialogTitle: 'Excluir rascunho',
-      editUrlType: 'rascunho' as const,
-      errorLogLabel: 'rascunho',
-      currentTab: 'drafts' as const,
-      dataKey: 'drafts' as const,
-      fetchKey: 'fetchDrafts' as const,
-      deleteKey: 'deleteDraft' as const,
-      testId: 'exam-drafts-page',
-      onCreatePropName: 'onCreateExam' as const,
-    },
-    models: {
-      activeTab: ExamTab.MODELS,
-      pageTitle: 'Modelos de provas',
-      emptyTitle: 'Você ainda não tem modelos salvos',
-      emptyDescription:
-        'Salve uma prova como modelo para reutilizá-la facilmente no futuro!',
-      buttonText: 'Criar prova',
-      itemLabel: 'modelos',
-      searchPlaceholder: 'Buscar modelo',
-      dialogTitle: 'Excluir modelo',
-      editUrlType: 'modelo' as const,
-      errorLogLabel: 'modelo',
-      currentTab: 'models' as const,
-      dataKey: 'models' as const,
-      fetchKey: 'fetchModels' as const,
-      deleteKey: 'deleteModel' as const,
-      testId: 'exam-models-page',
-      onCreatePropName: 'onCreateExam' as const,
-    },
-  },
-  PRESENCIAL: {
-    drafts: {
-      activeTab: ActivityTab.DRAFTS,
-      pageTitle: 'Rascunhos de atividades',
-      emptyTitle: 'Você ainda não tem rascunhos',
-      emptyDescription:
-        'Comece a criar uma atividade presencial e salve como rascunho para continuar depois!',
-      buttonText: 'Criar atividade',
-      itemLabel: 'rascunhos',
-      searchPlaceholder: 'Buscar rascunho',
-      dialogTitle: 'Excluir rascunho',
-      editUrlType: 'rascunho' as const,
-      errorLogLabel: 'rascunho',
-      currentTab: 'drafts' as const,
-      dataKey: 'drafts' as const,
-      fetchKey: 'fetchDrafts' as const,
-      deleteKey: 'deleteDraft' as const,
-      testId: 'presencial-activity-drafts-page',
-      onCreatePropName: 'onCreateActivity' as const,
-    },
-    models: {
-      activeTab: ActivityTab.MODELS,
-      pageTitle: 'Modelos de atividades',
-      emptyTitle: 'Você ainda não tem modelos salvos',
-      emptyDescription:
-        'Salve uma atividade presencial como modelo para reutilizá-la facilmente no futuro!',
-      buttonText: 'Criar atividade',
-      itemLabel: 'modelos',
-      searchPlaceholder: 'Buscar modelo',
-      dialogTitle: 'Excluir modelo',
-      editUrlType: 'modelo' as const,
-      errorLogLabel: 'modelo',
-      currentTab: 'models' as const,
-      dataKey: 'models' as const,
-      fetchKey: 'fetchModels' as const,
-      deleteKey: 'deleteModel' as const,
-      testId: 'presencial-activity-models-page',
-      onCreatePropName: 'onCreateActivity' as const,
-    },
-  },
-} as const;
+  ATIVIDADE: createCategoryConfig({
+    tabs: { drafts: ActivityTab.DRAFTS, models: ActivityTab.MODELS },
+    pluralNoun: 'atividades',
+    createButton: 'Criar atividade',
+    draftHint:
+      'Comece a criar uma atividade e salve como rascunho para continuar depois!',
+    modelHint:
+      'Salve uma atividade como modelo para reutilizá-la facilmente no futuro!',
+    testIdPrefix: 'activity',
+    onCreatePropName: 'onCreateActivity',
+  }),
+  PROVA: createCategoryConfig({
+    tabs: { drafts: ExamTab.DRAFTS, models: ExamTab.MODELS },
+    pluralNoun: 'provas',
+    createButton: 'Criar prova',
+    draftHint:
+      'Comece a criar uma prova e salve como rascunho para continuar depois!',
+    modelHint:
+      'Salve uma prova como modelo para reutilizá-la facilmente no futuro!',
+    testIdPrefix: 'exam',
+    onCreatePropName: 'onCreateExam',
+  }),
+  PRESENCIAL: createCategoryConfig({
+    tabs: { drafts: ActivityTab.DRAFTS, models: ActivityTab.MODELS },
+    pluralNoun: 'atividades',
+    createButton: 'Criar atividade',
+    draftHint:
+      'Comece a criar uma atividade presencial e salve como rascunho para continuar depois!',
+    modelHint:
+      'Salve uma atividade presencial como modelo para reutilizá-la facilmente no futuro!',
+    testIdPrefix: 'presencial-activity',
+    onCreatePropName: 'onCreateActivity',
+  }),
+};
 
 /**
  * Get page layout component based on activity category

--- a/src/components/UnifiedDraftModelPage/config.ts
+++ b/src/components/UnifiedDraftModelPage/config.ts
@@ -3,7 +3,7 @@ import {
   ActivityTab,
 } from '../ActivityPageLayout/ActivityPageLayout';
 import { ExamPageLayout, ExamTab } from '../ExamPageLayout/ExamPageLayout';
-import type { ActivityCategory } from '../TypeSelector/TypeSelector.types';
+import type { ExtendedActivityCategory } from '../TypeSelector/TypeSelector.types';
 
 /**
  * Page config type for drafts or models
@@ -38,7 +38,7 @@ type CategoryConfig = {
 /**
  * Configuration for drafts vs models by activity category
  */
-export const PAGE_CONFIG: Record<ActivityCategory, CategoryConfig> = {
+export const PAGE_CONFIG: Record<ExtendedActivityCategory, CategoryConfig> = {
   ATIVIDADE: {
     drafts: {
       activeTab: ActivityTab.DRAFTS,
@@ -119,11 +119,51 @@ export const PAGE_CONFIG: Record<ActivityCategory, CategoryConfig> = {
       onCreatePropName: 'onCreateExam' as const,
     },
   },
+  PRESENCIAL: {
+    drafts: {
+      activeTab: ActivityTab.DRAFTS,
+      pageTitle: 'Rascunhos de atividades',
+      emptyTitle: 'Você ainda não tem rascunhos',
+      emptyDescription:
+        'Comece a criar uma atividade presencial e salve como rascunho para continuar depois!',
+      buttonText: 'Criar atividade',
+      itemLabel: 'rascunhos',
+      searchPlaceholder: 'Buscar rascunho',
+      dialogTitle: 'Excluir rascunho',
+      editUrlType: 'rascunho' as const,
+      errorLogLabel: 'rascunho',
+      currentTab: 'drafts' as const,
+      dataKey: 'drafts' as const,
+      fetchKey: 'fetchDrafts' as const,
+      deleteKey: 'deleteDraft' as const,
+      testId: 'presencial-activity-drafts-page',
+      onCreatePropName: 'onCreateActivity' as const,
+    },
+    models: {
+      activeTab: ActivityTab.MODELS,
+      pageTitle: 'Modelos de atividades',
+      emptyTitle: 'Você ainda não tem modelos salvos',
+      emptyDescription:
+        'Salve uma atividade presencial como modelo para reutilizá-la facilmente no futuro!',
+      buttonText: 'Criar atividade',
+      itemLabel: 'modelos',
+      searchPlaceholder: 'Buscar modelo',
+      dialogTitle: 'Excluir modelo',
+      editUrlType: 'modelo' as const,
+      errorLogLabel: 'modelo',
+      currentTab: 'models' as const,
+      dataKey: 'models' as const,
+      fetchKey: 'fetchModels' as const,
+      deleteKey: 'deleteModel' as const,
+      testId: 'presencial-activity-models-page',
+      onCreatePropName: 'onCreateActivity' as const,
+    },
+  },
 } as const;
 
 /**
  * Get page layout component based on activity category
  */
-export const getPageLayout = (activityCategory: ActivityCategory) => {
+export const getPageLayout = (activityCategory: ExtendedActivityCategory) => {
   return activityCategory === 'PROVA' ? ExamPageLayout : ActivityPageLayout;
 };

--- a/src/components/UnifiedDraftModelPage/types.ts
+++ b/src/components/UnifiedDraftModelPage/types.ts
@@ -1,6 +1,6 @@
 import type {
-  ActivityCategory,
-  TypeRoutes,
+  ExtendedActivityCategory,
+  ActivityRoutesInput,
 } from '../TypeSelector/TypeSelector.types';
 import type { ActivityModelTableItem } from '../../types/activitiesHistory';
 import type { PaginationData } from '../../types/pagination';
@@ -20,8 +20,8 @@ export interface UserData {
 export interface UnifiedDraftModelPageProps {
   /** Type of page: drafts or models */
   type: 'drafts' | 'models';
-  /** Activity category: ATIVIDADE or PROVA */
-  activityCategory: ActivityCategory;
+  /** Activity category: ATIVIDADE, PROVA or PRESENCIAL */
+  activityCategory: ExtendedActivityCategory;
   /** Data to display in table */
   data: ActivityModelTableItem[];
   /** Loading state */
@@ -47,6 +47,9 @@ export interface UnifiedDraftModelPageProps {
   activityImage?: string;
   /** Image for no search results */
   noSearchImage?: string;
-  /** Routes configuration for both ATIVIDADE and PROVA */
-  routes: Record<ActivityCategory, TypeRoutes>;
+  /**
+   * Routes configuration. ATIVIDADE and PROVA are required; passing PRESENCIAL
+   * is what adds it to the type selector.
+   */
+  routes: ActivityRoutesInput;
 }

--- a/src/components/UnifiedDraftModelPage/types.ts
+++ b/src/components/UnifiedDraftModelPage/types.ts
@@ -1,6 +1,7 @@
 import type {
-  ExtendedActivityCategory,
+  ActivityCategory,
   ActivityRoutesInput,
+  TypeRoutes,
 } from '../TypeSelector/TypeSelector.types';
 import type { ActivityModelTableItem } from '../../types/activitiesHistory';
 import type { PaginationData } from '../../types/pagination';
@@ -17,11 +18,9 @@ export interface UserData {
 /**
  * Props for UnifiedDraftModelPage component
  */
-export interface UnifiedDraftModelPageProps {
+interface UnifiedDraftModelPageBaseProps {
   /** Type of page: drafts or models */
   type: 'drafts' | 'models';
-  /** Activity category: ATIVIDADE, PROVA or PRESENCIAL */
-  activityCategory: ExtendedActivityCategory;
   /** Data to display in table */
   data: ActivityModelTableItem[];
   /** Loading state */
@@ -47,9 +46,27 @@ export interface UnifiedDraftModelPageProps {
   activityImage?: string;
   /** Image for no search results */
   noSearchImage?: string;
-  /**
-   * Routes configuration. ATIVIDADE and PROVA are required; passing PRESENCIAL
-   * is what adds it to the type selector.
-   */
-  routes: ActivityRoutesInput;
 }
+
+/**
+ * Props for UnifiedDraftModelPage.
+ *
+ * Discriminated by category so a PRESENCIAL page cannot be rendered without its
+ * routes: without them, tab, create and row navigation would silently fall back
+ * to the ATIVIDADE URLs.
+ */
+export type UnifiedDraftModelPageProps = UnifiedDraftModelPageBaseProps &
+  (
+    | {
+        activityCategory: ActivityCategory;
+        /**
+         * Routes configuration. ATIVIDADE and PROVA are required; passing
+         * PRESENCIAL is what adds it to the type selector.
+         */
+        routes: ActivityRoutesInput;
+      }
+    | {
+        activityCategory: 'PRESENCIAL';
+        routes: ActivityRoutesInput & { PRESENCIAL: TypeRoutes };
+      }
+  );

--- a/src/components/UnifiedHistoryPage/UnifiedHistoryPage.test.tsx
+++ b/src/components/UnifiedHistoryPage/UnifiedHistoryPage.test.tsx
@@ -200,6 +200,30 @@ jest.mock('./config', () => {
           MODELS: 'modelos',
         },
       },
+      PRESENCIAL: {
+        PageLayout: MockActivityLayout,
+        pageTitle: 'Histórico de atividades',
+        activeTab: 'historico',
+        testId: 'presencial-activities-history-page',
+        itemLabel: 'atividades',
+        searchPlaceholder: 'Buscar atividade',
+        statusLabel: 'Status da Atividade',
+        statusOptions: [
+          { id: 'ATIVA', name: 'Ativa' },
+          { id: 'CONCLUIDA', name: 'Concluída' },
+          { id: 'VENCIDA', name: 'Vencida' },
+        ],
+        tableColumns: [],
+        emptyTitle: 'Nenhuma atividade presencial por aqui',
+        emptyDescription: 'Crie sua primeira atividade presencial',
+        buttonText: 'Criar atividade',
+        onCreatePropName: 'onCreateActivity',
+        tabs: {
+          HISTORY: 'historico',
+          DRAFTS: 'rascunhos',
+          MODELS: 'modelos',
+        },
+      },
     },
   };
 });
@@ -754,6 +778,77 @@ describe('UnifiedHistoryPage', () => {
       } finally {
         cfg.PAGE_CONFIG.ATIVIDADE.tableColumns = original;
       }
+    });
+  });
+
+  describe('PRESENCIAL category', () => {
+    const presencialRoutes = {
+      ...mockRoutes,
+      PRESENCIAL: {
+        base: '/atividades-presenciais',
+        create: '/criar-atividade-presencial',
+        details: (id: string) => `/atividades-presenciais/detalhes/${id}`,
+        editDraft: (id: string) => `/criar-atividade-presencial?id=${id}`,
+        editModel: (id: string) => `/criar-atividade-presencial?id=${id}`,
+      },
+    };
+
+    const presencialProps = (): UnifiedHistoryPageProps => ({
+      ...baseProps,
+      activityCategory: 'PRESENCIAL',
+      routes: presencialRoutes,
+    });
+
+    it('renders the activity layout', () => {
+      render(<UnifiedHistoryPage {...presencialProps()} />);
+      expect(screen.getByTestId('activity-page-layout')).toBeInTheDocument();
+    });
+
+    it('passes no filters, so only the search box remains', () => {
+      render(<UnifiedHistoryPage {...presencialProps()} />);
+      const lastCall = getMockPageLayout().mock.calls.at(-1)?.[0];
+      expect(lastCall.initialFilters).toBeUndefined();
+    });
+
+    it('still builds filters for the other categories', () => {
+      render(<UnifiedHistoryPage {...baseProps} />);
+      const lastCall = getMockPageLayout().mock.calls.at(-1)?.[0];
+      expect(lastCall.initialFilters).toEqual(expect.any(Array));
+    });
+
+    it('navigates to the presencial details route on row click', () => {
+      render(<UnifiedHistoryPage {...presencialProps()} />);
+      fireEvent.click(screen.getByText('Click Row'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/atividades-presenciais/detalhes/1'
+      );
+    });
+
+    it('navigates to the presencial drafts route on tab change', () => {
+      render(<UnifiedHistoryPage {...presencialProps()} />);
+      fireEvent.click(screen.getByText('Go to Drafts'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/atividades-presenciais/rascunhos'
+      );
+    });
+
+    it('navigates to the presencial create route', () => {
+      render(<UnifiedHistoryPage {...presencialProps()} />);
+      fireEvent.click(screen.getByText('Create Activity'));
+      expect(mockNavigate).toHaveBeenCalledWith('/criar-atividade-presencial');
+    });
+
+    it('enables the owner-only actions column, same as regular activities', () => {
+      render(
+        <UnifiedHistoryPage
+          {...presencialProps()}
+          currentUserId="user-1"
+          apiClient={{ delete: jest.fn() } as unknown as BaseApiClient}
+        />
+      );
+      expect(screen.getByTestId('has-actions-column')).toHaveTextContent(
+        'true'
+      );
     });
   });
 });

--- a/src/components/UnifiedHistoryPage/UnifiedHistoryPage.test.tsx
+++ b/src/components/UnifiedHistoryPage/UnifiedHistoryPage.test.tsx
@@ -816,26 +816,14 @@ describe('UnifiedHistoryPage', () => {
       expect(lastCall.initialFilters).toEqual(expect.any(Array));
     });
 
-    it('navigates to the presencial details route on row click', () => {
+    it.each([
+      ['Click Row', '/atividades-presenciais/detalhes/1'],
+      ['Go to Drafts', '/atividades-presenciais/rascunhos'],
+      ['Create Activity', '/criar-atividade-presencial'],
+    ])('navigates to the presencial route on "%s"', (action, expectedUrl) => {
       render(<UnifiedHistoryPage {...presencialProps()} />);
-      fireEvent.click(screen.getByText('Click Row'));
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/atividades-presenciais/detalhes/1'
-      );
-    });
-
-    it('navigates to the presencial drafts route on tab change', () => {
-      render(<UnifiedHistoryPage {...presencialProps()} />);
-      fireEvent.click(screen.getByText('Go to Drafts'));
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/atividades-presenciais/rascunhos'
-      );
-    });
-
-    it('navigates to the presencial create route', () => {
-      render(<UnifiedHistoryPage {...presencialProps()} />);
-      fireEvent.click(screen.getByText('Create Activity'));
-      expect(mockNavigate).toHaveBeenCalledWith('/criar-atividade-presencial');
+      fireEvent.click(screen.getByText(action));
+      expect(mockNavigate).toHaveBeenCalledWith(expectedUrl);
     });
 
     it('enables the owner-only actions column, same as regular activities', () => {

--- a/src/components/UnifiedHistoryPage/UnifiedHistoryPage.tsx
+++ b/src/components/UnifiedHistoryPage/UnifiedHistoryPage.tsx
@@ -13,6 +13,7 @@ import { EditActivityModal } from './EditActivityModal';
 import useToastStore from '../Toast/utils/ToastStore';
 import TypeSelector from '../TypeSelector/TypeSelector';
 import { createActivityCategoryConfig } from '../TypeSelector/TypeSelector.types';
+import type { TypeRoutes } from '../TypeSelector/TypeSelector.types';
 import type { FilterConfig } from '../Filter';
 import type { TableParams, ColumnConfig } from '../TableProvider/TableProvider';
 import type {
@@ -313,13 +314,9 @@ export const UnifiedHistoryPage = ({
     [routes]
   );
 
-  /**
-   * Routes for the active category. Optional categories (PRESENCIAL) only exist
-   * in `routes` when the app configured them — and an app never renders this
-   * page for a category it did not configure, so the fallback is unreachable in
-   * practice and exists only to keep the type total.
-   */
-  const currentRoutes = routes[activityCategory] ?? routes.ATIVIDADE;
+  // Guaranteed by the props type: a PRESENCIAL page can only be rendered with
+  // PRESENCIAL routes, so there is no fallback to another category's URLs.
+  const currentRoutes = routes[activityCategory] as TypeRoutes;
 
   /**
    * Handle tab change

--- a/src/components/UnifiedHistoryPage/UnifiedHistoryPage.tsx
+++ b/src/components/UnifiedHistoryPage/UnifiedHistoryPage.tsx
@@ -63,10 +63,19 @@ export const UnifiedHistoryPage = ({
 
   /**
    * Whether the owner-only delete action is enabled. Requires an api client and
-   * the logged user id, and only applies to activities (not exams).
+   * the logged user id, and only applies to activities (not exams). Presencial
+   * activities are activities too — same DELETE /activities/:id.
    */
   const deleteEnabled =
-    activityCategory === 'ATIVIDADE' && !!apiClient && !!currentUserId;
+    (activityCategory === 'ATIVIDADE' || activityCategory === 'PRESENCIAL') &&
+    !!apiClient &&
+    !!currentUserId;
+
+  /**
+   * Presencial activities have no school/class/subject breakdown to filter by,
+   * so the filter chips are dropped and only the search box remains.
+   */
+  const filtersEnabled = activityCategory !== 'PRESENCIAL';
 
   /** Activity currently pending deletion confirmation (drives the AlertDialog) */
   const [activityToDelete, setActivityToDelete] = useState<{
@@ -94,95 +103,101 @@ export const UnifiedHistoryPage = ({
   );
 
   /**
-   * Build filter configuration merging userData and API-sourced options
+   * Build filter configuration merging userData and API-sourced options.
+   * Returns undefined when the category has no filters (presencial), which is
+   * what BasePageLayout reads to hide the filter chips.
    */
   const initialFilterConfigs = useMemo(
-    (): FilterConfig[] => [
-      // Add creator type filter only for managers
-      ...(includeCreatorFilter
-        ? [
+    (): FilterConfig[] | undefined =>
+      !filtersEnabled
+        ? undefined
+        : [
+            // Add creator type filter only for managers
+            ...(includeCreatorFilter
+              ? [
+                  {
+                    key: 'creator',
+                    label: 'CRIADO POR',
+                    categories: [
+                      {
+                        key: 'creatorType',
+                        label: 'Criador',
+                        selectedIds: [],
+                        itens: CREATOR_TYPE_OPTIONS,
+                      },
+                    ],
+                  },
+                ]
+              : []),
+            // Status filter
             {
-              key: 'creator',
-              label: 'CRIADO POR',
+              key: 'status',
+              label: 'STATUS',
               categories: [
                 {
-                  key: 'creatorType',
-                  label: 'Criador',
+                  key: 'status',
+                  label: config.statusLabel,
                   selectedIds: [],
-                  itens: CREATOR_TYPE_OPTIONS,
+                  itens: config.statusOptions,
                 },
               ],
             },
-          ]
-        : []),
-      // Status filter
-      {
-        key: 'status',
-        label: 'STATUS',
-        categories: [
-          {
-            key: 'status',
-            label: config.statusLabel,
-            selectedIds: [],
-            itens: config.statusOptions,
-          },
-        ],
-      },
-      // Academic data filters
-      {
-        key: 'academic',
-        label: 'DADOS ACADÊMICOS',
-        categories: [
-          {
-            key: 'school',
-            label: 'Escola',
-            selectedIds: [],
-            itens: mergeFilterOptions(
-              userFilterOptions.schools,
-              apiFilterOptions.schools
-            ),
-          },
-          {
-            key: 'schoolYear',
-            label: 'Ano',
-            selectedIds: [],
-            itens: mergeFilterOptions(
-              userFilterOptions.schoolYears,
-              apiFilterOptions.schoolYears
-            ),
-          },
-          {
-            key: 'class',
-            label: 'Turma',
-            selectedIds: [],
-            itens: mergeFilterOptions(
-              userFilterOptions.classes,
-              apiFilterOptions.classes
-            ),
-          },
-        ],
-      },
-      // Content filters
-      {
-        key: 'content',
-        label: 'CONTEÚDO',
-        categories: [
-          {
-            key: 'subject',
-            label: 'Matéria',
-            selectedIds: [],
-            itens: mergeFilterOptions(
-              userFilterOptions.subjects,
-              apiFilterOptions.subjects
-            ),
-          },
-        ],
-      },
-    ],
+            // Academic data filters
+            {
+              key: 'academic',
+              label: 'DADOS ACADÊMICOS',
+              categories: [
+                {
+                  key: 'school',
+                  label: 'Escola',
+                  selectedIds: [],
+                  itens: mergeFilterOptions(
+                    userFilterOptions.schools,
+                    apiFilterOptions.schools
+                  ),
+                },
+                {
+                  key: 'schoolYear',
+                  label: 'Ano',
+                  selectedIds: [],
+                  itens: mergeFilterOptions(
+                    userFilterOptions.schoolYears,
+                    apiFilterOptions.schoolYears
+                  ),
+                },
+                {
+                  key: 'class',
+                  label: 'Turma',
+                  selectedIds: [],
+                  itens: mergeFilterOptions(
+                    userFilterOptions.classes,
+                    apiFilterOptions.classes
+                  ),
+                },
+              ],
+            },
+            // Content filters
+            {
+              key: 'content',
+              label: 'CONTEÚDO',
+              categories: [
+                {
+                  key: 'subject',
+                  label: 'Matéria',
+                  selectedIds: [],
+                  itens: mergeFilterOptions(
+                    userFilterOptions.subjects,
+                    apiFilterOptions.subjects
+                  ),
+                },
+              ],
+            },
+          ],
     [
       apiFilterOptions,
       config.statusOptions,
       config.statusLabel,
+      filtersEnabled,
       includeCreatorFilter,
       userFilterOptions,
     ]
@@ -299,11 +314,18 @@ export const UnifiedHistoryPage = ({
   );
 
   /**
+   * Routes for the active category. Optional categories (PRESENCIAL) only exist
+   * in `routes` when the app configured them — and an app never renders this
+   * page for a category it did not configure, so the fallback is unreachable in
+   * practice and exists only to keep the type total.
+   */
+  const currentRoutes = routes[activityCategory] ?? routes.ATIVIDADE;
+
+  /**
    * Handle tab change
    */
   const handleTabChange = useCallback(
     (tab: string) => {
-      const currentRoutes = routes[activityCategory];
       switch (tab) {
         case config.tabs.DRAFTS:
           navigate(`${currentRoutes.base}/rascunhos`);
@@ -315,24 +337,24 @@ export const UnifiedHistoryPage = ({
           navigate(currentRoutes.base);
       }
     },
-    [navigate, config, routes, activityCategory]
+    [navigate, config, currentRoutes]
   );
 
   /**
    * Handle create button click
    */
   const handleCreate = useCallback(() => {
-    navigate(routes[activityCategory].create);
-  }, [navigate, routes, activityCategory]);
+    navigate(currentRoutes.create);
+  }, [navigate, currentRoutes]);
 
   /**
    * Handle row click
    */
   const handleRowClick = useCallback(
     (row: ActivityTableItem | ExamTableItem) => {
-      navigate(routes[activityCategory].details(row.id));
+      navigate(currentRoutes.details(row.id));
     },
-    [navigate, routes, activityCategory]
+    [navigate, currentRoutes]
   );
 
   // Build layout props dynamically

--- a/src/components/UnifiedHistoryPage/config.ts
+++ b/src/components/UnifiedHistoryPage/config.ts
@@ -6,8 +6,9 @@ import { ExamPageLayout, ExamTab } from '../ExamPageLayout/ExamPageLayout';
 import { ACTIVITY_FILTER_STATUS_OPTIONS } from '../../types/activitiesHistory';
 import { EXAM_STATUS_OPTIONS } from '../../utils/examFilterHelpers';
 import { activitiesTableColumns } from '../ActivityPageLayout/activitiesTableConfig';
+import { presencialActivitiesTableColumns } from '../ActivityPageLayout/presencialActivitiesTableConfig';
 import { examsTableColumns } from '../ExamPageLayout/examsTableConfig';
-import type { ActivityCategory } from '../TypeSelector/TypeSelector.types';
+import type { ExtendedActivityCategory } from '../TypeSelector/TypeSelector.types';
 import type { ColumnConfig } from '../TableProvider/TableProvider';
 import type { ActivityTableItem } from '../../types/activitiesHistory';
 import type { ExamTableItem } from '../../types/examsHistory';
@@ -41,7 +42,7 @@ export interface PageConfig {
 /**
  * Configuration for activities vs exams
  */
-export const PAGE_CONFIG: Record<ActivityCategory, PageConfig> = {
+export const PAGE_CONFIG: Record<ExtendedActivityCategory, PageConfig> = {
   ATIVIDADE: {
     PageLayout: ActivityPageLayout,
     activeTab: ActivityTab.HISTORY,
@@ -83,5 +84,26 @@ export const PAGE_CONFIG: Record<ActivityCategory, PageConfig> = {
       MODELS: ExamTab.MODELS,
     },
     onCreatePropName: 'onCreateExam' as const,
+  },
+  PRESENCIAL: {
+    PageLayout: ActivityPageLayout,
+    activeTab: ActivityTab.HISTORY,
+    pageTitle: 'Histórico de atividades',
+    emptyTitle: 'Nenhuma atividade presencial por aqui',
+    emptyDescription:
+      'Crie uma nova atividade presencial e acompanhe o desempenho dos alunos!',
+    buttonText: 'Criar atividade',
+    itemLabel: 'atividades',
+    searchPlaceholder: 'Buscar atividade',
+    testId: 'presencial-activities-history-page',
+    statusOptions: ACTIVITY_FILTER_STATUS_OPTIONS,
+    statusLabel: 'Status da Atividade',
+    tableColumns: presencialActivitiesTableColumns,
+    tabs: {
+      HISTORY: ActivityTab.HISTORY,
+      DRAFTS: ActivityTab.DRAFTS,
+      MODELS: ActivityTab.MODELS,
+    },
+    onCreatePropName: 'onCreateActivity' as const,
   },
 } as const;

--- a/src/components/UnifiedHistoryPage/types.ts
+++ b/src/components/UnifiedHistoryPage/types.ts
@@ -1,6 +1,6 @@
 import type {
-  ActivityCategory,
-  TypeRoutes,
+  ExtendedActivityCategory,
+  ActivityRoutesInput,
 } from '../TypeSelector/TypeSelector.types';
 import type { ActivityTableItem } from '../../types/activitiesHistory';
 import type { ExamTableItem } from '../../types/examsHistory';
@@ -37,8 +37,8 @@ export interface ApiFilterOptions {
  * Props for UnifiedHistoryPage component
  */
 export interface UnifiedHistoryPageProps {
-  /** Activity category: ATIVIDADE or PROVA */
-  activityCategory: ActivityCategory;
+  /** Activity category: ATIVIDADE, PROVA or PRESENCIAL */
+  activityCategory: ExtendedActivityCategory;
   /** Data to display in table */
   data: ActivityTableItem[] | ExamTableItem[];
   /** Loading state */
@@ -59,12 +59,15 @@ export interface UnifiedHistoryPageProps {
   noSearchImage?: string;
   /** Include creator type filter (for managers/gestors) */
   includeCreatorFilter?: boolean;
-  /** Routes configuration for both ATIVIDADE and PROVA */
-  routes: Record<ActivityCategory, TypeRoutes>;
+  /**
+   * Routes configuration. ATIVIDADE and PROVA are required; passing PRESENCIAL
+   * is what adds it to the type selector.
+   */
+  routes: ActivityRoutesInput;
   /**
    * Logged user id. When provided together with `apiClient` (and category is
-   * ATIVIDADE), enables the owner-only delete action on activities created by
-   * this user (row.creatorId === currentUserId).
+   * ATIVIDADE or PRESENCIAL), enables the owner-only delete/edit actions on
+   * activities created by this user (row.creatorId === currentUserId).
    */
   currentUserId?: string | null;
   /**

--- a/src/components/UnifiedHistoryPage/types.ts
+++ b/src/components/UnifiedHistoryPage/types.ts
@@ -1,6 +1,7 @@
 import type {
-  ExtendedActivityCategory,
+  ActivityCategory,
   ActivityRoutesInput,
+  TypeRoutes,
 } from '../TypeSelector/TypeSelector.types';
 import type { ActivityTableItem } from '../../types/activitiesHistory';
 import type { ExamTableItem } from '../../types/examsHistory';
@@ -36,9 +37,7 @@ export interface ApiFilterOptions {
 /**
  * Props for UnifiedHistoryPage component
  */
-export interface UnifiedHistoryPageProps {
-  /** Activity category: ATIVIDADE, PROVA or PRESENCIAL */
-  activityCategory: ExtendedActivityCategory;
+interface UnifiedHistoryPageBaseProps {
   /** Data to display in table */
   data: ActivityTableItem[] | ExamTableItem[];
   /** Loading state */
@@ -60,11 +59,6 @@ export interface UnifiedHistoryPageProps {
   /** Include creator type filter (for managers/gestors) */
   includeCreatorFilter?: boolean;
   /**
-   * Routes configuration. ATIVIDADE and PROVA are required; passing PRESENCIAL
-   * is what adds it to the type selector.
-   */
-  routes: ActivityRoutesInput;
-  /**
    * Logged user id. When provided together with `apiClient` (and category is
    * ATIVIDADE or PRESENCIAL), enables the owner-only delete/edit actions on
    * activities created by this user (row.creatorId === currentUserId).
@@ -76,3 +70,26 @@ export interface UnifiedHistoryPageProps {
    */
   apiClient?: BaseApiClient;
 }
+
+/**
+ * Props for UnifiedHistoryPage.
+ *
+ * Discriminated by category so a PRESENCIAL page cannot be rendered without its
+ * routes: without them, tab, create and row navigation would silently fall back
+ * to the ATIVIDADE URLs.
+ */
+export type UnifiedHistoryPageProps = UnifiedHistoryPageBaseProps &
+  (
+    | {
+        activityCategory: ActivityCategory;
+        /**
+         * Routes configuration. ATIVIDADE and PROVA are required; passing
+         * PRESENCIAL is what adds it to the type selector.
+         */
+        routes: ActivityRoutesInput;
+      }
+    | {
+        activityCategory: 'PRESENCIAL';
+        routes: ActivityRoutesInput & { PRESENCIAL: TypeRoutes };
+      }
+  );

--- a/src/hooks/useActivitiesHistory.ts
+++ b/src/hooks/useActivitiesHistory.ts
@@ -88,6 +88,9 @@ export const transformActivityToTableItem = (
     deadline: activity.finalDate
       ? dayjs(activity.finalDate).format('DD/MM')
       : '-',
+    createdAt: activity.createdAt
+      ? dayjs(activity.createdAt).format('DD/MM')
+      : '-',
     creator: activity.creator?.name?.trim() ? activity.creator.name : '-',
     creatorId: activity.creator?.id ?? null,
     title: activity.title,

--- a/src/hooks/useActivityDetails.test.ts
+++ b/src/hooks/useActivityDetails.test.ts
@@ -208,6 +208,133 @@ describe('useActivityDetails', () => {
       });
     });
 
+    describe('presencial essays', () => {
+      const presencialQuiz = {
+        message: 'Success',
+        data: {
+          ...mockActivityMetadata,
+          type: 'ATIVIDADE',
+          isDigital: false,
+          essayThemeId: 'theme-1',
+        },
+      } as QuizResponse;
+
+      const twoStudents = {
+        message: 'Success',
+        data: {
+          ...mockDetailsApiResponse.data,
+          students: [
+            mockStudents[0],
+            {
+              ...mockStudents[0],
+              studentId: 'student-2',
+              studentName: 'Maria Souza',
+            },
+          ],
+        },
+      };
+
+      it('reads the essays of the activity and marks who delivered', async () => {
+        (mockApiClient.get as jest.Mock)
+          .mockResolvedValueOnce({ data: twoStudents })
+          .mockResolvedValueOnce({ data: presencialQuiz })
+          .mockResolvedValueOnce({
+            data: {
+              data: {
+                essays: [
+                  {
+                    student: { id: 'student-1' },
+                    submittedAt: '2024-01-16T10:30:00Z',
+                  },
+                ],
+              },
+            },
+          });
+
+        const { result } = renderHook(() => useActivityDetails(mockApiClient));
+        const details =
+          await result.current.fetchActivityDetails('activity-123');
+
+        expect(mockApiClient.get).toHaveBeenCalledWith('/essays/review', {
+          params: { activityId: 'activity-123', limit: 100 },
+        });
+        expect(details.students[0]).toMatchObject({
+          studentId: 'student-1',
+          essayStatus: 'RECEBIDO',
+          essayReceivedAt: '2024-01-16T10:30:00Z',
+        });
+        // No row in the essay listing means the sheet has not arrived.
+        expect(details.students[1]).toMatchObject({
+          studentId: 'student-2',
+          essayStatus: 'AGUARDANDO',
+          essayReceivedAt: null,
+        });
+      });
+
+      it('does not read essays when the activity requires none', async () => {
+        (mockApiClient.get as jest.Mock)
+          .mockResolvedValueOnce({ data: mockDetailsApiResponse })
+          .mockResolvedValueOnce({
+            data: {
+              message: 'Success',
+              data: { ...mockActivityMetadata, isDigital: false },
+            },
+          });
+
+        const { result } = renderHook(() => useActivityDetails(mockApiClient));
+        await result.current.fetchActivityDetails('activity-123');
+
+        expect(mockApiClient.get).not.toHaveBeenCalledWith(
+          '/essays/review',
+          expect.anything()
+        );
+      });
+
+      it('does not read essays for a digital activity', async () => {
+        (mockApiClient.get as jest.Mock)
+          .mockResolvedValueOnce({ data: mockDetailsApiResponse })
+          .mockResolvedValueOnce({
+            data: {
+              message: 'Success',
+              data: {
+                ...mockActivityMetadata,
+                isDigital: true,
+                essayThemeId: 'theme-1',
+              },
+            },
+          });
+
+        const { result } = renderHook(() => useActivityDetails(mockApiClient));
+        await result.current.fetchActivityDetails('activity-123');
+
+        expect(mockApiClient.get).not.toHaveBeenCalledWith(
+          '/essays/review',
+          expect.anything()
+        );
+      });
+
+      it('still renders the results when the essay listing fails', async () => {
+        const consoleErrorSpy = jest
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+
+        (mockApiClient.get as jest.Mock)
+          .mockResolvedValueOnce({ data: mockDetailsApiResponse })
+          .mockResolvedValueOnce({ data: presencialQuiz })
+          .mockRejectedValueOnce(new Error('500'));
+
+        const { result } = renderHook(() => useActivityDetails(mockApiClient));
+        const details =
+          await result.current.fetchActivityDetails('activity-123');
+
+        expect(details.students[0]).toMatchObject({
+          essayStatus: 'AGUARDANDO',
+          essayReceivedAt: null,
+        });
+        consoleErrorSpy.mockRestore();
+      });
+    });
+
     it('should handle details fetch failure', async () => {
       const consoleErrorSpy = jest
         .spyOn(console, 'error')

--- a/src/hooks/useActivityDetails.ts
+++ b/src/hooks/useActivityDetails.ts
@@ -11,6 +11,55 @@ import type {
   QuestionsAnswersByStudentResponse,
   SaveQuestionCorrectionPayload,
 } from '../utils/studentActivityCorrection';
+import { PRESENCIAL_DELIVERY_STATUS } from '../types/activityDetails';
+
+/** Page size used to read every essay of one activity in a single request. */
+const ESSAYS_PAGE_LIMIT = 100;
+
+/**
+ * Response of `GET /essays/review`, narrowed to what the delivery columns need.
+ */
+interface ActivityEssaysResponse {
+  data: {
+    essays: Array<{
+      student: { id: string };
+      submittedAt: string | null;
+    }>;
+  };
+}
+
+/**
+ * Read the essays handed in for one activity, keyed by student.
+ *
+ * A student with no row here simply has not handed the sheet in yet, so a
+ * failure to read is treated the same as "nothing delivered" — the screen still
+ * renders the rest of the results.
+ *
+ * @param apiClient - API client instance
+ * @param activityId - Activity whose essays are being read
+ * @returns Map of studentId to the essay delivery info
+ */
+const fetchActivityEssays = async (
+  apiClient: BaseApiClient,
+  activityId: string
+): Promise<Map<string, { submittedAt: string | null }>> => {
+  try {
+    const response = await apiClient.get<ActivityEssaysResponse>(
+      '/essays/review',
+      { params: { activityId, limit: ESSAYS_PAGE_LIMIT } }
+    );
+
+    return new Map(
+      response.data.data.essays.map((essay) => [
+        essay.student.id,
+        { submittedAt: essay.submittedAt },
+      ])
+    );
+  } catch (error) {
+    console.error('Erro ao carregar redações da atividade:', error);
+    return new Map();
+  }
+};
 
 /**
  * Hook return type for activity details
@@ -147,9 +196,31 @@ export const useActivityDetails = (
         apiClient.get<QuizResponse>(`/activities/${id}/quiz`).catch(() => null),
       ]);
 
+      const activity = quizResponse?.data?.data;
+      const details = detailsResponse.data.data;
+
+      // An in-person exam is printed with an essay sheet, delivered apart from
+      // the answer sheet. `/activities/:id/details` knows nothing about essays,
+      // so the delivery state comes from the essay listing of this activity.
+      if (!activity?.essayThemeId || activity.isDigital !== false) {
+        return { ...details, activity };
+      }
+
+      const essaysByStudent = await fetchActivityEssays(apiClient, id);
+
       return {
-        ...detailsResponse.data.data,
-        activity: quizResponse?.data?.data,
+        ...details,
+        activity,
+        students: details.students.map((student) => {
+          const essay = essaysByStudent.get(student.studentId);
+          return {
+            ...student,
+            essayStatus: essay
+              ? PRESENCIAL_DELIVERY_STATUS.RECEIVED
+              : PRESENCIAL_DELIVERY_STATUS.AWAITING,
+            essayReceivedAt: essay?.submittedAt ?? null,
+          };
+        }),
       };
     },
     [apiClient]

--- a/src/hooks/useActivityDraftModelPage.ts
+++ b/src/hooks/useActivityDraftModelPage.ts
@@ -7,7 +7,7 @@ import type {
 } from '../types/activitiesHistory';
 import type { ColumnConfig } from '../components/TableProvider/TableProvider';
 import type {
-  ActivityCategory,
+  ExtendedActivityCategory,
   TypeRoutes,
 } from '../components/TypeSelector/TypeSelector.types';
 import { createExamDraftsModelsTableColumns } from '../components/ExamPageLayout/examDraftsModelsTableConfig';
@@ -22,8 +22,8 @@ import { createDraftsModelsFiltersConfig } from '../utils/draftModelFilterHelper
  * Configuration options for the useActivityDraftModelPage hook
  */
 export interface UseActivityDraftModelPageOptions {
-  /** Activity category (ATIVIDADE or PROVA) */
-  activityCategory: ActivityCategory;
+  /** Activity category (ATIVIDADE, PROVA or PRESENCIAL) */
+  activityCategory: ExtendedActivityCategory;
   /** Function to fetch data with the given filters */
   fetchFn: (params: {
     page?: number;

--- a/src/hooks/useEssayThemes.test.ts
+++ b/src/hooks/useEssayThemes.test.ts
@@ -92,6 +92,39 @@ describe('useEssayThemes', () => {
     });
   });
 
+  it('drops a slower earlier response so it cannot overwrite the newer list', async () => {
+    let resolveFirst: (value: unknown) => void = () => {};
+    const first = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = {
+      data: {
+        message: 'ok',
+        data: {
+          themes: [{ ...themesResponse.data.data.themes[0], id: 'theme-2' }],
+          pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+        },
+      },
+    };
+
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce(second);
+    const useEssayThemes = createUseEssayThemes(makeApi(get));
+    const { result } = renderHook(() => useEssayThemes());
+
+    await act(async () => {
+      const stale = result.current.fetchThemes({ search: 'a' });
+      await result.current.fetchThemes({ search: 'ab' });
+      resolveFirst(themesResponse);
+      await stale;
+    });
+
+    // The newer search wins even though the older request resolved last.
+    expect(result.current.themes[0].id).toBe('theme-2');
+  });
+
   it('surfaces an error message when the request fails', async () => {
     const get = jest.fn().mockRejectedValue(new Error('403'));
     const useEssayThemes = createUseEssayThemes(makeApi(get));

--- a/src/hooks/useEssayThemes.test.ts
+++ b/src/hooks/useEssayThemes.test.ts
@@ -1,0 +1,110 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createUseEssayThemes } from './useEssayThemes';
+import type { BaseApiClient } from '../types/api';
+
+const themesResponse = {
+  data: {
+    message: 'ok',
+    data: {
+      themes: [
+        {
+          id: 'theme-1',
+          title: 'Cidadania digital na era da informação',
+          description: null,
+          supportingTexts: [],
+          isActive: true,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      pagination: { page: 1, limit: 20, total: 4, totalPages: 1 },
+    },
+  },
+};
+
+const makeApi = (get: jest.Mock): BaseApiClient =>
+  ({ get }) as unknown as BaseApiClient;
+
+describe('useEssayThemes', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('starts empty and not loading', () => {
+    const useEssayThemes = createUseEssayThemes(makeApi(jest.fn()));
+    const { result } = renderHook(() => useEssayThemes());
+
+    expect(result.current.themes).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.pagination.total).toBe(0);
+  });
+
+  it('reads the theme bank and exposes pagination', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse);
+    const useEssayThemes = createUseEssayThemes(makeApi(get));
+    const { result } = renderHook(() => useEssayThemes());
+
+    await act(async () => {
+      await result.current.fetchThemes();
+    });
+
+    expect(get).toHaveBeenCalledWith('/essays/themes', { params: {} });
+    expect(result.current.themes).toHaveLength(1);
+    expect(result.current.pagination.total).toBe(4);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('forwards pagination and search', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse);
+    const useEssayThemes = createUseEssayThemes(makeApi(get));
+    const { result } = renderHook(() => useEssayThemes());
+
+    await act(async () => {
+      await result.current.fetchThemes({
+        page: 2,
+        limit: 20,
+        search: 'cidadania',
+      });
+    });
+
+    expect(get).toHaveBeenCalledWith('/essays/themes', {
+      params: { page: 2, limit: 20, search: 'cidadania' },
+    });
+  });
+
+  it('omits an empty search, which the backend rejects', async () => {
+    const get = jest.fn().mockResolvedValue(themesResponse);
+    const useEssayThemes = createUseEssayThemes(makeApi(get));
+    const { result } = renderHook(() => useEssayThemes());
+
+    await act(async () => {
+      await result.current.fetchThemes({ page: 1, limit: 20, search: '   ' });
+    });
+
+    expect(get).toHaveBeenCalledWith('/essays/themes', {
+      params: { page: 1, limit: 20 },
+    });
+  });
+
+  it('surfaces an error message when the request fails', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('403'));
+    const useEssayThemes = createUseEssayThemes(makeApi(get));
+    const { result } = renderHook(() => useEssayThemes());
+
+    await act(async () => {
+      await result.current.fetchThemes();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Erro ao carregar temas de redação');
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.themes).toEqual([]);
+  });
+});

--- a/src/hooks/useEssayThemes.ts
+++ b/src/hooks/useEssayThemes.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { BaseApiClient } from '../types/api';
 import type {
   EssayTheme,
@@ -46,6 +46,12 @@ const useEssayThemesImpl = (apiClient: BaseApiClient): UseEssayThemesReturn => {
   });
 
   /**
+   * Sequence of the latest request. A slower earlier response must not
+   * overwrite a newer list — the search box can fire overlapping requests.
+   */
+  const requestIdRef = useRef(0);
+
+  /**
    * Fetch the essay theme bank. The endpoint only ever returns active themes,
    * so a theme retired after being picked stays on the activity but stops
    * showing up here.
@@ -54,6 +60,7 @@ const useEssayThemesImpl = (apiClient: BaseApiClient): UseEssayThemesReturn => {
    */
   const fetchThemes = useCallback(
     async (filters: EssayThemeFilters = {}) => {
+      const requestId = ++requestIdRef.current;
       setState((prev) => ({ ...prev, loading: true, error: null }));
 
       try {
@@ -68,6 +75,8 @@ const useEssayThemesImpl = (apiClient: BaseApiClient): UseEssayThemesReturn => {
           { params }
         );
 
+        if (requestId !== requestIdRef.current) return;
+
         setState({
           themes: response.data.data.themes,
           loading: false,
@@ -75,6 +84,8 @@ const useEssayThemesImpl = (apiClient: BaseApiClient): UseEssayThemesReturn => {
           pagination: response.data.data.pagination,
         });
       } catch (error) {
+        if (requestId !== requestIdRef.current) return;
+
         console.error('Erro ao carregar temas de redação:', error);
         setState((prev) => ({
           ...prev,

--- a/src/hooks/useEssayThemes.ts
+++ b/src/hooks/useEssayThemes.ts
@@ -1,0 +1,106 @@
+import { useState, useCallback } from 'react';
+import type { BaseApiClient } from '../types/api';
+import type {
+  EssayTheme,
+  EssayThemeFilters,
+  EssayThemesApiResponse,
+  EssayThemesPagination,
+} from '../types/essayThemes';
+
+/**
+ * Hook state
+ */
+export interface UseEssayThemesState {
+  themes: EssayTheme[];
+  loading: boolean;
+  error: string | null;
+  pagination: EssayThemesPagination;
+}
+
+/**
+ * Hook return type
+ */
+export interface UseEssayThemesReturn extends UseEssayThemesState {
+  fetchThemes: (filters?: EssayThemeFilters) => Promise<void>;
+}
+
+/**
+ * Default pagination values
+ */
+export const DEFAULT_ESSAY_THEMES_PAGINATION: EssayThemesPagination = {
+  page: 1,
+  limit: 10,
+  total: 0,
+  totalPages: 0,
+};
+
+/**
+ * Hook implementation
+ */
+const useEssayThemesImpl = (apiClient: BaseApiClient): UseEssayThemesReturn => {
+  const [state, setState] = useState<UseEssayThemesState>({
+    themes: [],
+    loading: false,
+    error: null,
+    pagination: DEFAULT_ESSAY_THEMES_PAGINATION,
+  });
+
+  /**
+   * Fetch the essay theme bank. The endpoint only ever returns active themes,
+   * so a theme retired after being picked stays on the activity but stops
+   * showing up here.
+   *
+   * @param filters - Pagination and text search
+   */
+  const fetchThemes = useCallback(
+    async (filters: EssayThemeFilters = {}) => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+
+      try {
+        const params: Record<string, unknown> = {};
+        if (filters.page) params.page = filters.page;
+        if (filters.limit) params.limit = filters.limit;
+        // The backend rejects an empty search, so only send it when typed.
+        if (filters.search?.trim()) params.search = filters.search.trim();
+
+        const response = await apiClient.get<EssayThemesApiResponse>(
+          '/essays/themes',
+          { params }
+        );
+
+        setState({
+          themes: response.data.data.themes,
+          loading: false,
+          error: null,
+          pagination: response.data.data.pagination,
+        });
+      } catch (error) {
+        console.error('Erro ao carregar temas de redação:', error);
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: 'Erro ao carregar temas de redação',
+        }));
+      }
+    },
+    [apiClient]
+  );
+
+  return { ...state, fetchThemes };
+};
+
+/**
+ * Factory function to create the useEssayThemes hook
+ *
+ * @param apiClient - API client instance (axios, fetch wrapper, etc.)
+ * @returns Hook for reading the essay theme bank
+ *
+ * @example
+ * ```tsx
+ * const useEssayThemes = createUseEssayThemes(api);
+ * const { themes, loading, fetchThemes } = useEssayThemes();
+ * ```
+ */
+export const createUseEssayThemes = (apiClient: BaseApiClient) => {
+  return (): UseEssayThemesReturn => useEssayThemesImpl(apiClient);
+};

--- a/src/types/activitiesHistory.ts
+++ b/src/types/activitiesHistory.ts
@@ -71,6 +71,12 @@ export interface ActivityHistoryResponse {
   title: string;
   startDate: string | null;
   finalDate: string | null;
+  /** Creation timestamp returned by GET /activities/history */
+  createdAt?: string | null;
+  /** false = in-person booklet, true = answered in the app */
+  isDigital?: boolean;
+  /** Whether the activity requires an essay (its `essayThemeId` is set) */
+  hasEssay?: boolean;
   status: GenericApiStatus;
   completionPercentage: number;
   subject: ActivitySubject | null;
@@ -97,6 +103,8 @@ export interface ActivityTableItem extends Record<string, unknown> {
   class: string;
   status: GenericDisplayStatus;
   completionPercentage: number;
+  /** Creation date (DD/MM), shown by the presencial activities table */
+  createdAt?: string;
 }
 
 /**

--- a/src/types/activityDetails.ts
+++ b/src/types/activityDetails.ts
@@ -23,6 +23,20 @@ export type StudentActivityStatus =
   (typeof STUDENT_ACTIVITY_STATUS)[keyof typeof STUDENT_ACTIVITY_STATUS];
 
 /**
+ * Delivery state of a physical sheet handed back by the student in an in-person
+ * exam. Kept apart from `STUDENT_ACTIVITY_STATUS` because it answers a narrower
+ * question — "did this sheet arrive?" — and applies to each sheet (answers,
+ * essay) on its own.
+ */
+export const PRESENCIAL_DELIVERY_STATUS = {
+  AWAITING: 'AGUARDANDO',
+  RECEIVED: 'RECEBIDO',
+} as const;
+
+export type PresencialDeliveryStatus =
+  (typeof PRESENCIAL_DELIVERY_STATUS)[keyof typeof PRESENCIAL_DELIVERY_STATUS];
+
+/**
  * Zod schema for student activity status
  */
 export const studentActivityStatusSchema = z.enum([
@@ -44,6 +58,14 @@ export interface ActivityStudentData {
   timeSpent: number;
   score: number | null;
   status: StudentActivityStatus;
+  /**
+   * Delivery state of the essay sheet. In-person exams are printed with an
+   * essay sheet attached, which the teacher scans along with the answer sheet —
+   * so it is delivered (or not) independently of the answers.
+   */
+  essayStatus?: PresencialDeliveryStatus | null;
+  /** When the essay sheet was received */
+  essayReceivedAt?: string | null;
 }
 
 /**
@@ -84,6 +106,13 @@ export interface ActivityMetadata {
   type?: string;
   subtype?: string;
   isDigital?: boolean | null;
+  /**
+   * Essay theme required by the activity; null when it requires no essay.
+   * Only ever set on in-person exams.
+   */
+  essayThemeId?: string | null;
+  /** Creation timestamp returned by GET /activities/:id/quiz */
+  createdAt?: string | null;
   startDate: string | null;
   finalDate: string | null;
   schoolName: string;
@@ -125,6 +154,10 @@ export interface ActivityStudentTableItem extends Record<string, unknown> {
   answeredAt: string | null;
   timeSpent: number;
   score: number | null;
+  /** Essay sheet delivery state (in-person exams only) */
+  essayStatus?: PresencialDeliveryStatus | null;
+  /** When the essay sheet was received (in-person exams only) */
+  essayReceivedAt?: string | null;
 }
 
 /**

--- a/src/types/essayThemes.ts
+++ b/src/types/essayThemes.ts
@@ -1,0 +1,64 @@
+/**
+ * Essay Themes Types
+ * Contract of `GET /essays/themes`, the theme bank a teacher picks from when
+ * assembling an in-person exam booklet.
+ */
+
+/**
+ * A supporting text shipped with the theme, shown to the student.
+ */
+export interface EssayThemeSupportingText {
+  content: string;
+  source?: string;
+}
+
+/**
+ * Essay theme as returned by the API.
+ */
+export interface EssayTheme {
+  id: string;
+  title: string;
+  description: string | null;
+  supportingTexts: EssayThemeSupportingText[];
+  isActive: boolean;
+  createdAt: string;
+  /**
+   * Where the theme comes from, e.g. "Enem 2024" — rendered as the badge on the
+   * theme card.
+   *
+   * PENDENTE: `essay_themes` has no origin/year column yet, so this is absent
+   * until the backend adds it. The badge is simply not rendered meanwhile;
+   * deriving it from `createdAt` would misdate every theme.
+   */
+  origin?: string | null;
+}
+
+/**
+ * Pagination block of the themes listing.
+ */
+export interface EssayThemesPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * Response of `GET /essays/themes`.
+ */
+export interface EssayThemesApiResponse {
+  message: string;
+  data: {
+    themes: EssayTheme[];
+    pagination: EssayThemesPagination;
+  };
+}
+
+/**
+ * Query parameters accepted by `GET /essays/themes`.
+ */
+export interface EssayThemeFilters {
+  page?: number;
+  limit?: number;
+  search?: string;
+}

--- a/src/types/sendActivity.ts
+++ b/src/types/sendActivity.ts
@@ -52,6 +52,11 @@ export interface CreateActivityPayload {
   startDate: string;
   finalDate: string | null;
   canRetry: boolean;
+  /**
+   * Essay theme required by the activity. The backend only accepts it when
+   * `isDigital` is false — an essay is handed in on paper with the booklet.
+   */
+  essayThemeId?: string | null;
 }
 
 /**

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -172,6 +172,7 @@ export default defineConfig({
     // ActivitiesHistory
     'ActivitiesHistory/index': 'src/components/ActivitiesHistory/index.ts',
     'hooks/useActivitiesHistory/index': 'src/hooks/useActivitiesHistory.ts',
+    'hooks/useEssayThemes/index': 'src/hooks/useEssayThemes.ts', // createUseEssayThemes
     'hooks/useActivityModels/index': 'src/hooks/useActivityModels.ts',
     'types/activitiesHistory/index': 'src/types/activitiesHistory.ts',
 
@@ -257,6 +258,8 @@ export default defineConfig({
     'Accordation/AccordionGroup/index':
       'src/components/Accordation/AccordionGroup.tsx', // AccordionGroup
     'ActivityCreate/index': 'src/components/ActivityCreate/ActivityCreate.tsx', // CreateActivity
+    'EssayThemePicker/index':
+      'src/components/EssayThemePicker/EssayThemePicker.tsx', // EssayThemePicker
     'ActivityCreate/ActivityCreate.types/index':
       'src/components/ActivityCreate/ActivityCreate.types.ts', // ActivityType
     'AlertManager/types/index': 'src/components/AlertManager/types.ts', // AlertData, AlertsConfig
@@ -354,6 +357,7 @@ export default defineConfig({
     'enums/Quiz/index': 'src/enums/Quiz.ts', // TrueFalseEnum
 
     // === migration: Types ===
+    'types/essayThemes/index': 'src/types/essayThemes.ts', // EssayTheme, EssayThemesApiResponse
     'types/activityDetails/index': 'src/types/activityDetails.ts', // ACTIVITY_AVAILABILITY, ActivityAvailability, STUDENT_ACTIVITY_STATUS, StudentActivityStatus
     'types/activityFilters/index': 'src/types/activityFilters.ts', // ActivityFiltersData
     'types/api/index': 'src/types/api.ts', // BaseApiClient


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for in-person activities across creation, history, drafts, and details.
  * Added essay theme browsing, searching, previewing, downloading, selecting, and removal.
  * In-person exams can include selected essay themes and display Questions/Redação tabs.
  * Added creation dates, delivery statuses, essay submission timestamps, and dedicated activity information.
  * Added exam-level PDF downloads with optional extra printable pages.
* **Bug Fixes**
  * Improved navigation and category handling when in-person activity routes are unavailable.
  * Added graceful handling for essay-theme loading and delivery-data errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->